### PR TITLE
Automatic creation of getter/setter accessor functions

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -589,6 +589,27 @@
   var extend = Backbone.Model.extend = Backbone.Collection.extend = Backbone.View.extend = function (protoProps, classProps) {
     var child = inherits(this, protoProps, classProps);
     child.extend = extend;
+
+    // Provide automatic get/set functions. An alternative implementation might
+    // not require explicit getters and setters via the `getSet` property, but
+    // would iterate over keys in `protoProps` and implicitly create them for
+    // any property that is not a function. Another idea is to use `accessors`
+    // instead of `getSet` kind of like Ruby.
+    _(protoProps.getSet || [])
+      .chain()
+      .reject(function (k) {
+        return k in child.prototype;
+      })
+      .each(function (k) {
+        child.prototype[k] = function (val, opts) {
+          var newVals = {};
+          newVals[k] = val;
+          return arguments.length > 0
+            ? this.set(newVals, opts)
+            : this.get(k);
+        };
+      });
+
     return child;
   };
 

--- a/test/model.js
+++ b/test/model.js
@@ -130,4 +130,26 @@ $(document).ready(function() {
     equals(lastError, "Can't change admin status.");
   });
 
+  // The automatic get/set is available when extending Collections and Views
+  // too, but this seemed like the most appropriate place to put these tests...
+  test("model: automatic get/set", function () {
+    var Model = Backbone.Model.extend({
+      getSet : ["foobar"]
+    });
+    var obj = new Model({
+      foobar : "hello"
+    })
+    equals(obj.foobar(), "hello");
+    equals(obj.foobar("hey").foobar(), "hey");
+
+    var hasChanged = false;
+    obj.bind("change", function () {
+      hasChanged = true;
+    });
+    obj.foobar("don't trigger", { silent : true });
+    equals(hasChanged, false);
+    obj.foobar("do trigger");
+    equals(hasChanged, true);
+  });
+
 });


### PR DESCRIPTION
I think that `foo.get("something")` and `foo.set({ something : another })` could be knocked up a notch with read/write accessors:

```
var Fruit = Backbone.Model.extend({
  getSet  : ["condition", "kind"],
  inspect : function () {
    var cond = this.condition(),
        kind = this.kind();
    return _.template("a <%= cond %> <%= kind %>", { cond : cond, kind : kind });
  }
});
var banana = new Fruit({ kind : "banana" });
banana.condition("ripe");
console.log(banana.inspect());
// Logs: "a ripe banana"
```

I think explicitly named getters and setters are much cleaner and more explicit than calling "get" or "set" all the time, so we might as well provide them out of the box if they are explicitly asked for via `getSet`.

You could even take this approach further and iterate over the keys in `protoProps`, find every member that is not a function, and create named accessors automatically for all of them.

Just a note: I used `getSet` because it was the first thing that came to mind, but I think `accessors` would work just as well (or even better).

Thoughts?
