### PR TITLE
Send changedAttributes to Backbone.sync

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -292,6 +292,7 @@
     // state will be `set` again.
     save : function(attrs, options) {
       options || (options = {});
+      var changedAttributes = this.changedAttributes(attrs);
       if (attrs && !this.set(attrs, options)) return false;
       var model = this;
       var success = options.success;
@@ -301,7 +302,7 @@
       };
       options.error = wrapError(options.error, model, options);
       var method = this.isNew() ? 'create' : 'update';
-      return (this.sync || Backbone.sync).call(this, method, this, options);
+      return (this.sync || Backbone.sync).call(this, method, this, options, changedAttributes);
     },
 
     // Destroy this model on the server if it was already persisted. Upon success, the model is removed


### PR DESCRIPTION
- When changedAttributes is called from within Backbone.sync
  it returns false as the change method overwrites
  _previousAttributes.  This makes it hard to send only
  the updated attributes to the server when a model is
  updated.
