### PR TITLE
Fixes issue #263 : collection.remove(collection.models)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -462,6 +462,11 @@
       }
       return this;
     },
+    
+    // Remove all models from the set.
+    clear : function(options) {
+      this.remove(this.models, options);
+    },
 
     // Get a model from the set by id.
     get : function(id) {

--- a/test/collection.js
+++ b/test/collection.js
@@ -228,6 +228,15 @@ $(document).ready(function() {
     equals(null, e.collection);
   });
 
+  test("Collection: clear", function() {
+    var col = new Backbone.Collection([
+          new Backbone.Model({id: 0, label: 'a'}),
+          new Backbone.Model({id: 1, label: 'b'})]);
+    col.clear();
+    equals(col.length, 0);
+    deepEqual(col.models, []);
+  });
+
   test("Collection: fetch", function() {
     col.fetch();
     equals(lastRequest[0], 'read');


### PR DESCRIPTION
- Ref: [#263](https://github.com/documentcloud/backbone/issues/263) : Includes a test case, as well as a test case for `collection.remove(array)`.
- Added `collection.clear()` helper method (and test case) to remove all instances in a set.
