### PR TITLE
optimized use of if / in to check for window.onhashchange

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -720,7 +720,7 @@
       if (oldIE) {
         this.iframe = $('<iframe src="javascript:0" tabindex="-1" />').hide().appendTo('body')[0].contentWindow;
       }
-      if ('onhashchange' in window && !oldIE) {
+      if (window['onhashchange'] && !oldIE) {
         $(window).bind('hashchange', this.checkUrl);
       } else {
         setInterval(this.checkUrl, this.interval);


### PR DESCRIPTION
Currently using if('onhashchange' in window) to detect hashchange support. In this case, it would probably be best to use brackets to check for the presence of 'onhashchange'.

Check out jsperf for performance stats on this.
http://jsperf.com/in-vs-brackets 
