### PR TITLE
Fixed a bug in IE iframe navigation.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -691,6 +691,8 @@
       var oldIE = ($.browser.msie && (!docMode || docMode <= 7));
       if (oldIE) {
         this.iframe = $('<iframe src="javascript:0" tabindex="-1" />').hide().appendTo('body')[0].contentWindow;
+        this.iframe.document.open().close();
+        this.iframe.location.hash = this.getFragment();
       }
       if ('onhashchange' in window && !oldIE) {
         $(window).bind('hashchange', this.checkUrl);


### PR DESCRIPTION
I don't know what your policies are on fixing bugs in old releases, but if you want to fix a bug in IE Backbone.history handling, then you can include this new tag release of 0.3.4, which fixes a bug in IE where on initial page load, IE will reset the page location hash to "#" (no matter what hash was there to start) but all subsequent hash changes will continue to work.

This bug has been fixed in 0.5.X releases, so this is probably a pretty low priority. We are still running a production app with 0.3.3 (we are almost done updating to 0.5.X) and thought we would contrib back this bugfix
