### PR TITLE
If trigger('all') is called, all the callbacks should run once instead of twice.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -104,7 +104,7 @@
     // Listening for `"all"` passes the true event name as the first argument.
     trigger : function(eventName) {
       var list, calls, ev, callback, args;
-      var both = 2;
+      var both = (eventName === 'all') ? 1 : 2;
       if (!(calls = this._callbacks)) return this;
       while (both--) {
         ev = both ? eventName : 'all';


### PR DESCRIPTION
All the functions bound to 'all' should have different arguments, i.e. the first arguments is the eventName.
If trigger('all') is called, the original code would run callbacks twice. At the first time, it would consider them as  normal functions, and wouldn't transfer the eventName. That would be the reason why some functions bound to 'all' events malfunction. On the other hand, it should not run twice when someone explicitly triggers an event only once. 
