### PR TITLE
Modifying Backbone.History.getFragment to work with a '/' route.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -769,7 +769,7 @@
           fragment = window.location.pathname;
           var search = window.location.search;
           if (search) fragment += search;
-          if (fragment.indexOf(this.options.root) == 0) fragment = fragment.substr(this.options.root.length);
+          if (fragment.length > 1 && fragment.indexOf(this.options.root) == 0) fragment = fragment.substr(this.options.root.length);
         } else {
           fragment = window.location.hash;
         }


### PR DESCRIPTION
Backbone.History.getFragment no longer eats a fragment of '/', which allows Backbone.History.start to find a '/' route.

I didn't see any tests for the start or getFragment methods, otherwise I would have accompanying tests.
