### PR TITLE
return immediately after redirect to hash route

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -806,6 +806,8 @@
       if (this._wantsPushState && !this._hasPushState && !atRoot) {
         this.fragment = this.getFragment(null, true);
         window.location.replace(this.options.root + '#' + this.fragment);
+        // Return immediately as browser will do redirect to new url
+        return true;
       } else if (this._wantsPushState && this._hasPushState && atRoot && loc.hash) {
         this.fragment = loc.hash.replace(hashStrip, '');
         window.history.replaceState({}, document.title, loc.protocol + '//' + loc.host + this.options.root + this.fragment);


### PR DESCRIPTION
Do not call loadUrl when redirecting to hash based URL on non-push state browser.

Otherwise on IE default route was executed for a short while before redirect.
