### PR TITLE
Discussion: "change" events after a set()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -197,6 +197,7 @@
       if (!attrs) return this;
       if (attrs.attributes) attrs = attrs.attributes;
       var now = this.attributes, escaped = this._escapedAttributes;
+      var changes = {};
 
       // Run validation.
       if (!options.silent && this.validate && !this._performValidation(attrs, options)) return false;
@@ -213,10 +214,16 @@
         var val = attrs[attr];
         if (!_.isEqual(now[attr], val)) {
           now[attr] = val;
+          changes[attr] = val;
           delete escaped[attr];
           this._changed = true;
-          if (!options.silent) this.trigger('change:' + attr, this, val, options);
         }
+      }
+
+      // Fire the change events after all of the attributes have been set.
+      for (var attr in changes) {
+        var val = changes[attr];
+        if (!options.silent) this.trigger('change:' + attr, this, val, options);
       }
 
       // Fire the `"change"` event, if the model has been changed.


### PR DESCRIPTION
Hi,

I'd like to open a discussion about the order change events fire after a `.set()`.

Currently, each change event is fired immediately after each attribute has been set. In the case where we are setting many attributes at once, our handlers may depend on other attributes being present.

Right now if we set the attributes `a` and `b` on a model, the order of events is this:

set `a`
fire `change:a`
set `b`
fire `change:b`

I would like to open a discussion and ask if that is the intended order.

Please consider the following scenario. We just received an API call containing many attributes. We also have handlers listening to various change events. If any of those handlers are expecting an attribute to be present, it may not execute properly, depending on the order that the attributes are set.

For example:

set `a`
fire `change:a`
handler listening for `change:a` wants to access the value of `b`, but `b` has not been set yet.

My proposal is to change the order of these events to:

set `a`
set `b`
fire `change:a`
fire `change:b`

I would like to open a discussion about the pros and cons of this change.

See the attached diff for a proposed solution.
