### PR TITLE
Don't set content type header for GET requests

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -982,7 +982,7 @@
 
     // Ensure that we have the appropriate request data.
     if (!params.data && model && (method == 'create' || method == 'update')) {
-      params.contentType = 'application/json',
+      params.contentType = 'application/json';
       params.data = JSON.stringify(model.toJSON());
     }
 


### PR DESCRIPTION
This appears to cause Node.js Connect's `bodyParser` middleware to fail silently presumably due to attempting to parse an empty body when the content type is `'application/json'`.
