### PR TITLE
processData should default to true

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1035,8 +1035,7 @@
     // Default JSON-request options.
     var params = _.extend({
       type:         type,
-      dataType:     'json',
-      processData:  false
+      dataType:     'json'
     }, options);
 
     // Ensure that we have a URL.
@@ -1053,7 +1052,6 @@
     // For older servers, emulate JSON by encoding the request into an HTML-form.
     if (Backbone.emulateJSON) {
       params.contentType = 'application/x-www-form-urlencoded';
-      params.processData = true;
       params.data        = params.data ? {model : params.data} : {};
     }
 
@@ -1067,6 +1065,11 @@
           xhr.setRequestHeader('X-HTTP-Method-Override', type);
         };
       }
+    }
+
+    // Don't process data on a non-GET request.
+    if (params.type !== 'GET') {
+      params.processData = false;
     }
 
     // Make the request.


### PR DESCRIPTION
Glad to see that #78 was taken into consideration and that options can now be passed through to the ajax request, but unfortunately [your example](http://documentcloud.github.com/backbone/#Collection-fetch) in the docs doesn't work (at least with jQuery 1.6.2).

```
var Accounts = new Backbone.Collection;
Accounts.url = '/accounts';
Accounts.fetch();
Accounts.fetch({data: {page: 3}});
// makes a request to "/accounts?[object%20Object]"
```

This fix resolves the issue by making the `processData` param default to false, unless it is a non-GET request.  This shouldn't break any backwards compatibility for non-GET requests, either.
