### PR TITLE
Fix initialization of models' previousAttributes during collection reset (Issue #407)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -510,6 +510,47 @@
       return this;
     },
 
+    // When you have an existing set of models in a collection, 
+    // you can do in-place updates of these models, reusing existing instances.
+    // - Items are matched against existing items in the collection by id
+    // - New items are added
+    // - matching models are updated using set(), triggers 'change'.
+    // - existing models not present in the update are removed if 'removeMissing' is passed.
+    // - a collection change event will be dispatched for each add() and remove()
+    update : function(models, options) {
+      models  || (models = []);
+      options || (options = {});
+
+      //keep track of the models we've updated, cause we're gunna delete the rest if 'removeMissing' is set.
+      var updateMap = _.reduce(this.models, function(map, model){ map[model.id] = false; return map },{});
+
+      _.each( models, function(model) {
+
+        var idAttribute = this.model.prototype.idAttribute;
+        var modelId = model[idAttribute];
+
+        if ( modelId == undefined ) throw new Error("Can't update a model with no id attribute. Please use 'reset'.");
+        
+        if ( this._byId[modelId] ) {
+          var attrs = (model instanceof Backbone.Model) ? _.clone(model.attributes) : _.clone(model);
+          delete attrs[idAttribute];
+          this._byId[modelId].set( attrs );
+          updateMap[modelId] = true;
+        }
+        else {
+          this.add( model );
+        }
+      }, this);
+
+      if ( options.removeMissing ) {
+        _.select(updateMap, function(updated, modelId){
+          if (!updated) this.remove( modelId );
+        }, this);
+      }
+
+      return this;
+    },
+
     // Fetch the default set of models for this collection, resetting the
     // collection when they arrive. If `add: true` is passed, appends the
     // models to the collection instead of resetting.
@@ -518,7 +559,7 @@
       var collection = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {
-        collection[options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
+        collection[options.update ? 'update' : options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
         if (success) success(collection, resp);
       };
       options.error = wrapError(options.error, collection, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -335,6 +335,35 @@ $(document).ready(function() {
     ok(_.isEqual(col.last().attributes, a.attributes));
   });
 
+  test("Collection: update", function() {
+    var l = col.last();
+
+    col.update(col.models);
+    equals(col.length, 4);
+    equals(col.last(), l);
+
+    col.update([{id: 3, label: 'updated'}])
+    equals(col.length, 4);
+    ok(col.last() === l);
+    equals(col.get(3).attributes.label, 'updated');
+
+
+    var aUpdated = new Backbone.Model({id: 3, label: 'updatedAgain'});
+    col.update([aUpdated])
+    equals(col.length, 4);
+    ok(col.last() === l);
+    equals(col.last().attributes.label, 'updatedAgain');
+
+    col.update([{id: 9, label: 'new'}]);
+    equals(col.length, 5);
+    equals(col.last().attributes.label, 'new');
+
+    col.update([{id: 3, label: 'a'}], {removeMissing: true})
+    equals(col.length, 1);
+    ok(col.last() === l);
+    equals(col.last().attributes.label, 'a');
+  });
+
   test("Collection: trigger custom events on models", function() {
     var fired = null;
     a.bind("custom", function() { fired = true; });


### PR DESCRIPTION
Failing test for a particular case of issue #407 and (not very good) fix for it.
