### PR TITLE
Trigger the 'route' event when any route occurs

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -682,6 +682,7 @@
     //     });
     //
     route : function(route, name, callback) {
+      this.trigger('route', this, options);
       Backbone.history || (Backbone.history = new Backbone.History);
       if (!_.isRegExp(route)) route = this._routeToRegExp(route);
       Backbone.history.route(route, _.bind(function(fragment) {


### PR DESCRIPTION
Here's the scenario I needed this for: I had a jQuery feature "tour" for my single-page Backbone app, and I needed to be able to make the little tour overlay/popup go away if a user navigated anywhere new (not just one specific route).

It seemed consistent with the general "change" event and then the specific "change:[attribute]" event.
