### PR TITLE
Add beforeroute event to Backbone.Route

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -686,6 +686,7 @@
       if (!_.isRegExp(route)) route = this._routeToRegExp(route);
       Backbone.history.route(route, _.bind(function(fragment) {
         var args = this._extractParameters(route, fragment);
+        this.trigger.apply(this, ['beforeroute:' + name].concat(args));
         callback.apply(this, args);
         this.trigger.apply(this, ['route:' + name].concat(args));
       }, this));


### PR DESCRIPTION
In some cases its useful to execute some code before executing a route. In my case, I was using Backbone with jQuery Mobile and wanted to show the loading message before a route execute, and let the route be responsible for hiding it (`router.bind('all', function(ev) {ev.indexOf('beforeroute:') === 0 && $.mobile.showPageLoadingMsg();});`), but I assume there are other use cases for making preparations to the page before executing a route.

Another possible place to do that could be a new event at Backbone.History.prototype.loadUrl, but than you won't get any information about the route being executed.

If anyone is interested, here's the monkey patch version of this change:

``` javascript
(function(rp) {
    var _route = rp.route;
    rp.route = function(route, name, callback) {
        return _route.call(this, route, name, function() {
            this.trigger.apply(this, ['beforeroute:' + name].concat(_.toArray(arguments)));
            callback.apply(this, arguments);
        });
    };
})(Backbone.Router.prototype);
```
