### PR TITLE
allow route to be defined but not require a callback method on the router

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -686,7 +686,9 @@
       if (!_.isRegExp(route)) route = this._routeToRegExp(route);
       Backbone.history.route(route, _.bind(function(fragment) {
         var args = this._extractParameters(route, fragment);
-        callback.apply(this, args);
+        if (callback){
+          callback.apply(this, args);
+        }
         this.trigger.apply(this, ['route:' + name].concat(args));
       }, this));
     },

--- a/test/router.js
+++ b/test/router.js
@@ -5,6 +5,7 @@ $(document).ready(function() {
   var Router = Backbone.Router.extend({
 
     routes: {
+      "noCallback":                 "noCallback",
       "search/:query":              "search",
       "search/:query/p:page":       "search",
       "splat/*args/end":            "splat",
@@ -40,6 +41,8 @@ $(document).ready(function() {
     anything : function(whatever) {
       this.anything = whatever;
     }
+
+    // do not provide a callback method for the noCallback route
 
   });
 
@@ -111,6 +114,22 @@ $(document).ready(function() {
       start();
       window.location.hash = '';
     }, 10);
+  });
+
+  asyncTest("Router: fires event when router doesn't have callback on it", 1, function() {
+    try{
+      var callbackFired = false;
+      var myCallback = function(){ callbackFired = true; }
+      router.bind("route:noCallback", myCallback);
+      window.location.hash = "noCallback";
+      setTimeout(function(){
+        equals(callbackFired, true);
+        start();
+        window.location.hash = '';
+      }, 10);
+    } catch (err) {
+      ok(false, "an exception was thrown trying to fire the router event with no router handler callback");
+    }
   });
 
 });


### PR DESCRIPTION
I'm using a router without using callback methods in an example app that I'm building, and I don't want to be required to build a callback method on my router. 

for example, i want this to work:

```
MyRouter = Backbone.Router.extend({
  routes: {
    "foo": "bar",
    "baz/:id": "bazIt"
  }
});
```

without defining a `bar` and `bazIt` function on the router, this would cause errors because the callback is undefined.

this patch adds support for using a router like this, which then allows me to bind to the router events independently of the router configuration:

```
myRouter = new MyRouter();

myRouter.bind("route:bar", function(){ ... });
```

this patch includes the test and implementation to cover this. 
