### PR TITLE
unescape URL value just before sending them to callback

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -722,7 +722,7 @@
     // Given a route, and a URL fragment that it matches, return the array of
     // extracted parameters.
     _extractParameters : function(route, fragment) {
-      return _.map(route.exec(fragment).slice(1), decodeURIComponent);
+      return _.map(route.exec(fragment).slice(1), function(param){ return typeof param == 'string' ? decodeURIComponent(param) : param});
     }
 
   });
@@ -831,7 +831,7 @@
     checkUrl : function(e) {
       var current = this.getFragment();
       if (current == this.fragment && this.iframe) current = this.getFragment(this.iframe.location.hash);
-      if (current == this.fragment || current == decodeURIComponent(this.fragment)) return false;
+      if (current == this.fragment || current == this.fragment) return false;
       if (this.iframe) this.navigate(current);
       this.loadUrl() || this.loadUrl(window.location.hash);
     },
@@ -855,7 +855,7 @@
     // a `hashchange` event.
     navigate : function(fragment, triggerRoute) {
       var frag = (fragment || '').replace(hashStrip, '');
-      if (this.fragment == frag || this.fragment == decodeURIComponent(frag)) return;
+      if (this.fragment == frag || this.fragment == frag) return;
       if (this._hasPushState) {
         var loc = window.location;
         if (frag.indexOf(this.options.root) != 0) frag = this.options.root + frag;


### PR DESCRIPTION
Problem: you have an URL like "#!/search/I%20have%20a%20%2fhere/page2". So I'm creating a route like
    "!/search/:query/page:page": "doSearch"
and expecting to get search query "I have a / here" and "2" as a page number.
But currently you will get nothing because URL is decoded before it is processed by Backbone - so your escaped dash will be processed like real dash and whole regex will fail.
Proposed solution - process URL fragment unescaped and unescape values before sending them into callback function.
