### PR TITLE
Allow 'refresh' to benefit from overriding 'parse'

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -490,7 +490,9 @@
       options || (options = {});
       this.each(this._removeReference);
       this._reset();
-      this.add(models, {silent: true});
+      for (var i = 0; i < models.length; i++) {
+				this.add(this.parse(models[i]), {silent: true});	
+			}
       if (!options.silent) this.trigger('refresh', this, options);
       return this;
     },
@@ -503,7 +505,7 @@
       var collection = this;
       var success = options.success;
       options.success = function(resp) {
-        collection[options.add ? 'add' : 'refresh'](collection.parse(resp), options);
+        collection[options.add ? 'add' : 'refresh'](resp, options);
         if (success) success(collection, resp);
       };
       options.error = wrapError(options.error, collection, options);


### PR DESCRIPTION
Overriding the 'parse' method of the Backbone.Collection seemed to only work for the 'fetch' method. This patch allows the 'refresh' method to properly refresh a Collection given a custom parse function.

My use-case here appeared while trying to bootstrap a collections model, but from a Rails to_json call.

Thoughts?
