### PR TITLE
Pass Collection#fetch options along to refresh

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -493,7 +493,7 @@
       var collection = this;
       var success = options.success;
       options.success = function(resp) {
-        collection[options.add ? 'add' : 'refresh'](collection.parse(resp));
+        collection[options.add ? 'add' : 'refresh'](collection.parse(resp), options);
         if (success) success(collection, resp);
       };
       options.error = wrapError(options.error, collection, options);


### PR DESCRIPTION
Super simple, passes Collection#fetch options along to refresh or add. Matches the behavior of Model#fetch.
