### PR TITLE
Collection test rewrite

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -518,7 +518,7 @@
       var collection = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {
-        collection[options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
+        if(status!="notmodified"&&xhr&&xhr.status!=304)collection[options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
         if (success) success(collection, resp);
       };
       options.error = wrapError(options.error, collection, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -262,6 +262,10 @@ $(document).ready(function() {
     equals(lastRequest[0], 'read');
     equals(lastRequest[1], col);
 
+    lastRequest[2].success(undefined, "notmodified", {status:304});
+    equals(col.length, 4);
+    lastRequest[2].success(undefined, "success", {status:200});
+    equals(col.length, 0);
   });
 
   test("Collection: create", function() {


### PR DESCRIPTION
Two things:

1)  Rewrote test collection.js to use module(..., {setup:...}) so that tests can be independent and not have to depend on each other.   This makes it easier to find failing tests.

2)  Added a test and fix for to handle cached 304 notmodified responses.  In the success callback of a 304,  a Collection must not try to reset itself as the data provided will always be undefined.
