### PR TITLE
pass attrs to model constructor in _prepareModel

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -566,7 +566,7 @@
     _prepareModel: function(model, options) {
       if (!(model instanceof Backbone.Model)) {
         var attrs = model;
-        model = new this.model(null, {collection: this});
+        model = new this.model(attrs, {collection: this});
         if (!model.set(attrs, options)) model = false;
       } else if (!model.collection) {
         model.collection = this;


### PR DESCRIPTION
In situations where `{silent: true}` is passed to `_prepareModel`, constructing the model without attributes means that the model is never initialized _and_ never notified that its attributes are later changed.  For instance:

```
var Item = Backbone.Model.extend({
  x: 0,
  initialize: function(){
    this.bind('change:x', this.updateX);
    this.updateX(this, this.get('x'));
  },
  updateX: function(self, val){
    if(_.isString(val)) self.x = parseInt(val, 10);
  }
});

var Items = Backbone.Collection.extend({
  model: Item,
  initialize: function(){
    _.bindAll(this, 'renderViews');
    this.bind('reset', this.renderViews);
  },
  renderViews: function(){
    console.log(items.at(0).x); // 0
    // render views...
  }
});

var items = new Items();
items.reset([{ x: '1' }]);
```

The model is not given any notification that its attributes have been changed and is thus rendered improperly.

There is a workaround that involves re-rendering the view:

```
var Item = Backbone.Model.extend({
  x: 0,
  initialize: function(){
    this.bind('change:x', this.updateX);
    this.updateX(this, this.get('x'));
    var self = this;
    this.collection.bind('reset', function(collection){
      self.updateX(self, self.get('x'));
      collection.renderViews();
    });
  },
  updateX: function(self, val){
    if(val) self.x = parseInt(val, 10);
  }
});
```

This is obviously not ideal and I believe is a side effect of the fact that an implicit contract has been broken.  That contract being "The model will get attributes upon initialization and then have a chance to process each change to its attributes".

The commit causes a bit of redundancy (set is called twice in a row), but that could be circumvented several ways, none of which affect the main issue.
