### PR TITLE
Add a urlBase option to model to allow specifying restful url without using a collection

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -287,7 +287,7 @@
     // using Backbone's restful methods, override this to change the endpoint
     // that will be called.
     url : function() {
-      var base = getUrl(this.collection);
+      var base = this.urlBase || getUrl(this.collection);
       if (this.isNew()) return base;
       return base + (base.charAt(base.length - 1) == '/' ? '' : '/') + this.id;
     },

--- a/test/model.js
+++ b/test/model.js
@@ -65,6 +65,16 @@ $(document).ready(function() {
     equals(failed, true);
     doc.collection = collection;
   });
+  
+  test("Model: url when using urlBase", function() {
+    var Model = Backbone.Model.extend({
+      urlBase: '/collection'
+    });
+    var model = new Model();
+    equals(model.url(), '/collection');
+    model.set({id: '1'});
+    equals(model.url(), '/collection/1');
+  });
 
   test("Model: clone", function() {
     attrs = { 'foo': 1, 'bar': 2, 'baz': 3};


### PR DESCRIPTION
When not using a collection there is currently no way to utilize the existing url() method. Add a urlBase to your model let's you specify the base path without having to copy paste the entire url() method from Backbone.Model.
