### PR TITLE
Remove coupling from model to view in example app

### DIFF
--- a/examples/todos/todos.js
+++ b/examples/todos/todos.js
@@ -28,12 +28,6 @@ $(function(){
     // Toggle the `done` state of this todo item.
     toggle: function() {
       this.save({done: !this.get("done")});
-    },
-
-    // Remove this Todo from *localStorage* and delete its view.
-    clear: function() {
-      this.destroy();
-      this.view.remove();
     }
 
   });
@@ -102,9 +96,9 @@ $(function(){
     // a one-to-one correspondence between a **Todo** and a **TodoView** in this
     // app, we set a direct reference on the model for convenience.
     initialize: function() {
-      _.bindAll(this, 'render', 'close');
+      _.bindAll(this, 'render', 'close', 'remove');
       this.model.bind('change', this.render);
-      this.model.view = this;
+      this.model.bind('destroy', this.remove);
     },
 
     // Re-render the contents of the todo item.
@@ -153,7 +147,7 @@ $(function(){
 
     // Remove the item, destroy the model.
     clear: function() {
-      this.model.clear();
+      this.model.destroy();
     }
 
   });
@@ -234,7 +228,7 @@ $(function(){
 
     // Clear all done todo items, destroying their models.
     clearCompleted: function() {
-      _.each(Todos.done(), function(todo){ todo.clear(); });
+      _.each(Todos.done(), function(todo){ todo.destroy(); });
       return false;
     },
 


### PR DESCRIPTION
- Remove coupling from model to view in example app by listening to model's 'destroy' event to remove the view.

This might be a pet peeve of mine, but it seems like an anti-pattern to have the model aware of the view in the example app. Instead of updating the view directly, this change makes the view listen to `destroy` events in order to remove items.
