### PR TITLE
Events.trigger() does not continue through other callbacks if one contains an error

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -103,7 +103,7 @@
     // same arguments as `trigger` is, apart from the event name.
     // Listening for `"all"` passes the true event name as the first argument.
     trigger : function(eventName) {
-      var list, calls, ev, callback, args;
+      var list, calls, ev, callback, args, errs = [];
       var both = 2;
       if (!(calls = this._callbacks)) return this;
       while (both--) {
@@ -114,9 +114,16 @@
               list.splice(i, 1); i--; l--;
             } else {
               args = both ? Array.prototype.slice.call(arguments, 1) : arguments;
-              callback.apply(this, args);
+              try {
+                callback.apply(this, args);
+              } catch(e) {
+                // Collect, and continue firing callbacks
+                errs.push(e);
+                continue;
+              }
             }
           }
+          if (!_.isEmpty(errs)) throw errs[0];  // Throw the first we collected
         }
       }
       return this;

--- a/test/events.js
+++ b/test/events.js
@@ -67,4 +67,23 @@ $(document).ready(function() {
     equals(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
 
+  test("Events: continues through callbacks if one errors out", function() {
+    var obj = {counter: 0};
+    _.extend(obj, Backbone.Events);
+    var callA = function() {
+      obj.counter += 1;
+      throw new Error('Bad callback');
+    };
+    var callB = function() {
+      obj.counter += 1;
+    };
+    obj.bind('event', callA);
+    obj.bind('event', callB);
+    var trigger = function() {
+      obj.trigger('event');
+    };
+    raises(trigger, 'Bad callback', 'triggering the event should have thrown an error');
+    equals(obj.counter, 2, 'callB should have been called bringing counter to 2');
+  });
+
 });


### PR DESCRIPTION
This behavior may be by design, but it was a surprise to me when I discovered it.

If you have bound two callbacks using Events.bind(), and the first callback throws an error; the second callback does not get called.

I solved this by collecting the errors and raising the first one after the list of callbacks has been depleted.
