### PR TITLE
declarative event handling in views

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -208,7 +208,7 @@
       if (this.validate) {
         var error = this.validate(attrs);
         if (error) {
-          this.trigger('error', this, error);
+          this.trigger('model:error', this, error);
           return false;
         }
       }
@@ -224,7 +224,7 @@
           now[attr] = val;
           if (!options.silent) {
             this._changed = true;
-            this.trigger('change:' + attr, this, val);
+            this.trigger('model:change:' + attr, this, val);
           }
         }
       }
@@ -242,7 +242,7 @@
       delete this.attributes[attr];
       if (!options.silent) {
         this._changed = true;
-        this.trigger('change:' + attr, this);
+        this.trigger('model:change:' + attr, this);
         this.change();
       }
       return value;
@@ -301,7 +301,7 @@
     // Call this method to fire manually fire a `change` event for this model.
     // Calling this will cause all objects observing the model to update.
     change : function() {
-      this.trigger('change', this);
+      this.trigger('model:change', this);
       this._previousAttributes = _.clone(this.attributes);
       this._changed = false;
     },
@@ -415,7 +415,7 @@
       options || (options = {});
       if (!this.comparator) throw new Error('Cannot sort a set without a comparator');
       this.models = this.sortBy(this.comparator);
-      if (!options.silent) this.trigger('refresh', this);
+      if (!options.silent) this.trigger('collection:refresh', this);
       return this;
     },
 
@@ -432,7 +432,7 @@
       options || (options = {});
       this._reset();
       this.add(models, {silent: true});
-      if (!options.silent) this.trigger('refresh', this);
+      if (!options.silent) this.trigger('collection:refresh', this);
       return this;
     },
 
@@ -487,7 +487,7 @@
       this.models.splice(index, 0, model);
       model.bind('all', this._boundOnModelEvent);
       this.length++;
-      if (!options.silent) this.trigger('add', model);
+      if (!options.silent) this.trigger('collection:add', model);
       return model;
     },
 
@@ -503,7 +503,7 @@
       this.models.splice(this.indexOf(model), 1);
       model.unbind('all', this._boundOnModelEvent);
       this.length--;
-      if (!options.silent) this.trigger('remove', model);
+      if (!options.silent) this.trigger('collection:remove', model);
       return model;
     },
 
@@ -516,10 +516,10 @@
             delete this._byId[model.previous('id')];
             this._byId[model.id] = model;
           }
-          this.trigger('change', model);
+          this.trigger('collection:model:change', model);
           break;
         case 'error':
-          this.trigger('error', model, error);
+          this.trigger('collection:model:error', model, error);
       }
     }
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -41,7 +41,7 @@ $(document).ready(function() {
 
   test("Collection: add", function() {
     var added = null;
-    col.bind('add', function(model){ added = model.get('label'); });
+    col.bind('collection:add', function(model){ added = model.get('label'); });
     e = new Backbone.Model({id: 0, label : 'e'});
     col.add(e);
     equals(added, 'e');
@@ -51,7 +51,7 @@ $(document).ready(function() {
 
   test("Collection: remove", function() {
     var removed = null;
-    col.bind('remove', function(model){ removed = model.get('label'); });
+    col.bind('collection:remove', function(model){ removed = model.get('label'); });
     col.remove(e);
     equals(removed, 'e');
     equals(col.length, 4);
@@ -100,7 +100,7 @@ $(document).ready(function() {
   test("Collection: refresh", function() {
     var refreshed = 0;
     var models = col.models;
-    col.bind('refresh', function() { refreshed += 1; });
+    col.bind('collection:refresh', function() { refreshed += 1; });
     col.refresh([]);
     equals(refreshed, 1);
     equals(col.length, 0);

--- a/test/model.js
+++ b/test/model.js
@@ -72,7 +72,7 @@ $(document).ready(function() {
     attrs = { 'foo': 1, 'bar': 2, 'baz': 3};
     a = new Backbone.Model(attrs);
     var changeCount = 0;
-    a.bind("change:foo", function() { changeCount += 1; });
+    a.bind("model:change:foo", function() { changeCount += 1; });
     a.set({'foo': 2});
     ok(a.get('foo')== 2, "Foo should have changed.");
     ok(changeCount == 1, "Change count should have incremented.");
@@ -117,7 +117,7 @@ $(document).ready(function() {
     model.validate = function(attrs) {
       if (attrs.admin) return "Can't change admin status.";
     };
-    model.bind('error', function(model, error) {
+    model.bind('model:error', function(model, error) {
       lastError = error;
     });
     var result = model.set({a: 100});

--- a/test/view.js
+++ b/test/view.js
@@ -61,22 +61,22 @@ $(document).ready(function() {
     var View = Backbone.View.extend({
 
       modelBraceRoutes : {
-        'change:shape' : 'mutate'
+        'model:change:shape' : 'mutate'
       },
 
       collectionBraceRoutes : {
         'col:sort' : 'sortCollection',
       },
 
-      onChangeFoo : function(obj, newValue) {
+      onModelChangeFoo : function(obj, newValue) {
         this.fooChanged = true;
       },
 
-      onAdd : function(item) {
+      onCollectionAdd : function(item) {
         this.itemAdded = true;
       },
 
-      onRemove : function(item) {
+      onCollectionRemove : function(item) {
         this.itemRemoved = true;
       },
 
@@ -96,21 +96,21 @@ $(document).ready(function() {
     });
 
     model.set({'foo' : 'bar'});
-    equals(view.fooChanged, true);
+    ok(view.fooChanged, 'model change property event not handled properly');
 
     var item = new Backbone.Model;
     col.add(item);
 
-    equals(view.itemAdded, true);
+    ok(view.itemAdded, 'collection add item event not handled properly');
 
     col.remove(item);
-    equals(view.itemRemoved, true);
+    ok(view.itemRemoved, 'collection remove item not handled properly');
 
     model.set({'shape' : 'trapezoid'});
-    equals(view.mutated, true);
+    ok(view.mutated, 'model declared event route not handled properly');
 
     col.trigger('col:sort');
-    equals(view.sorted, true);
+    ok(view.sorted, 'collection declared event route not handled properly');
   });
 
 });


### PR DESCRIPTION
I started playing around with this tonight. So far I'm really liking it. One concept I'd like to see added is declarative event handling in the views. Rather than manually binding each callback to the model when you instantiate a new view instance I like the idea of there being a well defined convention through which views can automatically handle events from the model. The patch I'm proposing does this with the convention onEvent[Property]. This turns out to be really useful when your views become more complex and need to handle multiple types of model events in sometimes subtle ways.
