### PR TITLE
Validate all attributes on save

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -292,7 +292,8 @@
     // state will be `set` again.
     save : function(attrs, options) {
       options || (options = {});
-      if (attrs && !this.set(attrs, options)) return false;
+      attrs = _.extend({}, this.attributes, attrs);
+      if (!this.set(attrs, options)) return false;
       var model = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {

--- a/test/model.js
+++ b/test/model.js
@@ -353,6 +353,20 @@ $(document).ready(function() {
     equals(boundError, undefined);
   });
 
+  test("Model: validate on save", function() {
+    var model = new Backbone.Model({a: 100});
+    model.validate = function(attrs) {
+      if (attrs.a == 100) return "'a' can't be 100";
+    };
+    var result = model.save();
+    equals(result, false);
+    equals(model.get('a'), 100);
+
+    result = model.save(undefined, {silent: true});
+    equals(lastRequest[0], "create");
+    ok(_.isEqual(lastRequest[1], model));
+  });
+
   test("Model: Inherit class properties", function() {
     var Parent = Backbone.Model.extend({
       instancePropSame: function() {},


### PR DESCRIPTION
We are using backbone in a project and we would like to use models like this:

```
var Person = Backbone.Model.extend({
  validate: function(attrs) {
    if(!attrs.age) {
      return "age is mandatory!";
    }
  }
});

var person = new Person({ name: "Rafael" });
person.save();
```

and have all attributes validated. The current implementation doesn't do that, so I changed the save a bit to always call set, even if attrs is not passed.
