### PR TITLE
Fix and test for recursion error when saving from within a change callback

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -242,9 +242,8 @@
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
     save : function(attrs, options) {
-      attrs   || (attrs = {});
       options || (options = {});
-      if (!this.set(attrs, options)) return false;
+      if (attrs && !this.set(attrs, options)) return false;
       var model = this;
       var success = function(resp) {
         if (!model.set(model.parse(resp), options)) return false;

--- a/test/model.js
+++ b/test/model.js
@@ -151,6 +151,15 @@ $(document).ready(function() {
     model.change();
     equals(model.get('name'), 'Rob');
   });
+  
+  test("Model: save within change event", function () {
+    var model = new Backbone.Model({firstName : "Taylor", lastName: "Swift"});
+    model.bind('change', function () {
+      model.save();
+      ok(_.isEqual(lastRequest[1], model));
+    });
+    model.set({lastName: 'Hicks'});
+  });
 
   test("Model: save", function() {
     doc.save({title : "Henry V"});


### PR DESCRIPTION
Unless you pass the silent option to model.save() from within a change callback you will always get a recursion error. 

This is a small fix that avoids calling model.set() from within model.save() unless new attributes were actually passed to model.save(), which if done from within a change callback should rightly through a recursion error.
