### PR TITLE
Ability to add model items to the collection immediately upon create

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -533,12 +533,15 @@
       options || (options = {});
       model = this._prepareModel(model, options);
       if (!model) return false;
-      var success = options.success;
-      options.success = function(nextModel, resp, xhr) {
-        coll.add(nextModel, options);
-        if (success) success(nextModel, resp, xhr);
-      };
+      if(!options.addImmediately) {
+        var success = options.success;
+        options.success = function(nextModel, resp, xhr) {
+          coll.add(nextModel, options);
+          if (success) success(nextModel, resp, xhr);
+        };
+      }
       model.save(null, options);
+      if(options.addImmediately) this.add(model, options);
       return model;
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -252,6 +252,23 @@ $(document).ready(function() {
     equals(model.get('label'), 'f');
     equals(model.collection, col);
   });
+  
+  test("Collection: adds the model to the collection upon success", function() {
+    var colE = new Backbone.Collection();
+    colE.create({label: 'f'});
+    equals(colE.length, 0);
+    lastRequest[2].success();
+    equals(colE.length, 1);
+    equals(colE.at(0).get("label"), 'f');
+  });
+  
+  test("Collection: adds the model immediately when told to do so", function() {
+    var colE = new Backbone.Collection();
+    colE.create({label: 'f'}, {addImmediately: true});
+    equals(colE.length, 1);
+    equals(colE.at(0).get("label"), 'f');
+    lastRequest[2].success();
+  });
 
   test("Collection: create enforces validation", function() {
     var ValidatingModel = Backbone.Model.extend({


### PR DESCRIPTION
I find myself needing to do this sometimes from a usability perspective.  It allows the UI to respond immediately and I can deal with the ramifications of a failure later.  
