### PR TITLE
Allow initialize on any class to pass on original arguments.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -143,7 +143,7 @@
     this._changed = false;
     this._previousAttributes = _.clone(this.attributes);
     if (options && options.collection) this.collection = options.collection;
-    this.initialize(attributes, options);
+    this.initialize.apply(this, arguments);
   };
 
   // Attach all inheritable methods to the Model prototype.
@@ -420,7 +420,7 @@
     _.bindAll(this, '_onModelEvent', '_removeReference');
     this._reset();
     if (models) this.reset(models, {silent: true});
-    this.initialize(models, options);
+    this.initialize.apply(this, arguments);
   };
 
   // Define the Collection's inheritable methods.
@@ -659,7 +659,7 @@
     options || (options = {});
     if (options.routes) this.routes = options.routes;
     this._bindRoutes();
-    this.initialize(options);
+    this.initialize.apply(this, arguments);
   };
 
   // Cached regular expressions for matching named param parts and splatted
@@ -880,7 +880,7 @@
     this._configure(options || {});
     this._ensureElement();
     this.delegateEvents();
-    this.initialize(options);
+    this.initialize.apply(this, arguments);
   };
 
   // Element lookup, scoped to DOM elements within the current view.


### PR DESCRIPTION
Several times, when I'm building my my own components, I feel the need to pass on extra arguments to the constructor. For example 

new MyApp.MyModel({a:2}, {storageType:'local'}, true);

new MyApp.MyModel({a:2}, {storageType:'db'}, false);

The current initialize functon only passes a predecided set of objects (eg - for model, it's only an attribute object). This commit allows developers to pass whatever arguments they want, and expect is as arguments in their initialize function implementation. 
