### PR TITLE
Let caller of navigate() know whether loadUrl() matched or not.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -866,7 +866,7 @@
           this.iframe.location.hash = frag;
         }
       }
-      if (triggerRoute) this.loadUrl(fragment);
+      if (triggerRoute) return this.loadUrl(fragment);
     }
 
   });


### PR DESCRIPTION
My click handler should be able to do something like this:

`return !Backbone.history.navigate(path, true);`
- Return false if navigate matched a route.
- Pass through if it didn't.

Currently this is not possible because `navigate()` keeps the result of `loadUrl()` to itself. This commit contains a simple fix.
