### PR TITLE
Model.set takes a single key/value pair

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -194,7 +194,7 @@
       if (_.isString(attrs) || _.isNumber(attrs)){
         var key = attrs;
         (attrs = {})[key] = options;
-        options = arguments.length > 2 ? arguments[3] : undefined;
+        options = arguments.length > 2 ? arguments[2] : undefined;
       }
 
       // Extract attributes and options.

--- a/test/model.js
+++ b/test/model.js
@@ -160,9 +160,15 @@ $(document).ready(function() {
   });
 
   test("Model: set single attribute", function() {
-    a = new Backbone.Model();
+    var counter = 0;
+    var a = new Backbone.Model();
+    a.bind('change:foo', function(){ counter++; });
     a.set('foo', 2);
     equals(a.attributes.foo, 2)
+    equals(counter, 1);
+    a.set('foo', 3, {silent: true});
+    equals(a.attributes.foo, 3);
+    equals(counter, 1);
   });
 
   test("Model: multiple unsets", function() {


### PR DESCRIPTION
I often find that I need to set one key/value pair on a model and that the key is stored in a variable.  This usually requires something like the following:

```
var attrs = {};
attrs[key] = val;
model.set(attrs);
```

Sometimes, if `attrs` is already defined, this can be shortened to:

```
(attrs = {})[key] = val;
model.set(attrs);
```

This, however, is about as small as it gets.  Also it's less clear than my proposed solution:

```
model.set(key, val);
```

This cuts down on boilerplate and allows for interesting bindings.  I know other solutions have been posted (#570 for instance) but I think this approach is simpler and more readable.
