### PR TITLE
If a DOM library can't be found on window, try to require jQuery.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -34,6 +34,13 @@
   // For Backbone's purposes, jQuery, Zepto, or Ender owns the `$` variable.
   var $ = root.jQuery || root.Zepto || root.ender;
 
+  // Try to require jQuery in case this is Node.js, Browserify or Ender.
+  if(!$ && (typeof require !== 'undefined')) {
+    try {
+      var $ = require('jQuery');
+    } catch (e) {}
+  }
+
   // Runs Backbone.js in *noConflict* mode, returning the `Backbone` variable
   // to its previous owner. Returns a reference to this Backbone object.
   Backbone.noConflict = function() {


### PR DESCRIPTION
This should help properly support Ender and Browserify. It also doesn't make jQuery a hard dependency by putting the require in a `try` block so Node.js people can just use Backbone models without having jQuery getting required.

All tests are passing and it works in the browser normally, with Browserify and in Node.js.
