### PR TITLE
bindOnce - only fire bind callback once

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -75,6 +75,16 @@
       return this;
     },
 
+    // Bind an event like bind(), but unbind the callback after the first time its called
+	  bindOnce : function(ev, callback, context) {
+		  var this2 = this;
+		  var bindCallback = function() {
+			  this2.unbind(ev, bindCallback);
+			  callback.apply(context || this, arguments);
+		  };
+		  this.bind(ev, bindCallback);
+	  },
+
     // Remove one or many callbacks. If `callback` is null, removes all
     // callbacks for the event. If `ev` is null, removes all bound callbacks
     // for all events.

--- a/test/events.js
+++ b/test/events.js
@@ -66,7 +66,22 @@ $(document).ready(function() {
     equals(obj.counterA, 1, 'counterA should have only been incremented once.');
     equals(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
-  
+
+  test("Events: two bindOnce", function() {
+   // Same as the previous test, but we use bindOnce rather than having to explicitly unbind
+   var obj = { counterA: 0, counterB: 0 };
+   _.extend(obj,Backbone.Events);
+   var incrA = function(){ obj.counterA += 1 };
+   var incrB = function(){ obj.counterB += 1 };
+   obj.bindOnce('event', incrA);
+   obj.bindOnce('event', incrB);
+   obj.trigger('event');
+   obj.trigger('event');
+   obj.trigger('event');
+   equals(obj.counterA, 1, 'counterA should have only been incremented once.');
+   equals(obj.counterB, 1, 'counterB should have only been incremented once.');
+ });
+
   test("Events: bind a callback with a supplied context", function () {
     expect(1);
     


### PR DESCRIPTION
Added bindOnce with tests -  bind an event like bind(), but unbind the callback after the first time its called.
Similar to jQuery one and Node.js emitter.once. See issue #156 for requests, discussion, and alternative implementation.
