### PR TITLE
Backbone.sync: Give options.contentType precedence over hardcoded value

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1057,7 +1057,7 @@
 
     // Ensure that we have the appropriate request data.
     if (!params.data && model && (method == 'create' || method == 'update')) {
-      params.contentType = 'application/json';
+      params.contentType || (params.contentType = 'application/json');
       params.data = JSON.stringify(model.toJSON());
     }
 


### PR DESCRIPTION
This is a patch for #592, my motivation is similar to the original report there.

I want to `PUT` and `POST` data to my service with a custom Content-Type header (`application/mycompany+json` in this case), by overriding the sync method of the respective model.

``` javascript
var MyModel;
MyModel = Backbone.Model.extend({
  sync: function(method, model, options) {
    return Backbone.sync(method, model, _.extend({
      contentType: "application/mycompany+json"
    }));
  }
});
```

I don't want to copy most of Backbone.sync to my own model to keep things DRY. Not all my models use the same content type, hence using jQuery's global ajaxSetup doesn't work.

Thanks for the great code!

---

Workaround:

``` javascript
var MyModel;
MyModel = Backbone.Model.extend({
  sync: function(method, model, options) {
    return Backbone.sync(method, model, _.extend({
      headers: {
        "Content-Type": "application/mycompany+json"
      }
    }));
  }
});
```
