### PR TITLE
Fix slight inconsistency with attrs passed to initialize()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -143,7 +143,7 @@
     this._changed = false;
     this._previousAttributes = _.clone(this.attributes);
     if (options && options.collection) this.collection = options.collection;
-    this.initialize.apply(this, arguments);
+    this.initialize.apply(this, [attributes].concat(Array.prototype.slice.call(arguments,1)));
   };
 
   // Attach all inheritable methods to the Model prototype.

--- a/test/model.js
+++ b/test/model.js
@@ -214,6 +214,19 @@ $(document).ready(function() {
     equals(model.get('two'), null);
   });
 
+  test("Model: defaults always extend attrs", function() {
+    var Defaulted = Backbone.Model.extend({
+      defaults: {
+        "one": 1
+      },
+      initialize : function(attrs,opts){
+        equals(attrs.one,1)
+      }
+    });
+    var providedattrs = new Defaulted({});
+    var emptyattrs = new Defaulted();
+  });
+
   test("Model: change, hasChanged, changedAttributes, previous, previousAttributes", function() {
     var model = new Backbone.Model({name : "Tim", age : 10});
     equals(model.changedAttributes(), false);


### PR DESCRIPTION
I noticed some weird inconsistencies in testing with Model constructor depending on if attributes was 'undefined' or provided as parameter. 
Because just 'arguments' is passed to the initialize apply() - the attributes passed will either be extended with defaults or not depending on if it was it was initially undefined.

I don't know if this difference in behavior is intentional or not...
My solution is just a quick hack to always ensure that the extended attrs get passed to initialize()
It kind of doesn't sit well with me in that I am altering the semantics of initialize() a bit - but it seems more consistent to always do this.
I thought about trying to use call() for arguments and options instead of concating an array for apply() - but then what if someone was relying on the use of the rest of arguments (I'm sure someone does).

Don't know why I made it three commits- can format patch or something/redo if you want to accept this.
