### PR TITLE
Appending when fetching collections

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -466,9 +466,13 @@
       options || (options = {});
       var collection = this;
       var success = function(resp) {
-        collection.refresh(collection.parse(resp));
-        if (options.success) options.success(collection, resp);
-      };
+          if(options.append) {
+              collection.add(collection.parse(resp));
+          } else {
+              collection.refresh(collection.parse(resp));
+          }
+          if (options.success) options.success(collection, resp);
+        };
       var error = options.error && _.bind(options.error, null, collection);
       Backbone.sync('read', this, success, error);
       return this;


### PR DESCRIPTION
I've added an append option flag to the Collection.fetch() method. 

When set, rather than doing a Collection.refresh() with the server's response, it will do a Collection.add().

This fits a use case I have been working on where I'm lazy loading a data set as a user scrolls (like NewTwitter).

Currently I'm keeping track of the number of items loaded vs. the total, in my application code and updating the Collection.url with a URL parameter corresponding to the page number. I'm not sure if it makes sense to move some of this into backbone since server implementations may vary.
