### PR TITLE
Fix localStorage example plugin

### DIFF
--- a/examples/backbone-localstorage.js
+++ b/examples/backbone-localstorage.js
@@ -64,7 +64,7 @@ _.extend(Store.prototype, {
 
 // Override `Backbone.sync` to use delegate to the model or collection's
 // *localStorage* property, which should be an instance of `Store`.
-Backbone.sync = function(method, model, options) {
+Backbone.sync = function(method, model, options, success, error) {
 
   var resp;
   var store = model.localStorage || model.collection.localStorage;
@@ -77,8 +77,8 @@ Backbone.sync = function(method, model, options) {
   }
 
   if (resp) {
-    options.success(resp);
+    success(resp);
   } else {
-    options.error("Record not found");
+    error("Record not found");
   }
 };


### PR DESCRIPTION
The example localStorage JS was replacing Backbone.sync with something that took 3 arguments, instead of the required 4 (options instead of success, error)
