### PR TITLE
Closure scope

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1034,4 +1034,4 @@
     return string.replace(/&(?!\w+;)/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
   };
 
-})();
+}).call(this);


### PR DESCRIPTION
Backbone uses `this` inside its closure to access jQuery or Zepto. If Backbone itself is wrapped inside another closure (say, a CommonJS module wrapper), it won't be able to access the global scope through `this`.

Here's a patch that passes along the current value of `this` to Backbone's closure.
