### PR TITLE
A declarative syntax for binding "change" events to the UI

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -642,7 +642,74 @@
       }
       return this;
     },
-
+    
+    // Lets you directly bind model attributes to the UI.
+    // 
+    // Also allows for declarative binding of attributes to element classes.
+    // 
+    // Lets you create a hash as follows
+    // 
+    //   contentBindings: {
+    //     title: '.title',
+    //     body: '#content'
+    //   }
+    // 
+    // This would automatically make the content of the `this.$('.title')`
+    // always match the title attribute. This is done by jQuery's `text()`
+    // method to ensure the content is properly escaped.
+    //
+    // It also implements class bindings if they exist. Class bindings take 
+    // two forms they if they are boolean values or "stringable" values.
+    // 
+    // Booleans will automatically add/remove an 'active' class. Where string
+    // values will remove the previous string value and add a class that matches
+    // the new string.
+    // 
+    //   classBindings: {
+    //     selected: '.title',
+    //     expanded: '.content'
+    //   }
+    // 
+    // If the `expanded` model attribute is a boolean it will add/remove `active`
+    // as a class on the `this.$('.content')` element.
+    handleBindings: function () {
+      var that = this;
+      
+      // content bindings
+      if (this.contentBindings) {
+        _.each(this.contentBindings, function (selector, key) {
+          that.model.bind('change:' + key, function () {
+            var el = (selector.length > 0) ? that.$(selector) : $(that.el);
+            
+            el.text(that.model.get(key));
+          });
+        });
+      }
+      
+      // class bindings
+      if (this.classBindings) {
+        _.each(this.classBindings, function (selector, key) {
+          that.model.bind('change:' + key, function () {
+            var newValue = that.model.get(key),
+              el = (selector.length > 0) ? that.$(selector) : $(that.el);
+      
+            // if it's a boolean value, just add/remove 'active' class
+            if (_.isBoolean(newValue)) {
+              if (newValue) {
+                el.addClass('active');
+              } else {
+                el.removeClass('active');    
+              }
+            // otherwise remove the previous value and add the new one as a class.
+            } else {
+              el.removeClass(that.model.previous(key)).addClass(newValue);
+            }
+          });
+        });
+      }
+      return this;
+    },
+    
     // Performs the initial configuration of a View with a set of options.
     // Keys with special meaning *(model, collection, id, className)*, are
     // attached directly to the view.

--- a/test/view.js
+++ b/test/view.js
@@ -54,6 +54,70 @@ $(document).ready(function() {
     equals(counter, 3);
   });
 
+  test("View: handleBindings", function() {
+    var ViewClass = Backbone.View.extend({
+        initialize: function () {
+          this.el = $('<div class="classic"><h1 class="title blue">something</h1><p class="content">the content</p></div>');
+          this.handleBindings();
+        },
+        
+        contentBindings: {
+          title: '.title',
+          body: ''
+        },
+        
+        classBindings: {
+          open: '.title',
+          color: '.title',
+          focused: '',
+          status: ''
+        }
+      }),
+      ModelClass = Backbone.Model.extend({
+        initialize: function () {
+          // set some initial values
+          this.set({
+            title: 'something',
+            open: false,
+            color: 'blue',
+            focused: false,
+            status: 'classic'
+          });
+        }
+      }),
+      model = new ModelClass(),
+      view = new ViewClass({model: model});
+      
+      equals(view.el.find('.title').text(), 'something');
+      
+      // change everything
+      model.set({
+        title: 'something else',
+        open: true,
+        color: 'green',
+        focused: true,
+        status: 'old'
+      });
+      // make sure our content updated
+      equals(view.el.find('.title').text(), 'something else');
+      
+      // make sure our boolean added active class
+      ok(view.el.find('.title').hasClass('active'), "okay: now has class 'active'");
+      
+      // make sure our string added new class property & removed old
+      ok(view.el.find('.title').hasClass('green'), "okay: now has class 'green'");
+      equals(view.el.find('.title').hasClass('blue'), false);
+      
+      // make sure works on parent element too.
+      ok(view.el.hasClass('active'), "okay: parent el now has class 'active'");
+      ok(view.el.hasClass('old'), "okay: now has class 'green'");
+      equals(view.el.hasClass('classic'), false);
+      
+      // make sure content works on parent too
+      model.set({body: "different"});
+      equals(view.el.text(), "different");
+  });
+
   test("View: _ensureElement", function() {
     var ViewClass = Backbone.View.extend({
       el: document.body


### PR DESCRIPTION
I know this is unsolicited, and perhaps I should have opened an issue first (my apologies). Clearly I'm a backbone fan as you may have seen [my post](http://andyet.net/blog/2010/oct/29/building-a-single-page-app-with-backbonejs-undersc/#disqus_thread) a few days ago. Take this as a suggestion, I'd love to get your thoughts on this.

When using backbone I find myself repeatedly writing `change` event handlers in my views in an attempt to bind certain attributes of my model to my UI. So I created a declarative syntax for doing this. 

Generally there are two types of bindings I care about. The first, I'll call `contentBindings` these are where I'd like to keep some text in a certain location in my DOM in sync with a certain model attribute. The second are `classBindings` these are where I'd like to set a class to sync with a model attribute or a boolean value that adds and removes an `active` class. I implemented this and wrote some tests for it. 

In short it lets me do this in my views:

```
var View = Backbone.View.extend({
  initialize: function () {
    this.handleBindings();
  },

  // the attribute I wish to bind and the 'selector' to find it like so:
  contentBindings: {
    title: '.title',
    body: ''
  },

  classBindings: {
    open: '.title',
    color: '.title',
    focused: '',
    status: ''
  }
});
```

I really like the result because it makes it super simple to bind a model to the UI using a short declarative syntax that closely matches what you already do with the `events` hash. I mixed in both of those into a single function called `handleBindings` that I added to the view prototype.

I saw a lot of discussion of these types of things in another thread. But I feel like my approach is a bit simpler and more explicit. It's also fairly self-evident, and doesn't feel like it's too much "magic".

It sets the classes or content on the parent element in the cases where you just use the empty string `""` instead of specifying a selector.

Like I said, take it as a suggestion. I can easily do this in a base class in my apps even if you don't feel it's appropriate to include. However, I figured I'd submit it because it seemed like something that _may_ fit into the philosophy/approach of backbone. Love your work. Thanks again!

My best,
Henrik
