### PR TITLE
Escape single quotes as well

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1077,9 +1077,9 @@
     };
   };
 
-  // Helper function to escape a string for HTML rendering.
+  // Helper function to escape a string for HTML rendering. (Allows use of HTML entities.)
   var escapeHTML = function(string) {
-    return string.replace(/&(?!\w+;|#\d+;|#x[\da-f]+;)/gi, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+    return string.replace(/&(?!\w+;|#\d+;|#x[\da-f]+;)/gi, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&#x27;');
   };
 
 }).call(this);


### PR DESCRIPTION
When single quotes are used for attribute values, user input containing unescaped single quotes cannot be trusted. 

XSS Demo: http://jsfiddle.net/wEzNJ/

[Previous comment on this topic](https://github.com/documentcloud/backbone/commit/0cdc525961d3fa98e810ffae6bcc8e3838e36d93)
