### PR TITLE
Add complex query string router test

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -97,6 +97,16 @@ $(document).ready(function() {
       start();
     }, 10);
   });
+  
+  asyncTest("Router: routes (complex query)", 2, function() {
+    var complex = '~!@#$%^&*()=+[]{}\\;:\'",/? ';
+    window.location.hash = 'complex?' + encodeURIComponent(complex);
+    setTimeout(function() {
+      equals(router.entity, 'complex');
+      equals(router.queryArgs, complex);
+      start();
+    }, 10);
+  });
 
   asyncTest("Router: routes (anything)", 1, function() {
     window.location.hash = 'doesnt-match-a-route';


### PR DESCRIPTION
As previous noted some browsers do not handle hash strings correctly (sometimes they're decoded, sometimes they're not) this test will expose when that happens. It will also expose if we ever break complex router string handling.
