### PR TITLE
Throw an exception when server response is clearly wrong

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -267,6 +267,18 @@
       return this;
     },
 
+    // Checks whether the server's response is something the rest of the API
+    // can work with. If not, throw an exception, since otherwise the program
+    // would crash at some later stage when incorrectly assuming the server's
+    // reponse was correct.
+    checkResponse : function(resp) {
+      var ty = typeof(resp);
+      if (ty && ty != "object") {
+        throw 'Invalid response received from server. Expected an object, but received a ' + ty + '.';
+      }
+      return resp;
+    },
+
     // Fetch the model from the server. If the server's representation of the
     // model differs from its current attributes, they will be overriden,
     // triggering a `"change"` event.
@@ -275,7 +287,7 @@
       var model = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {
-        if (!model.set(model.parse(resp, xhr), options)) return false;
+        if (!model.set(model.checkResponse(model.parse(resp, xhr), options))) return false;
         if (success) success(model, resp);
       };
       options.error = wrapError(options.error, model, options);
@@ -291,7 +303,7 @@
       var model = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {
-        if (!model.set(model.parse(resp, xhr), options)) return false;
+        if (!model.set(model.checkResponse(model.parse(resp, xhr), options))) return false;
         if (success) success(model, resp, xhr);
       };
       options.error = wrapError(options.error, model, options);


### PR DESCRIPTION
This patch throws an exception when the response from the server cannot be processed correctly. It affects Model.save() and Model.fetch().
These functions grab the server response and pass it to the model (by default) directly. If the response is not an object, the code in Model.set() will crash with an obscure error and without a very helpful stacktrace. Since in this case the application will crash one way or another, this patch opts to throw an exception with meaningful information instead, making it significantly easier for the developer to identify and resolve the issue.
