### PR TITLE
add 'contains' alias for 'include'

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -639,7 +639,7 @@
   // Underscore methods that we want to implement on the Collection.
   var methods = ['forEach', 'each', 'map', 'reduce', 'reduceRight', 'find', 'detect',
     'filter', 'select', 'reject', 'every', 'all', 'some', 'any', 'include',
-    'invoke', 'max', 'min', 'sortBy', 'sortedIndex', 'toArray', 'size',
+    'contains', 'invoke', 'max', 'min', 'sortBy', 'sortedIndex', 'toArray', 'size',
     'first', 'rest', 'last', 'without', 'indexOf', 'lastIndexOf', 'isEmpty'];
 
   // Mix in each Underscore method as a proxy to `Collection#models`.


### PR DESCRIPTION
Backbone Collections proxy most aliases from underscore (for instance 'filter' and 'select' or 'any' and 'some').  However, _.contains is not proxied along with _.include.
