### PR TITLE
Workaround for jQuery's JSONP "??" replacement.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -984,6 +984,9 @@
     // Ensure that we have the appropriate request data.
     if (!params.data && model && (method == 'create' || method == 'update')) {
       params.data = JSON.stringify(model.toJSON());
+      // See: http://bugs.jquery.com/ticket/8417
+      params.jsonp = false;
+      delete params.dataType;
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.


### PR DESCRIPTION
This started happening in jQuery 1.5.x.
See also: http://bugs.jquery.com/ticket/8417
