### PR TITLE
Allow overriding model id attribute

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -601,8 +601,8 @@
       if (ev == 'destroy') {
         this._remove(model, options);
       }
-      if (ev === 'change:id') {
-        delete this._byId[model.previous('id')];
+      if (ev === 'change:' + model.idAttribute) {
+        delete this._byId[model.previous(model.idAttribute)];
         this._byId[model.id] = model;
       }
       this.trigger.apply(this, arguments);

--- a/test/model.js
+++ b/test/model.js
@@ -352,7 +352,7 @@ $(document).ready(function() {
       idAttribute: '_id'
     });
 
-    var model = new Model();
+    var model = new Model;
 
     equals(model.isNew(), true);
     equals(model.id, undefined);
@@ -363,6 +363,29 @@ $(document).ready(function() {
 
     equals(model.isNew(), false);
     equals(model.id, 1);
+
+    var Models = Backbone.Collection.extend({
+      model: Model
+    });
+
+    var models = new Models;
+    models.add(model);
+
+    var found = models.get(1);
+
+    equals(found, model);
+
+    model.set({
+      _id: 2
+    });
+
+    found = models.get(1);
+
+    equals(found, undefined);
+
+    found = models.get(2);
+
+    equals(found, model);
   });
 
 });


### PR DESCRIPTION
Gives Backbone.Model an idAttribute member so custom id attribute names can be used (i.e. "ID" from a PascalCased language or "_id" from CouchDB)
