### PR TITLE
Allow swapping of HTTP backend without copypasting all of Backbone.sync

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1070,8 +1070,10 @@
     }
 
     // Make the request.
-    return $.ajax(params);
+    return Backbone.ajax(params);
   };
+
+  Backbone.ajax = $.ajax;
 
   // Helpers
   // -------


### PR DESCRIPTION
Users occasionally need to change how Backbone communicates with the server without completely re-writing Backbone.sync. For example, when using http://github.com/alexeymk/ajax_iframe_bridge, we still want all of Backbone's HTTP translation, but then we need to send the request through the bridge, instead of straight to $.ajax.

I think this patch has zero impact on people who don't need the functionality, so there's no cost to including it.
