### PR TITLE
addMany Option & Event

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -444,9 +444,11 @@
     // firing the `added` event for every new model.
     add : function(models, options) {
       if (_.isArray(models)) {
+        var appendedModels = [];
         for (var i = 0, l = models.length; i < l; i++) {
-          this._add(models[i], options);
+          appendedModels.push(this._add(models[i], options));
         }
+       if (options.addMany === true && !options.silent) this.trigger("addMany", appendedModels, this, options);
       } else {
         this._add(models, options);
       }
@@ -592,7 +594,7 @@
       this.models.splice(index, 0, model);
       model.bind('all', this._onModelEvent);
       this.length++;
-      if (!options.silent) model.trigger('add', model, this, options);
+      if (!options.silent && !options.addMany) model.trigger('add', model, this, options);
       return model;
     },
 


### PR DESCRIPTION
Hi there, 

Instead of just having the "add" event and the "reset" event, it is quite necessary to have also an "addMany" event. 

In any App you listen to event changes. If reset, render it all, if add, render just the added. BUT, what if you reset with 100 items, and append then 100 items. Instead of 100 times an "add" event, you now have just one "addMany" event.

usage: Model.fetch({add:true, addMany:true});
Will cause "trigger("addMany, addedModelsArray, sender)"
