### PR TITLE
Add underscore's chain() method to Collection

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -425,6 +425,13 @@
       return model.save(null, {success : success, error : options.error});
     },
 
+    // Proxy to _'s chain. Can't be proxied the same way the rest of the
+    // underscore methods are proxied because it relies on the underscore
+    // constructor.
+    chain: function () {
+      return _(this.models).chain();
+    },
+
     // Reset all internal state. Called when the collection is refreshed.
     _reset : function(options) {
       this.length = 0;

--- a/test/collection.js
+++ b/test/collection.js
@@ -95,6 +95,11 @@ $(document).ready(function() {
     ok(!_.include(col.without(d)), d);
     equals(col.max(function(model){ return model.id; }).id, 4);
     equals(col.min(function(model){ return model.id; }).id, 1);
+    same(col.chain()
+            .filter(function(o){ return o.id % 2 === 0; })
+            .map(function(o){ return o.id * 2; })
+            .value(),
+         [8, 4]);
   });
 
   test("Collection: refresh", function() {


### PR DESCRIPTION
I found that multiple times I want to chain underscore methods from a collection. Is there any reason why this isn't currently implemented?

It's implemented separately from the rest of the underscore methods because it relies on underscore's constructor. Couldn't think of a better way to do it other than just make it a special case compared to the rest of the proxied underscore methods.
