### PR TITLE
Multiple views per element

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -772,6 +772,7 @@
   // Creating a Backbone.View creates its initial element outside of the DOM,
   // if an existing element is not provided...
   Backbone.View = function(options) {
+    this.vid = _.uniqueId('v');
     this._configure(options || {});
     this._ensureElement();
     this.delegateEvents();
@@ -843,13 +844,13 @@
     // not `change`, `submit`, and `reset` in Internet Explorer.
     delegateEvents : function(events) {
       if (!(events || (events = this.events))) return;
-      $(this.el).unbind('.delegateEvents');
+      $(this.el).unbind('.delegateEvents' + this.vid);
       for (var key in events) {
         var methodName = events[key];
         var match = key.match(eventSplitter);
         var eventName = match[1], selector = match[2];
         var method = _.bind(this[methodName], this);
-        eventName += '.delegateEvents';
+        eventName += '.delegateEvents' + this.vid;
         if (selector === '') {
           $(this.el).bind(eventName, method);
         } else {

--- a/test/view.js
+++ b/test/view.js
@@ -64,4 +64,27 @@ $(document).ready(function() {
     equals(view.el, document.body);
   });
 
+  test("View: multiple views per element", function() {
+    var count = 0, ViewClass = Backbone.View.extend({
+      el: $("body"),
+      events: {
+        "click": "click"
+      },
+      click: function() {
+        count++;
+      }
+    });
+
+    var view1 = new ViewClass;
+    $("body").trigger("click");
+    equals(1, count);
+
+    var view2 = new ViewClass;
+    $("body").trigger("click");
+    equals(3, count);
+
+    view1.delegateEvents();
+    $("body").trigger("click");
+    equals(5, count);
+  });
 });


### PR DESCRIPTION
This patch makes it possible to have more than one view listening for events on the same element. For example, you may want to have separate view classes for different behaviors whose events delegate to listeners on `document.body`.
