### PR TITLE
Add Backbone.View.prototype.set(options) as a setter for options

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -931,6 +931,12 @@
       return el;
     },
 
+    // Options setter
+    set: function(options) {
+        _.extend(this.options, options);
+       return this;
+    },
+
     // Set callbacks, where `this.callbacks` is a hash of
     //
     // *{"event selector": "callback"}*


### PR DESCRIPTION
Mainly useful to make setting options chainable, e.g. someView.set({foo: 'bar'}).render()
