### PR TITLE
Document the options parameter in the Backbone.Model constructor.

### DIFF
--- a/index.html
+++ b/index.html
@@ -561,7 +561,7 @@ var Note = Backbone.Model.extend({
 </pre>
 
     <p id="Model-constructor">
-      <b class="header">constructor / initialize</b><code>new Model([attributes])</code>
+      <b class="header">constructor / initialize</b><code>new Model([attributes], [options])</code>
       <br />
       When creating an instance of a model, you can pass in the initial values
       of the <b>attributes</b>, which will be <a href="#Model-set">set</a> on the


### PR DESCRIPTION
This patch just documents the options parameter in the Backbone.Model constructor. The options parameter is used internally by Backbone.Collection to associate the model with a collection, but is also potentially useful to subclasses (e.g., to pass state other than model attributes to Backbone.Model.initialize).
