### PR TITLE
Add sync events

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -957,6 +957,20 @@
       processData:  false
     }, options);
 
+    if (!options.silent) {
+      var success = params.success,
+            error = params.error;
+
+      params.success = function() {
+        if (success) success.apply(this, arguments);
+        model.trigger('sync:success', model, method, options);
+      };
+      params.error = function() {
+        if (error) error.apply(this, arguments);
+        model.trigger('sync:error', model, method, options);
+      };
+    }
+
     // Ensure that we have a URL.
     if (!params.url) {
       params.url = getUrl(model) || urlError();
@@ -988,6 +1002,8 @@
 
     // Make the request.
     $.ajax(params);
+
+    if (!options.silent) model.trigger('sync', model, method, options);
   };
 
   // Helpers

--- a/test/sync.js
+++ b/test/sync.js
@@ -133,4 +133,16 @@ $(document).ready(function() {
     equals(lastRequest.url, '/one/two');
   });
 
+  test("sync: events", function() {
+    var sync, syncSuccess, syncError;
+    library.bind("sync", function() { sync = true; });
+    library.bind("sync:success", function() { syncSuccess = true; });
+    library.bind("sync:error", function() { syncError = true; });
+    library.fetch();
+    lastRequest.success();
+    equals(sync, true);
+    equals(syncSuccess, true);
+    equals(syncError, undefined);
+  });
+
 });


### PR DESCRIPTION
Adds `sync`, `sync:success`, and `sync:error` to Backbone.sync.

`refresh` and `change` events fire anytime the user or server updates a model. Sometimes you only want to react to server data changes.
### Use cases:

Caching model data after successful syncs:

```
@bind 'sync:success', (model) ->
  localStorage[model.url] = model.toJSON()
```

Flagging model data as fresh from the server:

```
@bind 'sync:success', -> model.fresh = true
```

Tracking busy states:

```
@bind 'sync',         (model) -> model.busy = true
@bind 'sync:success', (model) -> model.busy = false
@bind 'sync:error',   (model) -> model.busy = false
```

Related #180
