### PR TITLE
{id: ""} will make model.isNew() return true (instead of false)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -342,7 +342,8 @@
 
     // A model is new if it has never been saved to the server, and lacks an id.
     isNew : function() {
-      return this.id == null;
+      var unsaved = [null, ""]
+      return _(unsaved).include(this.id)
     },
 
     // Call this method to manually fire a `change` event for this model.

--- a/test/model.js
+++ b/test/model.js
@@ -101,9 +101,12 @@ $(document).ready(function() {
     attrs = { 'foo': 1, 'bar': 2, 'baz': 3, 'id': 0 };
     a = new Backbone.Model(attrs);
     ok(!a.isNew(), "any defined ID is legal, including zero");
-    ok( new Backbone.Model({          }).isNew(), "is true when there is no id");
-    ok(!new Backbone.Model({ 'id': 2  }).isNew(), "is false for a positive integer");
-    ok(!new Backbone.Model({ 'id': -5 }).isNew(), "is false for a negative integer");
+    ok( new Backbone.Model({                 }).isNew(), "is true when there is no id");
+    ok( new Backbone.Model({ 'id': undefined }).isNew(), "is true when the id is undefined");
+    ok( new Backbone.Model({ 'id': null      }).isNew(), "is true when the id is null");
+    ok( new Backbone.Model({ 'id': ""        }).isNew(), "is true when the id is an empty string");
+    ok(!new Backbone.Model({ 'id': 2         }).isNew(), "is false for a positive integer");
+    ok(!new Backbone.Model({ 'id': -5        }).isNew(), "is false for a negative integer");
   });
 
   test("Model: get", function() {


### PR DESCRIPTION
Ran into a situation where I was pulling model attributes from a serialized form, and found that if you instanciate a model off of {id: ""}, isNew() will return false. My workaround code right now is something like `if (attrs.id) delete attrs.id` which is pretty nasty, and I would love to remove it 

Love the framework, and am really excited to see where things end up :)
