### PR TITLE
Add an attributes parameter to toJSON on model, which returns whitelisted properties.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -165,8 +165,23 @@
     initialize : function(){},
 
     // Return a copy of the model's `attributes` object.
-    toJSON : function() {
-      return _.clone(this.attributes);
+    toJSON : function(attributes) {
+      var returnedAttrs = {};
+      if (!attributes) {
+        return _.clone(this.attributes);
+      } else if (!_.isArray(attributes)) {
+        attributes = _.keys(attributes);
+      }
+      
+      var i = attributes.length;
+      
+      while(i--) {
+        if (this.attributes.hasOwnProperty(attributes[i])) {
+          returnedAttrs[attributes[i]] = this.attributes[attributes[i]];
+        }
+      }
+      
+      return returnedAttrs;
     },
 
     // Get the value of an attribute.

--- a/test/model.js
+++ b/test/model.js
@@ -422,5 +422,35 @@ $(document).ready(function() {
     b = new B({a: a});
     a.set({state: 'hello'});
   });
+  
+  test("Model: toJSON returns expected JSON", function() {
+    var A = new (Backbone.Model.extend())();
+    
+    A.set({one: 1, two: 2});
+    
+    deepEqual(A.toJSON(), {one: 1, two: 2}, 'Expects the toJSON object to return {one:1,two:2}');
+  });
+  
+  test("Model: toJSON returns expected JSON, when provided attributes parameter", function() {
+    var A = new (Backbone.Model.extend({
+      defaults: {
+        'x': 'y'
+      }
+    }))();
+    
+    A.set({one: 1, two: 2});
+    
+    deepEqual(A.attributes, {x: 'y', one: 1, two: 2}, 'Ensure the attributes are as expected');
+    
+    deepEqual(A.toJSON(['one']), {one: 1}, 'Expects the toJSON object to return {one:1}');
+    
+    A.set({three: 3, four: 4});
+    
+    deepEqual(A.toJSON({one:true,two:true}), {one: 1, two: 2}, 'Expects the toJSON object to return {one:1,two:2}');
+    
+    deepEqual(A.toJSON({one:true,fake:true}), {one: 1}, 'Expects the toJSON object to return {one:1}');
+    
+    deepEqual(A.toJSON(['one', 'x']), {one: 1, x: 'y'}, 'Expects the toJSON object to return {one:1,x:"y"}');
+  });
 
 });


### PR DESCRIPTION
Add an attributes parameter to toJSON method which, when passed, runs a whitelist filter on returned attributes

Example Use:
    model.toJSON(['one', 'two']) == {one: 1, two: 2}

Use Case:

  When getting JSON representations of the model we want to send certain attributes to certain endpoints, and other attributes to other endpoints
