### PR TITLE
nested trigger with unbind

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -105,13 +105,15 @@
     trigger : function(eventName) {
       var list, calls, ev, callback, args;
       var both = 2;
+      var already = this._triggering;
+      this._triggering = true;
       if (!(calls = this._callbacks)) return this;
       while (both--) {
         ev = both ? eventName : 'all';
         if (list = calls[ev]) {
           for (var i = 0, l = list.length; i < l; i++) {
             if (!(callback = list[i])) {
-              list.splice(i, 1); i--; l--;
+              if (!already) { list.splice(i, 1); i--; l--; }
             } else {
               args = both ? Array.prototype.slice.call(arguments, 1) : arguments;
               callback[0].apply(callback[1] || this, args);
@@ -119,6 +121,7 @@
           }
         }
       }
+      if (!already) this._triggering = false;
       return this;
     }
 

--- a/test/events.js
+++ b/test/events.js
@@ -66,21 +66,33 @@ $(document).ready(function() {
     equals(obj.counterA, 1, 'counterA should have only been incremented once.');
     equals(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
-  
+
   test("Events: bind a callback with a supplied context", function () {
     expect(1);
-    
+
     var TestClass = function () { return this; }
     TestClass.prototype.assertTrue = function () {
       ok(true, '`this` was bound to the callback')
     };
-    
+
     var obj = _.extend({},Backbone.Events);
-    
+
     obj.bind('event', function () { this.assertTrue(); }, (new TestClass));
-    
+
     obj.trigger('event');
-    
+
+  });
+
+  test("Events: nested trigger with unbind", function () {
+    expect(1);
+    var obj = { counter: 0 };
+    _.extend(obj, Backbone.Events);
+    var incr1 = function(){ obj.counter += 1; obj.unbind('event', incr1); obj.trigger('event'); };
+    var incr2 = function(){ obj.counter += 1; };
+    obj.bind('event', incr1);
+    obj.bind('event', incr2);
+    obj.trigger('event');
+    equals(obj.counter, 3, 'counter should have been incremented three times');
   });
 
 });


### PR DESCRIPTION
Nested calls to trigger can cause event handlers to be skipped in the outer call because the callback list has been spliced in the inner call.  By splicing only in the outermost call to trigger we can avoid this issue.
