### PR TITLE
updated model isNew to use idAttribute

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -342,7 +342,7 @@
 
     // A model is new if it has never been saved to the server, and lacks an id.
     isNew : function() {
-      return this.id == null;
+      return this[this.idAttribute] == null;
     },
 
     // Call this method to manually fire a `change` event for this model.


### PR DESCRIPTION
While using mongodb and looking at the returned model, i'd like to know if its new or not in an arbitrary situation.  right now isNew checks explicitly for this.id, this patch extends that to be more flexible by utilizing the new idAttribute property.  

all tests passed and the linting apparently passes, no errors spouted out at least =)
