### PR TITLE
Bind an object with multiple callback functions to any event

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -71,7 +71,12 @@
     bind : function(ev, callback, context) {
       var calls = this._callbacks || (this._callbacks = {});
       var list  = calls[ev] || (calls[ev] = []);
-      list.push([callback, context]);
+      if(!_.isFunction(callback)) {
+        _.each(callback, function(call) { 
+          list.push([call, context])});
+      } else {
+        list.push([callback, context]);
+      }
       return this;
     },
 


### PR DESCRIPTION
Bind multiple callback functions to any event.

Use case:

```
 Todos = Backbone.Collection.extend({
 ...
 this.bind('reset', {this.firstCallback, this.secondCallback}, this);
 ...
 });
```

Instead of needing multiple binds for the same event.
