### PR TITLE
Added Backbone.model.strict - will prevent the model from setting attribu

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -189,7 +189,7 @@
     },
 
     // Set a hash of model attributes on the object, firing `"change"` unless you
-    // choose to silence it.
+    // choose to silence it. If this.strict is set to true, only the attributes in this.default will be set
     set : function(attrs, options) {
 
       // Extract attributes and options.
@@ -210,12 +210,14 @@
 
       // Update attributes.
       for (var attr in attrs) {
-        var val = attrs[attr];
-        if (!_.isEqual(now[attr], val)) {
-          now[attr] = val;
-          delete escaped[attr];
-          this._changed = true;
-          if (!options.silent) this.trigger('change:' + attr, this, val, options);
+        if (!this.strict || this.strict && this.defaults.hasOwnProperty(attr)) {
+          var val = attrs[attr];
+          if (!_.isEqual(now[attr], val)) {
+            now[attr] = val;
+            delete escaped[attr];
+            this._changed = true;
+            if (!options.silent) this.trigger('change:' + attr, this, val, options);
+          }
         }
       }
 

--- a/test/model.js
+++ b/test/model.js
@@ -370,6 +370,33 @@ $(document).ready(function() {
     var providedattrs = new Defaulted({});
     var emptyattrs = new Defaulted();
   });
+  
+  test("Model: set attribute with model.strict", function() {
+    var model = new (Backbone.Model.extend({
+      strict: false,
+      defaults: {
+        test: 'yes'
+      }
+    }))();
+    
+    model.set({'attr': true});
+    
+    ok(model.get('attr'), 'Expects the model to have set "attr"');
+    deepEqual(model.attributes, {'test': 'yes', 'attr': true}, 'Expects the model to have "test:yes" and "attr:true" attributes');
+    
+    model = new (Backbone.Model.extend({
+      strict: true,
+      defaults: {
+        test: 'yes'
+      }
+    }))();
+    
+    model.set({'attr': true});
+    ok(model.strict, 'Expects the model to be set to strict');
+    
+    ok(!model.get('attr'), 'Expects the model to have set "attr"');
+    deepEqual(model.attributes, {'test': 'yes'}, 'Expects the model to have only "test:yes" attributes');
+  });
 
   test("Model: Inherit class properties", function() {
     var Parent = Backbone.Model.extend({


### PR DESCRIPTION
Added Backbone.model.strict - will prevent the model from setting attributes that are not already in defaults.

Use Case:

   I am using the model to hit an endpoint that takes a specific set of parameters, if it includes parameters that it cannot recognise then it errors. I need to be able to trivially specify that the model should only allow certain parameters to pass through it
