### PR TITLE
Make this idAttribute nested attribute aware but uses evil eval method! 

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -201,8 +201,13 @@
       // Run validation.
       if (!options.silent && this.validate && !this._performValidation(attrs, options)) return false;
 
+      // TODO: Make this idAttribute nested attribute aware and non-eval
       // Check for changes of `id`.
-      if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];
+      //Before: if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];
+      // After with evil eval method, allows idAttribute = "myobject.id"
+      if (eval("attrs." + this.idAttribute)) {
+		this.id = eval("attrs." + this.idAttribute);
+      }
 
       // We're about to start triggering change events.
       var alreadyChanging = this._changing;


### PR DESCRIPTION
Okay I'm not sure how to do this any better, but I wanted the JSON response from the server to be "natural rails style" which is like

classname: { id: 3 }

So I wanted to set the Backbone.Model.idAttribute to "classname.id".

I'm not sure how to do it any better, but only required a minimal change in a freaky eval way.  I'm sure there's a simple and better way to do this, but I think with this one improvement, it will make using backbone.js with rails apps much easier.  

If you have a better way and can give me some pointers, I'd be more than happy to "finish it for you" so to speak.
