### PR TITLE
Fixes issue #263 : collection.remove(collection.models)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -454,8 +454,8 @@
     // firing the `removed` event for every model removed.
     remove : function(models, options) {
       if (_.isArray(models)) {
-        for (var i = 0, l = models.length; i < l; i++) {
-          this._remove(models[i], options);
+        for (var i = 0, l = models.length, _remove = _.clone(models); i < l; i++) {
+          this._remove(_remove[i], options);
         }
       } else {
         this._remove(models, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -123,6 +123,28 @@ $(document).ready(function() {
     equals(col.first(), d);
     equals(otherRemoved, null);
   });
+  
+  test("Collection: remove array of models", function() {
+    var a = new Backbone.Model({id: 0, label: 'a'}),
+        b = new Backbone.Model({id: 1, label: 'b'}),
+        c = new Backbone.Model({id: 2, label: 'c'}),
+        d = new Backbone.Model({id: 3, label: 'd'}),
+        col = new Backbone.Collection([a, b, c, d]);
+    col.remove([a, b, c, d]);
+    equals(col.length, 0);
+    deepEqual(col.models, []);
+  });
+  
+  test("Collection: remove all using collection.models", function() {
+    var a = new Backbone.Model({id: 0, label: 'a'}),
+        b = new Backbone.Model({id: 1, label: 'b'}),
+        c = new Backbone.Model({id: 2, label: 'c'}),
+        d = new Backbone.Model({id: 3, label: 'd'}),
+        col = new Backbone.Collection([a, b, c, d]);
+    col.remove(col.models);
+    equals(col.length, 0);
+    deepEqual(col.models, []);
+  });
 
   test("Collection: events are unbound on remove", function() {
     var counter = 0;


### PR DESCRIPTION
Includes a test case, as well as a test case for `collection.remove(array)`. Ref: [#263](https://github.com/documentcloud/backbone/issues/263)
