### PR TITLE
Fixed _prepareModel function erasing options hash

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -567,7 +567,8 @@
     _prepareModel: function(model, options) {
       if (!(model instanceof Backbone.Model)) {
         var attrs = model;
-        model = new this.model(attrs, {collection: this});
+        options.collection = this;
+        model = new this.model(attrs, options);
         if (model.validate && !model._performValidation(attrs, options)) model = false;
       } else if (!model.collection) {
         model.collection = this;


### PR DESCRIPTION
Current _prepareModel implementation doesn't pass the provided options hash to the model initialize function instead replacing it with only the collection variable.
