### PR TITLE
destroy of non-persisted model should not call sync

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -286,18 +286,22 @@
       return this;
     },
 
-    // Destroy this model on the server. Upon success, the model is removed
+    // Destroy this model on the server if it was already persisted. Upon success, the model is removed
     // from its collection, if it has one.
     destroy : function(options) {
       options || (options = {});
-      var model = this;
-      var success = options.success;
-      options.success = function(resp) {
-        model.trigger('destroy', model, model.collection, options);
-        if (success) success(model, resp);
-      };
-      options.error = wrapError(options.error, model, options);
-      (this.sync || Backbone.sync).call(this, 'delete', this, options);
+      if (this.isNew()) {
+        this.trigger('destroy', this, this.collection, options);
+      } else {
+        var model = this;
+        var success = options.success;
+        options.success = function(resp) {
+          model.trigger('destroy', model, model.collection, options);
+          if (success) success(model, resp);
+        };
+        options.error = wrapError(options.error, model, options);
+        (this.sync || Backbone.sync).call(this, 'delete', this, options);
+      }
       return this;
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -206,6 +206,17 @@ $(document).ready(function() {
     equals(null, e.collection);
   });
 
+  test("Colllection: non-persisted model destroy removes from all collections", function() {
+    var e = new Backbone.Model({title: 'Othello'});
+    e.sync = function(method, model, options) { throw "should not be called"; };
+    var colE = new Backbone.Collection([e]);
+    var colF = new Backbone.Collection([e]);
+    e.destroy();
+    ok(colE.length == 0);
+    ok(colF.length == 0);
+    equals(null, e.collection);
+  });
+
   test("Collection: fetch", function() {
     col.fetch();
     equals(lastRequest[0], 'read');

--- a/test/model.js
+++ b/test/model.js
@@ -276,6 +276,13 @@ $(document).ready(function() {
     ok(_.isEqual(lastRequest[1], doc));
   });
 
+  test("Model: non-persisted destroy", function() {
+    attrs = { 'foo': 1, 'bar': 2, 'baz': 3};
+    a = new Backbone.Model(attrs);
+    a.sync = function(method, model, options) { throw "should not be called"; };
+    ok(a.destroy(), "non-persisted model should not call sync");
+  });
+
   test("Model: validate", function() {
     var lastError;
     var model = new Backbone.Model();


### PR DESCRIPTION
Currently model destroy assumes that it should always to Backbone.sync - after this patch at first isNew() is checked and Backbone.sync is done just for persisted models, otherwise just destroy event is triggered (to ensure that model is removed from any collection).

Potential use case example - there is post model with many comments and you click on add new comment link (it creates new comment model and adds it to comments collection). If you press Save then comment save is called but if you press Cancel then comment destroy is called.
