### PR TITLE
Clear event callbacks with clearEvents

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -954,7 +954,7 @@
     delegateEvents : function(events) {
       if (!(events || (events = this.events))) return;
       if (_.isFunction(events)) events = events.call(this);
-      this.clearEvents();
+      this.undelegateEvents();
       for (var key in events) {
         var method = this[events[key]];
         if (!method) throw new Error('Event "' + events[key] + '" does not exist');
@@ -971,7 +971,7 @@
     },
 
     // Clears all callbacks previously bound to the view with `delegateEvents`.
-    clearEvents: function() {
+    undelegateEvents: function() {
       $(this.el).unbind('.delegateEvents' + this.cid);
     },
 

--- a/test/view.js
+++ b/test/view.js
@@ -56,7 +56,7 @@ $(document).ready(function() {
     equals(counter2, 3);
   });
 
-  test("View: clearEvents", function() {
+  test("View: undelegateEvents", function() {
     var counter = counter2 = 0;
     view.el = document.body;
     view.increment = function(){ counter++; };
@@ -67,7 +67,7 @@ $(document).ready(function() {
     $('#qunit-userAgent').trigger('click');
     equals(counter, 1);
     equals(counter2, 1);
-    view.clearEvents();
+    view.undelegateEvents();
     $('#qunit-userAgent').trigger('click');
     equals(counter, 1);
     equals(counter2, 2);


### PR DESCRIPTION
Hi,

Occasionally we need to clear events (and _usually_ reset them later with delegateEvents).

To accomodate this, I extracted the event clearing from the delegateEvents to make it simple, obvious, and DRY how one clears events set by delegateEvents. Yes, although one might resort to delegateEvents({}), it is not very intention revealing or semantic.
