### PR TITLE
Update support for collections.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -510,6 +510,47 @@
       return this;
     },
 
+    // When you have an existing set of models in a collection, 
+    // you can do in-place updates of these models, reusing existing instances.
+    // - Items are matched against existing items in the collection by id
+    // - New items are added
+    // - matching models are updated using set(), triggers 'change'.
+    // - existing models not present in the update are removed if 'removeMissing' is passed.
+    // - a collection change event will be dispatched for each add() and remove()
+    update : function(models, options) {
+      models  || (models = []);
+      options || (options = {});
+
+      //keep track of the models we've updated, cause we're gunna delete the rest if 'removeMissing' is set.
+      var updateMap = _.reduce(this.models, function(map, model){ map[model.id] = false; return map },{});
+
+      _.each( models, function(model) {
+
+        var idAttribute = this.model.prototype.idAttribute;
+        var modelId = model[idAttribute];
+
+        if ( modelId == undefined ) throw new Error("Can't update a model with no id attribute. Please use 'reset'.");
+        
+        if ( this._byId[modelId] ) {
+          var attrs = (model instanceof Backbone.Model) ? _.clone(model.attributes) : _.clone(model);
+          delete attrs[idAttribute];
+          this._byId[modelId].set( attrs );
+          updateMap[modelId] = true;
+        }
+        else {
+          this.add( model );
+        }
+      }, this);
+
+      if ( options.removeMissing ) {
+        _.select(updateMap, function(updated, modelId){
+          if (!updated) this.remove( modelId );
+        }, this);
+      }
+
+      return this;
+    },
+
     // Fetch the default set of models for this collection, resetting the
     // collection when they arrive. If `add: true` is passed, appends the
     // models to the collection instead of resetting.
@@ -518,7 +559,7 @@
       var collection = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {
-        collection[options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
+        collection[options.update ? 'update' : options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
         if (success) success(collection, resp);
       };
       options.error = wrapError(options.error, collection, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -323,6 +323,35 @@ $(document).ready(function() {
     ok(_.isEqual(col.last().attributes, a.attributes));
   });
 
+  test("Collection: update", function() {
+    var l = col.last();
+
+    col.update(col.models);
+    equals(col.length, 4);
+    equals(col.last(), l);
+
+    col.update([{id: 3, label: 'updated'}])
+    equals(col.length, 4);
+    ok(col.last() === l);
+    equals(col.get(3).attributes.label, 'updated');
+
+
+    var aUpdated = new Backbone.Model({id: 3, label: 'updatedAgain'});
+    col.update([aUpdated])
+    equals(col.length, 4);
+    ok(col.last() === l);
+    equals(col.last().attributes.label, 'updatedAgain');
+
+    col.update([{id: 9, label: 'new'}]);
+    equals(col.length, 5);
+    equals(col.last().attributes.label, 'new');
+
+    col.update([{id: 3, label: 'a'}], {removeMissing: true})
+    equals(col.length, 1);
+    ok(col.last() === l);
+    equals(col.last().attributes.label, 'a');
+  });
+
   test("Collection: trigger custom events on models", function() {
     var fired = null;
     a.bind("custom", function() { fired = true; });


### PR DESCRIPTION
This pull request resolves the issue described here:
https://github.com/documentcloud/backbone/issues/137

It adds in-place updating support for collections, which is the ability to refresh the contents of a collection without creating new model instances for models that already exist client-side.

The use case is something like this: 
- I have a collection representing a list of bookings. 
- I have a view bound to each booking in the collection.
- I can edit bookings, other people can add/edit bookings.
- I want to be able to fetch the current bookings from the server, and update my screen without having to recreate/rebind all my views for existing bookings.
- I want to leverage all of the usual backbone mechanisims, for example when an attribute of a booking is changed in the most recent fetch(), it will update & trigger a change event for the booking model I already have clientside & bound to my views.

It works well for us. I think some flavour of this mechanism would be very useful to include in backbone, even if you think this initial implementation isn't quite right from an API pov.

Let me know what you think!
