### PR TITLE
inject js library with `Backbone.use(myLib)`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -34,6 +34,25 @@
   // For Backbone's purposes, jQuery, Zepto, or Ender owns the `$` variable.
   var $ = root.jQuery || root.Zepto || root.ender;
 
+
+  // Set the javascript library that will be used for the selector work
+  // (a.k.a. the `$` variable).
+  //
+  // By default Backbone will use: jQuery, Zepto, or Ender; but the `use()`
+  // method let's you inject an alternate javascript library (or a mock
+  // library for testing your views outside of a browser). This is also useful
+  // if you are using a packaging library -- to add support for `require()`
+  // calls in the browser (e.g. ender or browserify). The scoping used to
+  // support `require()`, prevents Backbone from automatically loading the
+  // default javascript library.
+  //
+  //     Backbone.use(jQuery)
+  //
+  Backbone.use = function(lib) {
+    $ = lib;
+  };
+
+
   // Runs Backbone.js in *noConflict* mode, returning the `Backbone` variable
   // to its previous owner. Returns a reference to this Backbone object.
   Backbone.noConflict = function() {

--- a/test/test.html
+++ b/test/test.html
@@ -18,6 +18,7 @@
   <script type="text/javascript" src="view.js"></script>
   <script type="text/javascript" src="sync.js"></script>
   <script type="text/javascript" src="speed.js"></script>
+  <script type="text/javascript" src="use.js"></script>
 </head>
 <body>
   <h1 id="qunit-header">Backbone Test Suite</h1>

--- a/test/use.js
+++ b/test/use.js
@@ -1,0 +1,26 @@
+$(document).ready(function() {
+
+  var view = new Backbone.View({
+    id        : 'test-use',
+    className : 'test-use'
+  });
+
+  // a mock javascript library
+  var myLib = function(){ return "spam" }
+
+  module("Backbone.use");
+
+  test('Backbone.use', function() {
+    view.el = document.body;
+
+    // switch to mock library and see if it is being used
+    Backbone.use(myLib);
+    ok(view.$('#qunit-header a') === 'spam');
+
+    // switch back to jQuery and make sure it works
+    Backbone.use(jQuery);
+    ok(view.$('#qunit-header a').get(0).innerHTML.match(/Backbone Test Suite/));
+
+  });
+
+});


### PR DESCRIPTION
I ran into an issue where the Backbone views were unable to pick up the javascript library I was using (Zepto), because of the way that browserify changes the scope to support `require('backbone')` in the browser -- it looks like ender suffers from the same issue. This would also make it easier to test views outside of the browser by injecting a mock jQuery library.
