### PR TITLE
Backbone.Collection.toJSON()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -329,6 +329,11 @@
     // The default model for a collection is just a **Backbone.Model**.
     // This should be overridden in most cases.
     model : Backbone.Model,
+    
+    // Return a array containing each model's toJSON result.
+    toJSON : function() {
+      return this.models.map(function(model){ return model.toJSON(); })
+    },
 
     // Add a model, or list of models to the set. Pass **silent** to avoid
     // firing the `added` event for every new model.


### PR DESCRIPTION
When using simple javascript templating solutions that expect just a JSON object and wanting to dump an entire collection into the template, this makes a lot of sense.
