### PR TITLE
Fix for json contentType not getting set properly on create/update

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1048,9 +1048,11 @@
     }
 
     // Ensure that we have the appropriate request data.
-    if (!params.data && model && (method == 'create' || method == 'update')) {
+    if (method == 'create' || method == 'update') {
       params.contentType = 'application/json';
-      params.data = JSON.stringify(model.toJSON());
+      if (!params.data && model) {
+        params.data = JSON.stringify(model.toJSON());
+      }
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.


### PR DESCRIPTION
When I upgraded to master branch, this commit started breaking my rails app:
https://github.com/documentcloud/backbone/commit/83250a5a62ba5de7648ad2ee08ce379bad6b010d

It seems we should only be looking at the request method to set the json contentType and leave the request data particulars out of it.

Peter
