### PR TITLE
Quick typo in documentation about Backbone.History

### DIFF
--- a/index.html
+++ b/index.html
@@ -1645,7 +1645,7 @@ app.navigate("help/troubleshooting", true);
 $(function(){
   new WorkspaceRouter();
   new HelpPaneRouter();
-  Backbone.history.start({pushState: true});
+  Backbone.history.start({silent: true});
 });
 </pre>
 


### PR DESCRIPTION
The example after the discussion Backbone.History's `silent` option shows passing option `pushState` instead of `silent`.
