### PR TITLE
The attributes argument defaults to an empty object if the Backbone.View 

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -931,7 +931,7 @@
     //
     make : function(tagName, attributes, content) {
       var el = document.createElement(tagName);
-      if (attributes) $(el).attr(attributes);
+      if (!_.isEmpty(attributes)) $(el).attr(attributes);
       if (content) $(el).html(content);
       return el;
     },


### PR DESCRIPTION
The attributes argument defaults to an empty object if the Backbone.View is instantiated without attributes. Trying to set an empty object as attributes of an element gives an error in jQuery 1.5.2 (only one tested)
