### PR TITLE
favour function over object, it allows private

### DIFF
--- a/test/model.js
+++ b/test/model.js
@@ -403,4 +403,27 @@ $(document).ready(function() {
     a.set({state: 'hello'});
   });
 
+  test("Model: private per object", function() {
+    var A = Backbone.Model.extend(function(){
+      var private_var = 1;
+
+      function private_fun(r){
+        private_var = r;
+      }
+      return {
+        initialize: function(){
+          equal(1, private_var);
+          var r = Math.random();
+          private_fun(r);
+          equal(r, private_var);
+        }
+      };
+    });
+    for(var i = 0; i < 3; i++){
+      new A();
+    }
+  });
+
+  
+
 });

--- a/test/view.js
+++ b/test/view.js
@@ -90,6 +90,23 @@ $(document).ready(function() {
     equals(view.el.id, 'two');
   });
 
+  test("Views: function as event handler", function(){
+    var count = 0, ViewClass = Backbone.View.extend(function(){
+      function click() {
+          count++;
+        }
+      return {
+        el: $("body"),
+        events: {
+          "click": click
+        }
+      };
+    });
+    var view1 = new ViewClass;
+    $("body").trigger("click");
+    equals(1, count);
+  });
+
   test("View: multiple views per element", function() {
     var count = 0, ViewClass = Backbone.View.extend({
       el: $("body"),


### PR DESCRIPTION
Function has more power than object. 
As already can pass an `object` to extend, how about  pass a `function` that returns an `object`. 
Closure gives us private function and variable. 
Attach `state` to `this` makes code hard to reason,  at least for me. 

Example:

``` js
   Backbone.Model.extend(function(){
      var private_var = 1; // per object.
      function private_fun(r){
        private_var = r;
      }
      return {
        initialize: function(){
        }
        .....
      };
    });

```

Do not break exists code. All testing code run happily.
