### PR TITLE
Implement model.is() attr test

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -158,6 +158,11 @@
       return this._escapedAttributes[attr] = escapeHTML(val == null ? '' : val);
     },
 
+    // Returns true if the attribute evalutates to a truthy value. False otherwise.
+    is : function(attr) {
+      return !!this.attributes[attr] === true;
+    },
+
     // Set a hash of model attributes on the object, firing `"change"` unless you
     // choose to silence it.
     set : function(attrs, options) {

--- a/index.html
+++ b/index.html
@@ -168,6 +168,7 @@
       <li>– <a href="#Model-constructor">constructor / initialize</a></li>
       <li>– <a href="#Model-get">get</a></li>
       <li>– <a href="#Model-escape">escape</a></li>
+      <li>– <a href="#Model-is">is</a></li>
       <li>– <a href="#Model-set">set</a></li>
       <li>– <a href="#Model-unset">unset</a></li>
       <li>– <a href="#Model-clear">clear</a></li>
@@ -557,6 +558,13 @@ var hacker = new Backbone.Model({
 
 alert(hacker.escape('name'));
 </pre>
+
+    <p id="Model-is">
+      <b class="header">is</b><code>model.is(attribute)</code>
+      <br />
+      Returns whether an attribute is set to a truthy value or not. For example:
+      <tt>note.get("title")</tt>
+    </p>
 
     <p id="Model-set">
       <b class="header">set</b><code>model.set(attributes, [options])</code>

--- a/test/model.js
+++ b/test/model.js
@@ -104,6 +104,21 @@ $(document).ready(function() {
     equals(doc.escape('audience'), '');
   });
 
+  test("Model: is", function() {
+    attrs = { 'foo': 1 };
+    a = new Backbone.Model(attrs);
+    // falsiness
+    _([false, null, undefined, '', 0]).each(function(value) {
+      a.set({'foo': value});
+      equals(a.is("foo"), false);
+    });
+    // truthiness
+    _([true, "Truth!", 1]).each(function(value) {
+      a.set({'foo': value});
+      equals(a.is("foo"), true);
+    });
+  });
+
   test("Model: set and unset", function() {
     attrs = { 'foo': 1, 'bar': 2, 'baz': 3};
     a = new Backbone.Model(attrs);


### PR DESCRIPTION
Adds an attribute tester (similar to Ruby's `model.foo?` methods).

For example:

```
modelset({'foo': ''})
model.is("foo") === false

modelset({'foo': 'Yes'})
model.is("foo") === true
```

Includes tests, docs.
