### PR TITLE
Added Backbone.View[0] for jQuery/Zepto integration

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -987,9 +987,11 @@
         var attrs = this.attributes || {};
         if (this.id) attrs.id = this.id;
         if (this.className) attrs['class'] = this.className;
-        this.el = this.make(this.tagName, attrs);
+        this.el = this[0] = this.make(this.tagName, attrs);
+        this.length = 1;
       } else if (_.isString(this.el)) {
-        this.el = $(this.el).get(0);
+        this.el = this[0] = $(this.el).get(0);
+        this.length = 1;
       }
     }
 

--- a/test/view.js
+++ b/test/view.js
@@ -15,9 +15,10 @@ $(document).ready(function() {
   });
 
   test("View: jQuery", function() {
-    view.el = document.body;
+    view.el = view[0] = document.body;
     ok(view.$('#qunit-header a').get(0).innerHTML.match(/Backbone Test Suite/));
     ok(view.$('#qunit-header a').get(1).innerHTML.match(/Backbone Speed Suite/));
+    ok($(view).find('#qunit-header a').get(1).innerHTML.match(/Backbone Speed Suite/));
   });
 
   test("View: make", function() {


### PR DESCRIPTION
this[0] mirrors this.el inside a Backbone.View class. Allows for Backbone.View instances to be passed directly to jQuery / Zepto:

  var MyView = new Backbone.View;
  $(MyView).click(...);
