### PR TITLE
Use JSONP in the github demo

### DIFF
--- a/demos/gist.js
+++ b/demos/gist.js
@@ -24,9 +24,14 @@ var GistApp = Backbone.View.extend({
 var GithubAccount = Backbone.Model.extend({
 
   initialize : function() {
-    $.getJSON(this.url(), {}, _.bind(function(resp) {
-      this.set(resp.user);
-    }, this));
+    var me = this;
+    $.ajax({
+      url : me.url(),
+      dataType : "jsonp",
+      success : function (data, status, xhr) {
+        me.set(data.user);
+      }
+    });
   },
 
   url : function() {
@@ -45,7 +50,6 @@ var AccountView = Backbone.View.extend({
   },
 
   render : function() {
-    console.log(this.model);
     var ui = $('#accountTemplate').tmpl({account : this.model});
     $(this.el).html(ui);
   }


### PR DESCRIPTION
I'm not sure how other browsers handle XHRs from `file:///`, but Chrome considers an XHR to `http://github.com` to be in violation of the Same Origin Policy. I had to change the demo to use JSONP to make it work.

Cheers,

Nick
