### PR TITLE
FEAT: Backbone.Model.merge() - extend attributes

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -169,6 +169,13 @@
       return this.attributes[attr] != null;
     },
 
+    // Merge a hash of model attributes with the object
+    merge: function(attrs, options) {
+        var merged = {};
+        for(var key in attrs) { merged[key] = _.extend( _.isArray(attrs[key]) ? [] : {}, this.attributes[key], attrs[key]) }
+        return this.set(merged);
+    },
+
     // Set a hash of model attributes on the object, firing `"change"` unless you
     // choose to silence it.
     set : function(attrs, options) {

--- a/test/model.js
+++ b/test/model.js
@@ -155,6 +155,19 @@ $(document).ready(function() {
     equals(model.get('name'), '');
   });
 
+  test("Model: merge", function() {
+      var complex = { dict: { one: 1, two: 2, three: 3 }, list: [1,2,3] };
+      var model = new Backbone.Model(complex);
+
+      var extra = { dict: { four: 4 }, list: [,,,4] };
+
+      model.merge(extra);
+
+      same(model.get('dict'), {one:1,two:2,three:3,four:4}, 'attribute MUST contain the merged hash elements');
+      same(model.get('list'), [1,2,3,4], 'attribute MUST contain the merged array elements');
+      same(model.toJSON(), {dict: {one:1,two:2,three:3,four:4}, list: [1,2,3,4]}, 'attributes MUST be merged');
+  });
+
   test("Model: clear", function() {
     var changed;
     var model = new Backbone.Model({name : "Model"});


### PR DESCRIPTION
Allow the model attributes to be extended.

SYNOPSIS

```
    var x = new Backbone.Model( { foo: {two: 2}, bar: [1,2]} );

    x.merge( { foo: {one: 1}, bar: [,,3] } );

    x.toJSON === { foo: {one: 1, two: 2}, bar: [1,2,3] };
    x.get('foo').two === 2;
```

NAMING
extend is already in use, took merge()

TESTS
wrote a couple of test cases, for Arrays and Objects in particular
