### PR TITLE
Check for strings passed as first argument to #set

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -195,6 +195,7 @@
       // Extract attributes and options.
       options || (options = {});
       if (!attrs) return this;
+      if (Object.prototype.toString.call(attrs) == "[object String]") throw TypeError("First argument should not be a string");
       if (attrs.attributes) attrs = attrs.attributes;
       var now = this.attributes, escaped = this._escapedAttributes;
 


### PR DESCRIPTION
I've passed a string and new value as first and second arguments to set() a few times, which chokes on `in` in the `this.idAttribute in attrs` line. 

Reinforced by my volatile memory, and maybe by the fact that setters in many languages/frameworks have a syntax along these lines `set(propertyName, newValue)`. Thus adding a simple check for a string could be a good idea. What do you think?
