### PR TITLE
Model is no longer considered to be new if its id is a falsey value

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -342,7 +342,7 @@
     // A model is new if it has never been saved to the server, and has a negative
     // ID.
     isNew : function() {
-      return !this.id;
+      return this.id == null;
     },
 
     // Call this method to manually fire a `change` event for this model.

--- a/test/model.js
+++ b/test/model.js
@@ -98,6 +98,9 @@ $(document).ready(function() {
     attrs = { 'foo': 1, 'bar': 2, 'baz': 3, 'id': -5 };
     a = new Backbone.Model(attrs);
     ok(!a.isNew(), "any defined ID is legal, negative or positive");
+    attrs = { 'foo': 1, 'bar': 2, 'baz': 3, 'id': 0 };
+    a = new Backbone.Model(attrs);
+    ok(!a.isNew(), "any defined ID is legal, including zero");
   });
 
   test("Model: get", function() {


### PR DESCRIPTION
Backbone simply tests the value of this.id to determine if a model's id exists. It fails if this.id is some falsey value like 0.

It's now fixed in model.isNew(), and I also looked other places to make sure it doesn't happen to other functions. However, the only one I can find is in view._ensureElement(), but since the id here will be assigned to element's id, I think it makes no sense to allow falsey values, so I didn't make the change.

Corresponding unit test is added, and I also fixed a bug that existed in the test for model.isNew(), which fails to create a new model instance when testing new attributes.
