### PR TITLE
Added ``useTrailingSlashes`` option.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -52,6 +52,10 @@
   // form param named `model`.
   Backbone.emulateJSON = false;
 
+  // Turn on `useTrailingSlashes` to support servers that prefer URLs have
+  // a trailing slash.
+  Backbone.useTrailingSlashes = false;
+
   // Backbone.Events
   // -----------------
 
@@ -1051,6 +1055,11 @@
     if (!params.data && model && (method == 'create' || method == 'update')) {
       params.contentType = 'application/json';
       params.data = JSON.stringify(model.toJSON());
+    }
+
+    // For server-side code that prefers a trailing slash.
+    if (Backbone.useTrailingSlashes) {
+      params.url += (params.url.charAt(params.url.length - 1) == '/' ? '' : '/');
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.

--- a/test/sync.js
+++ b/test/sync.js
@@ -46,6 +46,19 @@ $(document).ready(function() {
     equals(data.length, 123);
   });
 
+  test("sync: create with useTrailingSlashes", function() {
+    Backbone.useTrailingSlashes = true;
+    library.add(library.create(attrs));
+    equals(lastRequest.url, '/library/');
+    equals(lastRequest.type, 'POST');
+    equals(lastRequest.dataType, 'json');
+    var data = JSON.parse(lastRequest.data);
+    equals(data.title, 'The Tempest');
+    equals(data.author, 'Bill Shakespeare');
+    equals(data.length, 123);
+    Backbone.useTrailingSlashes = false;
+  });
+
   test("sync: update", function() {
     library.first().save({id: '1-the-tempest', author: 'William Shakespeare'});
     equals(lastRequest.url, '/library/1-the-tempest');
@@ -56,6 +69,20 @@ $(document).ready(function() {
     equals(data.title, 'The Tempest');
     equals(data.author, 'William Shakespeare');
     equals(data.length, 123);
+  });
+
+  test("sync: update with useTrailingSlashes, emulateHTTP and emulateJSON", function() {
+    Backbone.emulateHTTP = Backbone.emulateJSON = Backbone.useTrailingSlashes = true;
+    library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
+    equals(lastRequest.url, '/library/2-the-tempest/');
+    equals(lastRequest.type, 'POST');
+    equals(lastRequest.dataType, 'json');
+    equals(lastRequest.data._method, 'PUT');
+    var data = JSON.parse(lastRequest.data.model);
+    equals(data.id, '2-the-tempest');
+    equals(data.author, 'Tim Shakespeare');
+    equals(data.length, 123);
+    Backbone.emulateHTTP = Backbone.emulateJSON = Backbone.useTrailingSlashes = false;
   });
 
   test("sync: update with emulateHTTP and emulateJSON", function() {
@@ -70,6 +97,19 @@ $(document).ready(function() {
     equals(data.author, 'Tim Shakespeare');
     equals(data.length, 123);
     Backbone.emulateHTTP = Backbone.emulateJSON = false;
+  });
+
+  test("sync: update with just useTrailingSlashes", function() {
+    Backbone.useTrailingSlashes = true;
+    library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
+    equals(lastRequest.url, '/library/2-the-tempest/');
+    equals(lastRequest.type, 'PUT');
+    equals(lastRequest.contentType, 'application/json');
+    var data = JSON.parse(lastRequest.data);
+    equals(data.id, '2-the-tempest');
+    equals(data.author, 'Tim Shakespeare');
+    equals(data.length, 123);
+    Backbone.useTrailingSlashes = false;
   });
 
   test("sync: update with just emulateHTTP", function() {


### PR DESCRIPTION
I added a `Backbone.useTrailingSlashes` option for compatibility with server-side code that prefers trailing slashes. For instance, Django in general (and more specifically my REST framework Tastypie - http://github.com/toastdriven/django-tastypie) usually has trailing slashes at the end of URLs, which causes problems when `Backbone.sync` is fired.

I've added three (passing) tests to cover the option as well as combining it with the `emulate*` options.
