### PR TITLE
Previous and next associations - linked lists essentially

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -590,6 +590,14 @@
                   this.comparator ? this.sortedIndex(model, this.comparator) :
                   this.length;
       this.models.splice(index, 0, model);
+      if (index > 0) {
+        model.prev = this.models[index-1]
+        model.prev.next = model
+      }
+      if (index < this.length) {
+        model.next = this.models[index+1]
+        model.next.prev = model
+      }
       model.bind('all', this._onModelEvent);
       this.length++;
       if (!options.silent) model.trigger('add', model, this, options);


### PR DESCRIPTION
models now have next and prev associations where applicable when added to a collection.

I may have missed something, but I couldn't see how to traverse within a collection so I amended the _add function of Backbone.Collection to add model.next and model.prev where appropriate. 

If there is already an established means of doing this, please let me know.

Thanks!
