### PR TITLE
New Sync default behavior - take 2

### DIFF
--- a/index.html
+++ b/index.html
@@ -1252,10 +1252,12 @@ var othello = NYPL.create({
     </ul>
 
     <p>
-      If your web server makes it difficult to work with real <tt>PUT</tt> and
-      <tt>DELETE</tt> requests, you may choose to emulate them instead, using
-      HTTP <tt>POST</tt>, and passing them under the <tt>_method</tt> parameter
-      instead, by turning on <tt>Backbone.emulateHTTP</tt>:
+      If you want to work with a legacy web server that doesn't support Backbones's
+      default JSON centric approach, you may choose to turn on <tt>Backbone.emulateHttp</tt>.
+      Setting this option will emulate <tt>PUT</tt> and <tt>DELETE</tt> requests with
+      a HTTP <tt>POST</tt>, and passing them under the <tt>_method</tt> parameter. Setting this option
+      will also send the model under a <tt>model</tt> param and use <tt>application/x-www-form-urlencoded</tt>
+      instead of the default <tt>application/json</tt> as the content-type for data sent. 
     </p>
 
 <pre>
@@ -1264,20 +1266,9 @@ Backbone.emulateHTTP = true;
 model.save();  // Sends a POST to "/collection/id", with "_method=PUT"
 </pre>
 
-     <p>
-       Also you can choose to send the body with content-type 
-       <tt>application/x-www-form-urlencoded</tt> and the model in a JSON
-       string param called <tt>model</tt> by turning on <tt>Backbone.emulateJSON</tt>:
-    </p>
-          
-<pre>
-Backbone.emulateJSON = true;
-
-model.save();  //sends data as application/x-www-form-urlencoded
-</pre>
     <p>
       As an example, a Rails handler responding to an <tt>"update"</tt> call from
-      <b>Backbone.sync</b> might look like this: <i>(In real code, never use
+      <tt>Backbone</tt> might look like this: <i>(In real code, never use
       </i><tt>update_attributes</tt><i> blindly, and always whitelist the attributes
       you allow to be changed.)</i>
     </p>

--- a/test/sync.js
+++ b/test/sync.js
@@ -42,18 +42,6 @@ $(document).ready(function() {
     equals(data.length, 123);
   });
 
-  test("sync: create with emulateJSON", function() {
-	Backbone.emulateJSON = true;
-    library.add(library.create(attrs));
-    equals(lastRequest.url, '/library');
-    equals(lastRequest.type, 'POST');
-    equals(lastRequest.dataType, 'json');
-    var data = JSON.parse(lastRequest.data.model);
-    equals(data.title, 'The Tempest');
-    equals(data.author, 'Bill Shakespeare');
-    equals(data.length, 123);
-	Backbone.emulateJSON = false;
-  });
 
   test("sync: update", function() {
     library.first().save({id: '1-the-tempest', author: 'William Shakespeare'});
@@ -67,46 +55,18 @@ $(document).ready(function() {
     equals(data.length, 123);
   });
 
-  test("sync: update with emulateHTTP", function() {
-    Backbone.emulateHTTP = true;
+  test("sync: update with emulateHttp", function() {
+    Backbone.emulateHttp = true;
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     equals(lastRequest.url, '/library/2-the-tempest');
     equals(lastRequest.type, 'POST');
     equals(lastRequest.dataType, 'json');
     equals(lastRequest.data._method, 'PUT');
-	Backbone.emulateHTTP = false;
-  });
-
-  test("sync: update with emulateJSON", function() {
-    Backbone.emulateJSON = true;
-    library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
-    equals(lastRequest.url, '/library/2-the-tempest');
-    equals(lastRequest.type, 'PUT');
-    var data = JSON.parse(lastRequest.data.model);
-    equals(lastRequest.dataType, 'json');
+    var data = lastRequest.data.model;
     equals(data.id, '2-the-tempest');
-    equals(data.title, 'The Tempest');
     equals(data.author, 'Tim Shakespeare');
     equals(data.length, 123);
-	Backbone.emulateJSON = false;
-   });
-
-  test("sync: update with emulateHTTP and emulateJSON", function() {
-    Backbone.emulateHTTP = true;
-    Backbone.emulateJSON = true;
-    library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
-    equals(lastRequest.url, '/library/2-the-tempest');
-    equals(lastRequest.type, 'POST');
-    equals(lastRequest.dataType, 'json');
-    equals(lastRequest.data._method, 'PUT');
-    var data = JSON.parse(lastRequest.data.model);
-    equals(lastRequest.dataType, 'json');
-    equals(data.id, '2-the-tempest');
-    equals(data.title, 'The Tempest');
-    equals(data.author, 'Tim Shakespeare');
-    equals(data.length, 123);
-	Backbone.emulateHTTP = false;
-	Backbone.emulateJSON = false;
+    Backbone.emulateHttp = false;
   });
 
   test("sync: read model", function() {
@@ -123,20 +83,13 @@ $(document).ready(function() {
     ok(_.isEmpty(lastRequest.data));
   });
 
-  test("sync: destroy with emulateJSON", function() {
-    library.first().destroy();
-    equals(lastRequest.url, '/library/2-the-tempest');
-    equals(lastRequest.type, 'DELETE');
-    ok(_.isEmpty(lastRequest.data));
-  });
-
-  test("sync: destroy with emulateHTTP", function() {
-    Backbone.emulateHTTP = true;
+  test("sync: destroy with emulateHttp", function() {
+    Backbone.emulateHttp = true;
     library.first().destroy();
     equals(lastRequest.url, '/library/2-the-tempest');
     equals(lastRequest.type, 'POST');
     equals(JSON.stringify(lastRequest.data), '{"_method":"DELETE"}');
-   Backbone.emulateHTTP = false;
+   Backbone.emulateHttp = false;
   });
 
 });


### PR DESCRIPTION
Ignore the first commit, this one is better I think.  After studying how Rals 2.3 and Rails 3 do PUT JSON routing,  and the underlying Rack code mentioned here (https://rails.lighthouseapp.com/projects/8994/tickets/2289-_methodput-ignored-for-xhr-and-xml-requests) and doing some testing, I think the last commit in this pull request is the cleanest and simplest approach for Backbone users.

By default all data is sent `application/json` encoded.  The model is simply converted to a JSON string and sent in the body.  The HTTP method mapping in the documentation holds, with updates being sent as PUT requests and deletes as DELETE requests.

In order to support legacy end-points that don't support application/json in the body or PUT requests, or legacy browsers that will not recognize the PUT request, users can turn on `emulateHttp`.   This will do the following
- For PUT and DELETE requests, they will be sent as POST, the right `_method` param will be put in the body, and an appropriate `X-Http-Method-Override` header will be added to the request.  This will guarantee safe routing in Rails 2.3 pre-rack routing.
- Send the model as a `model` param in the body.
- Always encode the body as `application/x-www-form-urlencoded`.

I got rid of the `emulateJSON` idea because in cases where it was needed, the flag `emulateHTTP` would also be needed and then questions would arise as to how they interact.  We don't want to cover all the possible uses cases.  We just want to provide one broad clean default option and one broad legacy option, and let the user override `Backbone.sync` if neither of them work.  Am I right?
