### PR TITLE
Collection initialization behavior improvement

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -416,8 +416,7 @@
     }
     _.bindAll(this, '_onModelEvent', '_removeReference');
     this._reset();
-    this.initialize(null, options);
-    if (models) this.refresh(models, {silent: true});
+    this.initialize(models, options);
   };
 
   // Define the Collection's inheritable methods.
@@ -427,9 +426,11 @@
     // This should be overridden in most cases.
     model : Backbone.Model,
 
-    // Initialize is an empty function by default. Override it with your own
-    // initialization logic.
-    initialize : function(){},
+    // Initialize does collection refresh by default.
+    // Override it with your own initialization logic.
+    initialize : function(models, options) {
+        if (models) this.refresh(models, {silent: true});
+    },
 
     // The JSON representation of a Collection is an array of the
     // models' attributes.


### PR DESCRIPTION
Hi everyone!

Yesterday I was playing with Backbone and was surprised by collection initialization behavior.
Say, given this code:

``` javascript

// Instances of this model are assumed to be members of the MyCollection
var MyModel = Backbone.Model.extend({
    defaults: { ... },
    initialize: function() {
        if ( this.collection && !this.collection.someImportantStuff
                             && !this.collection.someUselessStuff )
        {
            throw new Error("Collection is not initialized");
        }

        // Initialize model using pieces of data shared by the collection
        ...
    }
});

// This collection allows some options to be passed to initializer
var MyCollection = Backbone.Collection.extend({
    model: MyModel,
    initialize: function(models, options) {
        options = ( options || { someImportantOption: false } )
        if ( options.someImportantOption ) {
            this.someImportantStuff = { ... };
        } else {
            this.someUselessStuff = { ... };
        }
    }
});

```

Now assume that we want to instantiate the collection with `someImportantOption` set to `true` and a number of model instances inside. Here is the most obvious way:

``` javascript

var data = new MyCollection(
    [ { ... }, { ... }, { ... } ],
    { someImportantOption: true }
);

```

But that would throw `Error`... Hacking inside I'we found that it because of [Collection.refresh is called before Collection.initialize](https://github.com/documentcloud/backbone/blob/master/backbone.js#L419-420) so model initialization have a deal with not yet initialized collection.

Workaroud this behavior can be done a little tricky:

``` javascript

var data = new MyCollection( null, { someImportantOption: true } );
data.refresh( [ { ... }, { ... }, { ... } ] );

```

But that's not a good style, so I fixed it...

Any thoughts or suggestions?
