### PR TITLE
Added History::matchUrl

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -810,9 +810,9 @@
       this.fragment = fragment;
       historyStarted = true;
       var started = this.loadUrl() || this.loadUrl(window.location.hash);
-      if (this._wantsPushState && !this._hasPushState && window.location.pathname != this.options.root) {
+      if (this._wantsPushState && !this._hasPushState && window.location.pathname != (this.options.fallbackRoot || this.options.root)) {
         this.fragment = this.getFragment(null, true);
-        window.location = this.options.root + '#' + this.fragment;
+        window.location = (this.options.fallbackRoot || this.options.root) + '#' + this.fragment;
       } else {
         return started;
       }


### PR DESCRIPTION
Added Backbone.History::matchUrl to only test if a url matches any routes. Useful when testing a url before sending it to Router::setLocation.
Modified annotation on ::loadUrl.
