### PR TITLE
Sync-events

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1032,6 +1032,10 @@
   // `application/json` with the model in a param named `model`.
   // Useful when interfacing with server-side languages like **PHP** that make
   // it difficult to read the body of `PUT` requests.
+  //
+  // Backbone.sync will send "sync:start", "sync:done", "sync:fail" and "sync:always" events
+  // to the model or collection that was synced with the synced model or collection as first parameter.
+  //
   Backbone.sync = function(method, model, options) {
     var type = methodMap[method];
 
@@ -1075,8 +1079,13 @@
       params.processData = false;
     }
 
-    // Make the request.
-    return $.ajax(params);
+    // Make the request and trigger applicable sync-events
+    model.trigger("sync:start", model);
+    var ajaxDeferred = $.ajax(params);
+    ajaxDeferred.done(function(){ model.trigger("sync:done", model) });
+    ajaxDeferred.fail(function(){ model.trigger("sync:fail", model) });
+    ajaxDeferred.always(function(){ model.trigger("sync:always", model) });
+    return ajaxDeferred;
   };
 
   // Helpers


### PR DESCRIPTION
I've implemented these in my own code and liked the idea so much that I thought I'd share it. See this pull request as a conversation starter :)

To be able to block parts of the UI while updating (using the jQuery.blockUI plugin) I wanted to listen to when a model was being fetched and when the fetch was done. My suggestion to solve this would be to add a few `sync`-events to the `Backbone.sync`-method.
- `sync:start` fires when the sync begins
- `sync:done` fires when the sync has ended successfully
- `sync:fail` fires when the sync has ended unsuccessfully
- `sync:always` fires when the sync has ended, regardless of success.

This way, in views I can listen to `sync`-events on the models and collections and block and unblock the UI or insert ajax-loader-gifs or the equivalent. It was a pretty small addition using the jQuery deferred object.
