### PR TITLE
Silent start

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -812,7 +812,10 @@
         this.fragment = loc.hash.replace(hashStrip, '');
         window.history.replaceState({}, document.title, loc.protocol + '//' + loc.host + this.options.root + this.fragment);
       }
-      return this.loadUrl();
+
+      if (!this.options.silent) {
+        return this.loadUrl();
+      }
     },
 
     // Add a route to be tested when the fragment changes. Routes added later may


### PR DESCRIPTION
In the situation where a user is utilizing server backed pages for the initial page request, calling the bound router callback in loadUrl does not make sense.  It does make sense to trigger the router callback for subsequent requests to the initial page.

This patch essentially allows a user to pass in `silent: true` to start and not have Backbone automatically call the callback.

Still trying to figure out how t write a backing unit test.  Any ideas?
