### PR TITLE
Send rails auth token when calling model.destroy()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1048,7 +1048,7 @@
     }
 
     // Ensure that we have the appropriate request data.
-    if (!params.data && model && (method == 'create' || method == 'update')) {
+    if (!params.data && model && (method == 'create' || method == 'update'  || method == 'delete')) {
       params.contentType = 'application/json';
       params.data = JSON.stringify(model.toJSON());
     }

--- a/test/sync.js
+++ b/test/sync.js
@@ -109,7 +109,6 @@ $(document).ready(function() {
     library.first().destroy();
     equals(lastRequest.url, '/library/2-the-tempest');
     equals(lastRequest.type, 'DELETE');
-    equals(lastRequest.data, null);
   });
 
   test("sync: destroy with emulateHTTP", function() {
@@ -117,7 +116,7 @@ $(document).ready(function() {
     library.first().destroy();
     equals(lastRequest.url, '/library/2-the-tempest');
     equals(lastRequest.type, 'POST');
-    equals(JSON.stringify(lastRequest.data), '{"_method":"DELETE"}');
+	equals(lastRequest.data._method, "DELETE");
     Backbone.emulateHTTP = Backbone.emulateJSON = false;
   });
 


### PR DESCRIPTION
Rails authenticity token is not included in the params when using the model.destroy() method, since we only include the model data when the request is either create or update.
