### PR TITLE
Updated the Model constructor to pass options to set

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -124,7 +124,7 @@
     this.attributes = {};
     this._escapedAttributes = {};
     this.cid = _.uniqueId('c');
-    this.set(attributes, {silent : true});
+    this.set(attributes, options);
     this._changed = false;
     this._previousAttributes = _.clone(this.attributes);
     if (options && options.collection) this.collection = options.collection;


### PR DESCRIPTION
This change is to address the issue #271. This patch changes the behavior of the Model constructor so that when set is called to set the value of the attributes, it will no long pass {silent: true} but will pass the options given to the constructor.

Here's the text from the issue:

When creating a new model and then saving it as follows:

```
var todo = new Todo({title: 'Fix bugs'});
todo.save();
```

The model's validation method is not called before making the POST request unless the save method is passed the attributes. This passes through validation prior to the server request:

```
var todo = new Todo();
todo.save({title: 'Fix bugs'});
```

Is this intentional? If so, it seems a little counterintuitive to skip validation for newly instantiated models.
