### PR TITLE
model.previous() example abuses scope in change event callback

### DIFF
--- a/index.html
+++ b/index.html
@@ -887,7 +887,7 @@ var bill = new Backbone.Model({
 });
 
 bill.bind("change:name", function(model, name) {
-  alert("Changed name from " + bill.previous("name") + " to " + name);
+  alert("Changed name from " + model.previous("name") + " to " + name);
 });
 
 bill.set({name : "Bill Jones"});


### PR DESCRIPTION
The example uses `bill.previos("name")` instead of `model.previous("name")` in the `change` callback defined on `bill`.

The example works just fine, but the callback will not work if `bill` is redefined or lost from scope (pardon if I'm wrong, I'm not as intricately knowledgable in JS as I'd like).
