### PR TITLE
Adds support for dynamic setters.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -212,7 +212,12 @@
       for (var attr in attrs) {
         var val = attrs[attr];
         if (!_.isEqual(now[attr], val)) {
-          now[attr] = val;
+          if (this["write_" +  attr]) {
+            this["write_" + attr].call(this, now, val)
+          }
+          else {
+            now[attr] = val; 
+          }
           delete escaped[attr];
           this._changed = true;
           if (!options.silent) this.trigger('change:' + attr, this, val, options);

--- a/test/model.js
+++ b/test/model.js
@@ -159,6 +159,16 @@ $(document).ready(function() {
     equals(a.id, undefined, "Unsetting the id should remove the id property.");
   });
 
+  test("Model: dynamic set", function() {
+    a = new Backbone.Model();
+    a.write_foo = function(now, val) {
+      now.foo = val + "FOO";
+    };
+    a.set({foo: "THIS SHOULD END WITH "});
+    
+    equals(a.get('foo'), "THIS SHOULD END WITH FOO", "Dynamic setters intervene with set.");
+  });
+
   test("Model: multiple unsets", function() {
     var i = 0;
     var counter = function(){ i++; };


### PR DESCRIPTION
Added test for dynamic setter.

In this feature one my define a method following the pattern "write_#{property_name}"

In this implementation of the set method, if this method exists it is called with the now object and the passed value.

Would it be better to just take the returned value of the "write_#{property_name}" method and set that in the now object without requiring the dynamic setter to handle that part? (Does seem like the name wouldn't be very good in that implementation.)

Anyway, I've been using this and find it quite useful.
