### PR TITLE
Added the ability to add and remove multiple events in a single "bind" call

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -67,11 +67,11 @@
   Backbone.Events = {
 
     // Bind an event or events, specified by a string name, `ev`, to a `callback` function.
-    // Passing mutliple events seperated by a space will bind the specifiec callback to each event.
+    // Passing mutliple events seperated by a space will bind the specific callback to each event.
     // Passing `"all"` will bind the callback to all events fired.
     bind : function(ev, callback, context) {
       var calls = this._callbacks || (this._callbacks = {});
-      ev = ev.split(' ')
+      ev = ev.split(' ');
       for(var i = 0, l = ev.length; i < l; i++){
         var list  = calls[ev[i]] || (calls[ev[i]] = []);
         list.push([callback, context]);
@@ -83,22 +83,27 @@
     // callbacks for the event. If `ev` is null, removes all bound callbacks
     // for all events.
     unbind : function(ev, callback) {
-      var calls;
-      if (!ev) {
-        this._callbacks = {};
-      } else if (calls = this._callbacks) {
-        if (!callback) {
-          calls[ev] = [];
-        } else {
-          var list = calls[ev];
-          if (!list) return this;
-          for (var i = 0, l = list.length; i < l; i++) {
-            if (list[i] && callback === list[i][0]) {
-              list[i] = null;
-              break;
+      if (ev) {
+        ev = ev.split(' ');
+        for(var j = 0, k = ev.length; j < k; j++){
+          var calls;
+          if (calls = this._callbacks) {
+            if (!callback) {
+              calls[ev[j]] = [];
+            } else {
+              var list = calls[ev[j]];
+              if (!list) return this;
+              for (var i = 0, l = list.length; i < l; i++) {
+                if (list[i] && callback === list[i][0]) {
+                  list[i] = null;
+                  break;
+                }
+              }
             }
           }
         }
+      } else {
+        this._callbacks = {};
       }
       return this;
     },

--- a/test/events.js
+++ b/test/events.js
@@ -39,6 +39,76 @@ $(document).ready(function() {
     equals(obj.counterB, 2, 'counterB should have been incremented twice.');
   });
 
+  test("Events: bind two events (using a single bind) and trigger", function() {
+    var obj = { counter: 0 };
+    _.extend(obj,Backbone.Events);
+    var callback = function() { obj.counter += 1; };
+    obj.bind('event1 event2', callback);
+    obj.trigger('event1');
+    obj.trigger('event2');
+    equals(obj.counter, 2, 'counter should have been incremented twice.');
+  });
+
+  test("Events: bind two events (using a single bind), and unbind only one", function() {
+    var obj = { counter: 0 };
+    _.extend(obj,Backbone.Events);
+    var callback = function() { obj.counter += 1; };
+    obj.bind('event1 event2', callback);
+    obj.trigger('event1');
+    obj.trigger('event2');
+    obj.unbind('event1', callback)
+    obj.trigger('event1');
+    obj.trigger('event2');
+    equals(obj.counter, 3, 'counter should have been incremented three times.');
+  });
+
+  test("Events: bind two events (using a single bind), and unbind both (using a single unbind)", function() {
+    var obj = { counter: 0 };
+    _.extend(obj,Backbone.Events);
+    var callback = function() { obj.counter += 1; };
+    obj.bind('event1 event2', callback);
+    obj.trigger('event1');
+    obj.trigger('event2');
+    obj.unbind('event1 event2', callback)
+    obj.trigger('event1');
+    obj.trigger('event2');
+    equals(obj.counter, 2, 'counter should have been incremented twice.');
+  });
+
+  test("Events: bind four events (using 2 binds) with different callbacks, and unbind all events with particular callback (using a single unbind)", function() {
+    var obj = { counterA: 0, counterB: 0 };
+    _.extend(obj,Backbone.Events);
+    var callbackA = function() { 
+      obj.counterA += 1; };
+    var callbackB = function() { 
+      obj.counterB += 1; };
+    obj.bind('event1 event2', callbackA);
+    obj.bind('event1 event2', callbackB);
+    obj.trigger('event1');
+    obj.trigger('event2');
+    obj.unbind('event1 event2', callbackA)
+    obj.trigger('event1');
+    obj.trigger('event2');
+    equals(obj.counterA, 2, 'counterA should have only been incremented once.');
+    equals(obj.counterB, 4, 'counterB should have been incremented twice.');
+  });
+
+  test("Events: bind 2 events (using one bind), then unbind all functions", function() {
+    var obj = { counterA: 0, counterB: 0 };
+    _.extend(obj,Backbone.Events);
+    var callbackA = function() { obj.counterA += 1; };
+    var callbackB = function() { obj.counterB += 1; };
+    obj.bind('event1 event2', callbackA);
+    obj.bind('event1 event2', callbackB)
+    obj.trigger('event1');
+    obj.trigger('event2');
+    obj.unbind();
+    obj.trigger('event1');
+    obj.trigger('event2');
+    equals(obj.counterA, 2, 'counterA should have only been incremented once.');
+    equals(obj.counterB, 2, 'counterB should have been incremented twice.');
+  });
+
   test("Events: unbind a callback in the midst of it firing", function() {
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);


### PR DESCRIPTION
I added some simple functionality that allows you to add multiple events in a single bind call, similar to the jquery bind i.e. obj.bind('change add:child'). The list of events is delimited by spaces. The callback and context functionality remains unchanged, meaning that providing a callback/context for a list of events will apply the callback/context to each event respectively. This also means that you can unbind a set of events giving it a specific callback. I added a series of tests to the suite for this functionality.
