### PR TITLE
Added support for late binding triggering of events.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -68,21 +68,26 @@
 
     // Bind an event, specified by a string name, `ev`, to a `callback` function.
     // Passing `"all"` will bind the callback to all events fired.
-    bind : function(ev, callback, context, catchup) {
+    bind : function(ev, callback, context, late_binding) {
       var calls = this._callbacks || (this._callbacks = {});
       var list  = calls[ev] || (calls[ev] = []);
 
       // If we are late binding an event that has already been triggered,
       // trigger execution of our callback on the initial bind.
       var history = this._event_history || (this._event_history = {});
-      if(history[ev]) {
-        if(catchup) {
-          for(var i=0; i<history[ev]; i++) {
+      if(typeof late_binding !== 'undefined' && late_binding !== null) {
+        if(history[ev]) {
+          if(late_binding === 'full') {
+            for(var i=0; i<history[ev]; i++) {
+              callback.apply(context || this);
+            }
+          }
+          else if(late_binding === 'once') {
             callback.apply(context || this);
           }
-        }
-        else {
-          callback.apply(context || this);
+          else {
+            throw new Error('Invalid late_binding option. Must be one of [null, "once", "full"]');
+          }
         }
       }
       list.push([callback, context]);

--- a/test/events.js
+++ b/test/events.js
@@ -17,6 +17,7 @@ $(document).ready(function() {
 
   test("Events: late binding and trigger", function() {
     var obj = { counter: 0 };
+    var obj1 = { counter: 0 };
     var obj2 = { counter: 0 };
     var obj3 = { counter: 0 };
     _.extend(obj,Backbone.Events);
@@ -25,16 +26,20 @@ $(document).ready(function() {
     obj.trigger('event');
     obj.trigger('event');
     equals(obj.counter,3,'counter should be incremented.');
+    equals(obj1.counter,0,'counter should be zero.');
     equals(obj2.counter,0,'counter should be zero.');
     equals(obj3.counter,0,'counter should be zero.');
-    obj.bind('event', function() { obj2.counter += 1; });
-    obj.bind('event', function() { obj3.counter += 1; }, obj, true);
+    obj.bind('event', function() { obj1.counter += 1; }, obj);
+    obj.bind('event', function() { obj2.counter += 1; }, obj, 'once');
+    obj.bind('event', function() { obj3.counter += 1; }, obj, 'full');
     equals(obj.counter,3,'counter should be incremented.');
-    equals(obj2.counter,1,'counter should be incremented after late binding.');
-    equals(obj3.counter,3,'counter should be incremented after late binding.');
+    equals(obj1.counter,0,'counter should not be incremented after late binding with no flag set.');
+    equals(obj2.counter,1,'counter should be incremented after late binding with once flag set.');
+    equals(obj3.counter,3,'counter should be incremented after late binding with full flag set.');
     obj.trigger('event');
     obj.trigger('event');
     equals(obj.counter, 5, 'counter should be incremented five times.');
+    equals(obj1.counter, 2, 'late bound counter counter should be incremented two times.');
     equals(obj2.counter, 3, 'late bound counter counter should be incremented three times.');
     equals(obj3.counter, 5, 'late bound counter counter should be incremented five times.');
   });


### PR DESCRIPTION
We have often found it useful, when binding events, to have our callback function executed in the case where the event we are binding to on an object has already been triggered. This case has come up many times when we are dealing with fetching an object from our API, and based on the data in the response, creating the appropriate View based on the metadata. We stick to the typical "this.model.bind('change', ...)" approach, however, in the case where the model/collection has already been fetched from the server, we want the view to know that the events have already occurred, and the have the callback methods executed.

Here is a silly example, assume that in real life we have wired up custom Collections with proper urls, etc.

``` javascript
var model = new Backbone.Model();
var SpecialView = Backbone.View.extend({
  initialize: function(options) {
    this.model.bind('change', this.render);
  }
});
model.bind('change', function() {
  var view;
  if(this.get('attribute') == 'special') {
    view = new SpecialView({model: this});
  }
  else {
    view = new Backbone.View({model: this});
  }
  $(document).append(view.el);
})
model.fetch();
```

This is again, a silly example, but the basic idea is that we want to be able to use SpecialView in a normal case where we associate a model with a View and then we fetch it from the server (and on fetch complete/data change the callback is triggered) and when we already fetched the model from the server, and based on processing, want to use the same SpecialView to render it as well (without calling render manually, just letting the built-in mechanisms.

We find this pattern useful for all events, but hopefully this silly Model example demonstrates the basic idea.

Thanks!
Nowell
