### PR TITLE
Setting to a minimum of one character when matching URL parameters

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -714,8 +714,8 @@
     // against the current location hash.
     _routeToRegExp : function(route) {
       route = route.replace(escapeRegExp, "\\$&")
-                   .replace(namedParam, "([^\/]*)")
-                   .replace(splatParam, "(.*?)");
+                   .replace(namedParam, "([^\/]+)")
+                   .replace(splatParam, "(.+?)");
       return new RegExp('^' + route + '$');
     },
 


### PR DESCRIPTION
Currently the regex created at at _routeToRegExp also matches an empty string (`.*`).

I have a route that matches a single parameter without any string as a prefix or suffix (`routes:{':foo': 'displayFoo'}`) that should be triggered for a URL like http://www.foo.com/#bar, but not for http://www.foo.com/ without any fragment at all. This isn't currently possible as the regex that's created for ':foo' is simply `[^\/]*`, which also matches an empty string.
