### PR TITLE
Comment fix

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1045,7 +1045,7 @@
     // Add static properties to the constructor function, if supplied.
     if (staticProps) _.extend(child, staticProps);
 
-    // Correctly set child's `prototype.constructor`, for `instanceof`.
+    // Correctly set child's `prototype.constructor`.
     child.prototype.constructor = child;
 
     // Set a convenience property in case the parent's prototype is needed later.


### PR DESCRIPTION
Hello,

I fixed a minor error in the Backbone comments. The original comment seemed to imply that `child.prototype.constructor` would influence the behavior of `instanceof`, but it does not. The result of `instanceof` is determined by the object stored in child.prototype.

Thanks!

Jimmy
