### PR TITLE
Root is now window if it exists. This fixes compatibility with Browserify

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -10,7 +10,7 @@
   // -------------
 
   // Save a reference to the global object.
-  var root = this;
+  var root = window || this;
 
   // Save the previous value of the `Backbone` variable.
   var previousBackbone = root.Backbone;


### PR DESCRIPTION
"root" is now window if it exists. This fixes compatibility with Browserify and other wrappers which redefine "this" to something else than the global object.
