### PR TITLE
Fix to allow loading of routes with empty fragment

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -687,8 +687,7 @@
       if (current == this.fragment && this.iframe) {
         current = this.getFragment(this.iframe.location);
       }
-      if (!current ||
-          current == this.fragment ||
+      if (current == this.fragment ||
           current == decodeURIComponent(this.fragment)) return false;
       if (this.iframe) {
         window.location.hash = this.iframe.location.hash = current;


### PR DESCRIPTION
Related to issue #67.

   routes: {
      "": "upcoming" // this should be allowed
      "all": "all",
    }
