### PR TITLE
Guard against missing `new` keywords with a TypeError

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -28,8 +28,12 @@
   // Similar to `goog.inherits`, but uses a hash of prototype properties and
   // class properties to be extended.
   var inherits = function(parent, protoProps, classProps) {
-    var child = protoProps.hasOwnProperty('constructor') ? protoProps.constructor :
-                function(){ return parent.apply(this, arguments); };
+    var child = protoProps.hasOwnProperty('constructor') ?
+      protoProps.constructor : function () {
+        if ( ! (this instanceof arguments.callee) )
+          throw new TypeError("Must use 'new' with constructors.");
+        return parent.apply(this, arguments);
+      };
     var ctor = function(){};
     ctor.prototype = parent.prototype;
     child.prototype = new ctor();
@@ -120,6 +124,8 @@
   // Create a new model, with defined attributes. A client id (`cid`)
   // is automatically generated and assigned for you.
   Backbone.Model = function(attributes) {
+    if ( ! (this instanceof arguments.callee) )
+      throw new TypeError("Must use 'new' with model constructors.");
     this.attributes = {};
     this.cid = _.uniqueId('c');
     this.set(attributes || {}, {silent : true});
@@ -303,6 +309,8 @@
   // or unordered. If a `comparator` is specified, the Collection will maintain
   // its models in sort order, as they're added and removed.
   Backbone.Collection = function(models, options) {
+    if ( ! (this instanceof arguments.callee) )
+      throw new TypeError("Must use 'new' with collection constructors.");
     options || (options = {});
     if (options.comparator) {
       this.comparator = options.comparator;
@@ -488,6 +496,8 @@
   // Creating a Backbone.View creates its initial element outside of the DOM,
   // if an existing element is not provided...
   Backbone.View = function(options) {
+    if ( ! (this instanceof arguments.callee) )
+      throw new TypeError("Must use 'new' with view constructors.");
     this._configure(options || {});
     if (this.options.el) {
       this.el = this.options.el;

--- a/test/collection.js
+++ b/test/collection.js
@@ -111,4 +111,23 @@ $(document).ready(function() {
     equals(col.min(function(model){ return model.id; }).id, 1);
   });
 
+  test("collections: Constructors without 'new' throw a TypeError", 2, function () {
+    try {
+      Backbone.Collection([]);
+      ok(false, "Directly from Backbone.Collection");
+    } catch (err) {
+      ok(err instanceof TypeError,
+         "Directly from Backbone.Collection");
+    }
+
+    var Klass = Backbone.Collection.extend({});
+    try {
+      Klass([]);
+      ok(false, "And also with 'subclasses' down the prototype chain.");
+    } catch (err) {
+      ok(err instanceof TypeError,
+         "And also with 'subclasses' down the prototype chain.");
+    }
+  });
+
 });

--- a/test/model.js
+++ b/test/model.js
@@ -130,4 +130,23 @@ $(document).ready(function() {
     equals(lastError, "Can't change admin status.");
   });
 
+  test("model: Constructors without 'new' throw a TypeError", 2, function () {
+    try {
+      Backbone.Model({ foo: 1 });
+      ok(false, "Directly from Backbone.Model");
+    } catch (err) {
+      ok(err instanceof TypeError,
+         "Directly from Backbone.Model");
+    }
+
+    var Klass = Backbone.Model.extend({ foo: 1 });
+    try {
+      Klass({ foo: 1 });
+      ok(false, "And also with 'subclasses' down the prototype chain.");
+    } catch (err) {
+      ok(err instanceof TypeError,
+         "And also with 'subclasses' down the prototype chain.");
+    }
+  });
+
 });

--- a/test/view.js
+++ b/test/view.js
@@ -53,4 +53,23 @@ $(document).ready(function() {
     equals(counter, 3);
   });
 
+  test("view: Constructors without 'new' throw a TypeError", 2, function () {
+    try {
+      Backbone.View();
+      ok(false, "Directly from Backbone.View");
+    } catch (err) {
+      ok(err instanceof TypeError,
+         "Directly from Backbone.View");
+    }
+
+    var Klass = Backbone.View.extend({ foo: 1 });
+    try {
+      Klass();
+      ok(false, "And also with 'subclasses' down the prototype chain.");
+    } catch (err) {
+      ok(err instanceof TypeError,
+         "And also with 'subclasses' down the prototype chain.");
+    }
+  });
+
 });


### PR DESCRIPTION
I know this is a little bit of a philosophical decision, but I think that it is safest to let people know right up front when they are forgetting the `new` keyword for a constructor. It is going to cause bugs anyways, might as well throw a TypeError immediately and not waste anyone's time.

Thoughts?
