### PR TITLE
Request Parsing Function

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -316,8 +316,8 @@
       return resp;
     },
 
-    // **parseRequest** converts any request into the proper formatting, allows for adjusting any
-    // of the request parameters. The default implementation is just to pass the request along.
+    // **parseRequest** converts any request into the proper formatting, allows for encoding the request as desired.
+    // The default implementation is just to stringify the object into json.
     parseRequest : function(req) {
       return JSON.stringify(req);
     },


### PR DESCRIPTION
I'm working on an application that requires us to interact with a service that only accepts xml.  We already have an object -> xml converter, but needed a hook into the sync function to allow this to happen.  To make the hook more general purpose I figured we could send the whole set of request parameters in.

The other option I see as being useful would be to put the hook just around parsing the data, replace the JSON.strigify(model.toJSON) with a parse method, that does that by default but can be overridden.

I also know that we can do this by defining our own sync method, but the only change we want to make is to change the data.

If you want to go the other route of having a hook to just override the data, let me know and I can submit a pull for that.
