### PR TITLE
Event#bindOnce

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -53,6 +53,16 @@
       list.push(callback);
       return this;
     },
+    
+    // Bind an event, specified by a string name, `ev`, to a `callback` function.
+    // The `callback` is only fired the first time the event is triggered.
+    bindOnce : function(ev, callback) {
+      var fn = function() {
+        this.unbind(ev, fn);
+        callback.apply(this, arguments);
+      }
+      this.bind(ev, fn);
+    },
 
     // Remove one or many callbacks. If `callback` is null, removes all
     // callbacks for the event. If `ev` is null, removes all bound callbacks


### PR DESCRIPTION
Binds a callback but only gets triggered the first time the event is called. I've found this pattern to be super handy for instantiating things when an event is called multiple times. For instance (in CoffeeScript) this renders the footer only the first time the user logs in:

```
session.bind 'status:change', =>
  dynamic_content.render(session)

session.bindOnce 'status:change', ->
  static_footer.render()
```

Also, when the user hits the "save" button, if they arn't signed in it will prompt them to do so and save the form when they do. If they sign out and then back in again, the form wont save as the callback will have been unbound.

```
  fn = ->
    @save {...}

  if session.logged_in?
    fn()
  else
   session.bindOnce 'signin', fn
   session_controller.signIn()
```

I could be barking up the wrong tree with a terrible anti-pattern but it seems pretty sweet to me.
