### PR TITLE
add options argument to Backbone.Model initialize function

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -107,12 +107,12 @@
 
   // Create a new model, with defined attributes. A client id (`cid`)
   // is automatically generated and assigned for you.
-  Backbone.Model = function(attributes) {
+  Backbone.Model = function(attributes, options) {
     this.attributes = {};
     this.cid = _.uniqueId('c');
     this.set(attributes || {}, {silent : true});
     this._previousAttributes = _.clone(this.attributes);
-    if (this.initialize) this.initialize(attributes);
+    if (this.initialize) this.initialize(attributes, options);
   };
 
   // Attach all inheritable methods to the Model prototype.

--- a/test/model.js
+++ b/test/model.js
@@ -38,6 +38,16 @@ $(document).ready(function() {
     equals(model.one, 1);
   });
 
+  test("Model: initialize with attributes and options", function() {
+    var Model = Backbone.Model.extend({
+      initialize: function(attributes, options) {
+        this.one = options.one;
+      }
+    });
+    var model = new Model({}, {one: 1});
+    equals(model.one, 1);
+  });
+
   test("Model: url", function() {
     equals(doc.url(), '/collection/1-the-tempest');
     doc.collection = null;


### PR DESCRIPTION
It would be useful to have additional options argument in Backbone.Model initialize function in similar way as in Backbone.Collection initialize function. Options could be used to pass reference to other models that should not be stored in attributes (but could be stored in initializer as property). It could be useful to model has_one / belongs_to relationships, e.g.

```
User = Backbone.Model.extend({
  newProfile: function(attributes) {
    this.profile = new Profile(attributes, {user: this});
  }
});
Profile = Backbone.Model.extend({
  initialize: function(attributes, options) {
    this.user = options.user;
  },
  fullDescription: function() {
    return this.user.get("name")+" has profile desription: "+this.get("description");
  }
});
user = new User({name: "John"});
user.newProfile({description: "lorem ipsum"});
user.profile.fullDescription();
```
