### PR TITLE
Fix incorrect variable name on docs for delegateEvents

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -936,7 +936,7 @@
       return el;
     },
 
-    // Set callbacks, where `this.callbacks` is a hash of
+    // Set callbacks, where `this.events` is a hash of
     //
     // *{"event selector": "callback"}*
     //


### PR DESCRIPTION
Change "this.callbacks" to "this.events"
