### PR TITLE
Add AMD registration as an option.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -36,7 +36,7 @@
   Backbone.noConflict = function() {
     root.Backbone = previousBackbone;
     return exports;
-  }
+  };
 
   // Turn on `emulateHTTP` to support legacy HTTP servers. Setting this option will
   // fake `"PUT"` and `"DELETE"` requests via the `_method` parameter and set a
@@ -1201,8 +1201,8 @@
     // Create a global for Backbone.
     // Call the factory function to attach the Backbone
     // properties to the exports value.
-    factory(function(value) {
-      if (value === 'jquery') {
+    factory(function(id) {
+      if (id === 'jquery') {
         // Support libraries that support the portions of
         // the jQuery API used by Backbone.
         return root.jQuery || root.Zepto || root.ender;


### PR DESCRIPTION
Uses a common factory function with adapters for CommonJS and default browser env to register appropriately based on the environment.

I placed the define() call on the same line as the function(define) { so that a level of indent in the backbone.js code would trigger a noisy diff. However, I can place it on its own line and do an indent of the code if that is preferred.

I also have an [optamd-withtest branch](https://github.com/jrburke/backbone/tree/optamd-withtest) that has a test-requirejs.html file showing it working with an AMD loader. I also tested the code in Node, doing a simple test with a Backbone.Model. I did not commit that Node test since it was just a simple code check.

Backbone probably does not want the test page, so I just put the core registration changes in this pull request branch. However I have no problem merging in the test page if that is preferred. The test uses underscore 1.2.1 and jQuery 1.7rc1, which both call define() to register as AMD modules.

Related to Issue #684, where it highlights the usefulness of this patch. Also see the [similar ticket for underscore](https://github.com/documentcloud/underscore/pull/338). In short, AMD registration is useful because:
- It encourages modules for use in the browser in a way that does not require dumping globals.
- Since dependencies are string names, alternate implementations can be swapped in. For Backbone, it means it can ask for 'jquery' but have zepto loaded instead. It avoids the need for a script like Backbone to have to know of all the scripts that could be used instead of jQuery.
- Because globals can be avoided, it is possible to build contained libraries. Even ones that do not use an AMD loader, but just the API to connect its individual components. The [almond AMD shim](https://github.com/jrburke/almond) can be used for those cases.
- noConflict() is not enough due to timing issue of script execution and script onload callbacks for dynamically added scripts in IE. For building contained libraries, use of noConflict() for all the modules becomes unwieldy.
