### PR TITLE
Fix and test for Backbone.sync DELETE dataType

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -903,7 +903,7 @@
       type:         type,
       contentType:  'application/json',
       data:         modelJSON,
-      dataType:     'json',
+      dataType:     (type === 'DELETE') ? null : 'json',
       processData:  false,
       success:      success,
       error:        error

--- a/test/sync.js
+++ b/test/sync.js
@@ -107,6 +107,7 @@ $(document).ready(function() {
     equals(lastRequest.url, '/library/2-the-tempest');
     equals(lastRequest.type, 'DELETE');
     equals(lastRequest.data, null);
+    equals(lastRequest.dataType, null);
   });
 
   test("sync: destroy with emulateHTTP", function() {


### PR DESCRIPTION
When calling `Backbone.sync` with a DELETE request the dataType is set to json. If the server does not return a json response for the delete action then the error callback will be fired (instead of success) and `collection.remove` will not be fired.
