### PR TITLE
Add support for jQuery.Deferred on ajax calls

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -145,8 +145,9 @@
     // CouchDB users may want to set this to `"_id"`.
     idAttribute : 'id',
 
-    // A jQuery promise object (set on 'fetch', 'save' and 'destroy')
-    promise: null,
+    // The most recent request object (set on 'fetch', 'save' and 'destroy').
+	// Enables the use of jQuery.Deferred methods. 
+    request: null,
 
     // Initialize is an empty function by default. Override it with your own
     // initialization logic.
@@ -267,7 +268,7 @@
         if (success) success(model, resp);
       };
       options.error = wrapError(options.error, model, options);
-      this.promise = (this.sync || Backbone.sync).call(this, 'read', this, options);
+      this.request = (this.sync || Backbone.sync).call(this, 'read', this, options);
       return this;
     },
 
@@ -285,7 +286,7 @@
       };
       options.error = wrapError(options.error, model, options);
       var method = this.isNew() ? 'create' : 'update';
-      this.promise = (this.sync || Backbone.sync).call(this, method, this, options);
+      this.request = (this.sync || Backbone.sync).call(this, method, this, options);
       return this;
     },
 
@@ -300,7 +301,7 @@
         if (success) success(model, resp);
       };
       options.error = wrapError(options.error, model, options);
-      this.promise = (this.sync || Backbone.sync).call(this, 'delete', this, options);
+      this.request = (this.sync || Backbone.sync).call(this, 'delete', this, options);
       return this;
     },
 
@@ -418,8 +419,9 @@
     // This should be overridden in most cases.
     model : Backbone.Model,
 
-    // A jQuery promise object (set on 'fetch')
-    promise: null,
+    // The most recent request object (set on 'fetch'). Enables the use of
+	// jQuery.Deferred methods.
+    request: null,
 
     // Initialize is an empty function by default. Override it with your own
     // initialization logic.
@@ -513,7 +515,7 @@
         if (success) success(collection, resp);
       };
       options.error = wrapError(options.error, collection, options);
-      this.promise = (this.sync || Backbone.sync).call(this, 'read', this, options);
+      this.request = (this.sync || Backbone.sync).call(this, 'read', this, options);
       return this;
     },
 
@@ -1012,8 +1014,7 @@
     }
 
     // Make the request.
-    var request = $.ajax(params);
-    return _.isFunction( request.promise ) ? request.promise() : request;
+    return $.ajax(params);
   };
 
   // Helpers


### PR DESCRIPTION
Deferreds (as of jQuery 1.5, see http://api.jquery.com/category/deferred-object/) can make it much easier to cope with (possibly) async behavior. See for examples http://www.erichynds.com/jquery/using-deferreds-in-jquery/ .

I've tried to incorporate this in Backbone without making any backwards incompatible change (so, didn't touch any return values) by adding a 'promise' attribute to Model and Collection that gets updated when using the Collection.fetch and Model.fetch/save/destroy functions. An alternative would be to make these methods return the XHR object right away.

This is (at least for me ;) ) very useful in cases where you may (or may not) need to make a number of requests to the server. Example:

```
var req = model.save();
// or, when using a version where the latest request is exposed as a property:
var req = model.save().request;

// all callbacks are executed whenever the request finishes (or right away if it's finished already)
req
    .done( function( response, textStatus, xhr ) {
        // success callback
    })
    .fail( function( response, textStatus, xhr ) {
        // error callback
     })
    .then( function( response, textStatus, xhr ) {
        // called on complete
    });
```

A more complicated example (where this feature is even nicer to have):

```
// Get a Collection of Tags; one or more may have to be created
var tags = TagList.getOrCreateByName( ['inbox', 'waiting for', 'work' ] );

// Get an array of all the promises
var promises = tags.map( function( tag ) {
    return tag.promise;
});

// $.when accept one or more promises, but not an array of promises, so use apply here.
// The .then() will execute when all Tags are either found, or created
$.when.apply( null, promises ).then( function() {
    // Do something that requires all Tags to be created
});
```

The change doesn't depend jQuery btw; if the xhr object doesn't have a "promise" function, it just assigns the xhr object itself.
