### PR TITLE
View#el can be a string

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -879,12 +879,20 @@
     },
 
     // Ensure that the View has a DOM element to render into.
+    // If `this.el` is a string, pass it through `$()`, take the first
+    // matching element, and re-assign it to `el`. Otherwise, create
+    // an element from the `id`, `className` and `tagName` proeprties.
     _ensureElement : function() {
-      if (this.el) return;
-      var attrs = {};
-      if (this.id) attrs.id = this.id;
-      if (this.className) attrs["class"] = this.className;
-      this.el = this.make(this.tagName, attrs);
+      if (_.isString(this.el)) {
+        this.el = $(this.el).get(0);
+      }
+
+      if (!this.el) {
+        var attrs = {};
+        if (this.id) attrs.id = this.id;
+        if (this.className) attrs["class"] = this.className;
+        this.el = this.make(this.tagName, attrs);
+      }
     }
 
   });

--- a/test/view.js
+++ b/test/view.js
@@ -56,12 +56,34 @@ $(document).ready(function() {
     equals(counter2, 3);
   });
 
-  test("View: _ensureElement", function() {
+  test("View: _ensureElement with DOM node el", function() {
     var ViewClass = Backbone.View.extend({
       el: document.body
     });
     var view = new ViewClass;
     equals(view.el, document.body);
+  });
+
+  test("View: _ensureElement with string el", function() {
+    var ViewClass = Backbone.View.extend({
+      el: "body"
+    });
+    var view = new ViewClass;
+    equals(view.el, document.body);
+
+    ViewClass = Backbone.View.extend({
+      el: "body > h2"
+    });
+    view = new ViewClass;
+    equals(view.el, $("#qunit-banner").get(0));
+
+    ViewClass = Backbone.View.extend({
+      el: "#nonexistent"
+    });
+    view = new ViewClass;
+    ok(view.el);
+    equals(view.el.tagName.toLowerCase(), "div");
+    equals(view.el.parentNode, null);
   });
 
   test("View: multiple views per element", function() {


### PR DESCRIPTION
This patch adds support for specifying `el` as a string in `Backbone.View` subclasses, so that you can more easily defer element querying to the time of instantiation rather than delcaration.

If an element can't be found from the given string, `_ensureElement` falls back to calling `make`. Not sure if that's the right thing to do here. It might be better to raise an exception instead.
