### PR TITLE
Make the hashStrip regex strip bang (!) from hash if it's present

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -731,7 +731,7 @@
   };
 
   // Cached regex for cleaning hashes.
-  var hashStrip = /^#*/;
+  var hashStrip = /^#*!?/;
 
   // Has the history handling already been started?
   var historyStarted = false;


### PR DESCRIPTION
Changes the hashStrip regex to also strip the bang as well, if it's present. This should allow hash-bang URLs to work transparently. Without this change you need to include the ! in front of the route definition.
