### PR TITLE
Models created using Collection.create should be validated.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -511,7 +511,9 @@
       var coll = this;
       options || (options = {});
       if (!(model instanceof Backbone.Model)) {
-        model = new this.model(model, {collection: coll});
+        modelRef = model;
+        model = new this.model(null, {collection: coll});
+        if(!model.set(modelRef)) return false;
       } else {
         model.collection = coll;
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -208,6 +208,19 @@ $(document).ready(function() {
     equals(model.collection, col);
   });
 
+  test("Collection: create enforces validation", function() {
+    var ValidatingModel = Backbone.Model.extend({
+        validate: function(attrs) {
+                return "fail"
+        }
+    });
+    var ValidatingCollection = Backbone.Collection.extend({
+        model: ValidatingModel
+    });
+    var col = new ValidatingCollection();
+    equals(col.create({"foo":"bar"}),false);
+  });
+
   test("collection: initialize", function() {
     var Collection = Backbone.Collection.extend({
       initialize: function() {


### PR DESCRIPTION
The documentation implies that `Collection.create` "Returns the model, or false if a validation error prevented the model from being created." (http://documentcloud.github.com/backbone/#Collection-create)

This commit forces client-side validation in `Collection.create` by explicitly calling `set` rather than passing the attrs to the model's constructor which calls `set` with `{silent:true}`.
