### PR TITLE
Make Backbone.View.delegateEvents lookup the method bound to the event on calltime

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -892,7 +892,7 @@
               match = key.match(eventSplitter),
               eventName = match[1], 
               selector = match[2],
-              deferredLookup = function() { self[methodName].call(self) };
+              deferredLookup = function() { self[methodName].apply(self,arguments) };
           eventName += '.delegateEvents' + self.cid;
           if (selector === '') {
             $(self.el).bind(eventName,deferredLookup);


### PR DESCRIPTION
This commit allows modification of a view's callback method after the view is instantiated. Underscore provides lots of nice functions for doing this, it'd be a shame not to be able to use them with Backbone's Views.

```
var instance = new FooView()
instance.onSomeCallback = _.wrap(instance.onSomeCallback,function(func) {
  somethingElse()
  return func()
})
```

or

```
dojo.connect(instance,'onSomeCallback',function() { alert('callback 1') })
...
dojo.connect(instance,'onSomeCallback',function() { alert('callback 2') })
....
```

This gives you all the flexibility in the world to listen to a views' callbacks, adding and detaching them after instantiation.
