### PR TITLE
The call to delegateEvents() in Backbone.View's constructor can introduce unnecessary performance penalty

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -827,7 +827,9 @@
     this.cid = _.uniqueId('view');
     this._configure(options || {});
     this._ensureElement();
-    this.delegateEvents();
+    if (!this.options.skipDelegateEvents) {
+        this.delegateEvents();
+    }
     this.initialize(options);
   };
 

--- a/test/view.js
+++ b/test/view.js
@@ -113,4 +113,24 @@ $(document).ready(function() {
     $("body").trigger("click");
     equals(5, count);
   });
+
+  test("View: with skipDelegateEvents", function() {
+    var originalDelegateEvents = Backbone.View.prototype.delegateEvents;
+    
+    var delegateEventsCalled = false;
+    Backbone.View.prototype.delegateEvents = function() {
+      delegateEventsCalled = true;
+    };
+    var view = new Backbone.View({skipDelegateEvents: true});
+    equals(delegateEventsCalled, false);
+    delegateEventsCalled = false;
+    var view = new Backbone.View({skipDelegateEvents: false});
+    equals(delegateEventsCalled, true);
+    delegateEventsCalled = false;
+    var view = new Backbone.View();
+    equals(delegateEventsCalled, true);
+    
+    Backbone.View.prototype.delegateEvents = originalDelegateEvents;
+  });
+
 });


### PR DESCRIPTION
TWIMC:

While investigating performance problems in our Backbone views, the profiler showed us that the call to `delegateEvents()` in the `Backbone.View` constructor was responsible for several seconds of the time to render the view.

We attach 6 events to each of 75 views (in the case that we profiled). The `Backbone.View` constructor ends up calling the guts of `delegateEvents()` 450 times on the default DOM element that Backbone creates to back the view. Later, we attach the view to an actual, dynamically-created DOM element and call `delegateEvents()`, making the same 450 calls hooking up the events to the correct element. The first `delegateEvents()` is wasted time.

Our solution is simple, if heavy-handed--we added a boolean option (`skipDelegateEvents`) to the constructor to skip the call to `delegateEvents()`. If you are attaching a number of events to a large number of views, and you're late-binding `this.el`, you'd set the option to `true`.

We included tests covering the feature. Let us know if you have any questions about this patch!

Thanks!

Ed Ruder
