### PR TITLE
url function should respect the url parameters

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -330,8 +330,8 @@
       var param = "";
       var index = base.indexOf("?");
       if (index > 0){
-        base = base.substring(0, index);
         param = base.substring(index);
+        base = base.substring(0, index);
       }
       
       return base + (base.charAt(base.length - 1) == '/' ? '' : '/') + encodeURIComponent(this.id) + param;

--- a/test/model.js
+++ b/test/model.js
@@ -76,6 +76,16 @@ $(document).ready(function() {
     equals(model.url(), '/collection/%2B1%2B');
   });
 
+  test("Model: url when using parameters in urlRoot", function() {
+    var Model = Backbone.Model.extend({
+      urlRoot: '/collection?foo=bar'
+    });
+    var model = new Model();
+    equals(model.url(), '/collection?foo=bar');
+    model.set({id: '42'});
+    equals(model.url(), '/collection/42?foo=bar');
+  });
+  
   test("Model: clone", function() {
     attrs = { 'foo': 1, 'bar': 2, 'baz': 3};
     a = new Backbone.Model(attrs);


### PR DESCRIPTION
The original implementation just appends a model id to an url so i end up with urls like this
    /api/users?filter=value/1
when i want to pass parameters to my applications json api

This commit modifes the default url implemetation of a model to respect url parameters, so i now get
    /api/users/1?filter=value
what makes me happy ;)
