### PR TITLE
Adds helper method to Backbone.View for retrieving sub-elements of $(this.el).

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1000,6 +1000,16 @@
       } else if (_.isString(this.el)) {
         this.el = $(this.el).get(0);
       }
+    },
+
+    // Makes an el sub-element lookup based on selector, and
+    // caches the element reference.  A useful alternative
+    // to writing $(this.el).find() repeatedly.
+    find : function (selector) {
+        if (!this.elcache) this.elcache = {};
+        if (this.elcache['selector']) return this.elcache['selector'];
+        this.elcache[selector] = $(this.el).find(selector);
+        return this.elcache[selector];
     }
 
   });


### PR DESCRIPTION
Adds helper method to Backbone.View for retrieving sub-elements of $(this.el).

I constantly find myself having to write code like this:

$(this.el).find('.stream');

$(this.el).find('input[type="name"]').keydown( function () { ... });

Using this.el is awkward.  I added a utility method for looking up sub-elements of this.el:

this.find('.stream');
this.find('input[type="name"]').keydown(function () { ... });

find() also caches element references based on selector strings for faster lookup.
