### PR TITLE
Patch for emulateJSON sync. Forced processData setting breaks Backbone.emaulteJSON mode.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1070,7 +1070,7 @@
     }
 
     // Don't process data on a non-GET request.
-    if (params.type !== 'GET') {
+    if (params.type !== 'GET' && ! Backbone.emulateJSON) {
       params.processData = false;
     }
 


### PR DESCRIPTION
In the master of 5.2, in sync, any request that is not a GET, processData is forced to false (line 1074). This breaks sync when emulateJSON is true, as the new form data is not stringified for POST, PUT, and DELETE resulting in [Object object](the toString of an object) being send as the request data. 
