### PR TITLE
Add option to bind multiple events

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -70,7 +70,7 @@
     // Passing `"all"` will bind the callback to all events fired.
     bind : function(evs, callback, context) {
       var calls = this._callbacks || (this._callbacks = {});
-      evs = evs.replace(/ /g,'').split(',');
+      evs = evs.split(' ');
       _.each(evs, function (ev) {
         var list = calls[ev] || (calls[ev] = []);
         list.push([callback, context]);
@@ -86,7 +86,7 @@
       if (!evs) {
         this._callbacks = {};
       } else if (calls = this._callbacks) {
-        evs = evs.replace(/ /g,'').split(',');
+        evs = evs.split(' ');
         if (!callback) {
           _.each(evs, function(ev) {
             calls[ev] = [];

--- a/test/events.js
+++ b/test/events.js
@@ -86,7 +86,7 @@ $(document).ready(function() {
   test("Events: bind an array of events", function() {
     var obj = { counter: 0 };
     _.extend(obj,Backbone.Events);
-    obj.bind('event1, event2', function() { obj.counter += 1; });
+    obj.bind('event1 event2', function() { obj.counter += 1; });
     obj.trigger('event1');
     obj.trigger('event2');
     equals(obj.counter,2,'counter should be incremented for each event.');
@@ -100,12 +100,12 @@ $(document).ready(function() {
   test("Events: unbind an array of events", function() {
     var obj = { counter: 0 };
     _.extend(obj,Backbone.Events);
-    obj.bind('event1,event2,event3', function() { obj.counter += 1; });
+    obj.bind('event1 event2 event3', function() { obj.counter += 1; });
     obj.trigger('event1');
     obj.trigger('event2');
     obj.trigger('event3');
     equals(obj.counter,3,'counter should be incremented for each event.');
-    obj.unbind('event1, event2')
+    obj.unbind('event1 event2')
     obj.trigger('event1');
     obj.trigger('event2');
     obj.trigger('event3');
@@ -116,12 +116,12 @@ $(document).ready(function() {
     var obj = { counter: 0 };
     var callback = function() { obj.counter += 1 };
     _.extend(obj,Backbone.Events);
-    obj.bind('event1, event2 , event3', callback);
+    obj.bind('event1 event2 event3', callback);
     obj.trigger('event1');
     obj.trigger('event2');
     obj.trigger('event3');
     equals(obj.counter,3,'counter should be incremented for each event.');
-    obj.unbind('event1, event2', callback)
+    obj.unbind('event1 event2', callback)
     obj.trigger('event1');
     obj.trigger('event2');
     obj.trigger('event3');


### PR DESCRIPTION
Updated the Backbone.Events.bind method to accept multiple events to bind to, which allows the following syntax:

```
collection.bind('add remove', this.onCollectionSizeChanged);
```

The multiple events are space delimited.
