### PR TITLE
#673 - Adding index as a property on the options object that gets passed 

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -608,6 +608,7 @@
       this.models.splice(index, 0, model);
       model.bind('all', this._onModelEvent);
       this.length++;
+      options.index = index;
       if (!options.silent) model.trigger('add', model, this, options);
       return model;
     },
@@ -620,8 +621,10 @@
       if (!model) return null;
       delete this._byId[model.id];
       delete this._byCid[model.cid];
-      this.models.splice(this.indexOf(model), 1);
+      var index = this.indexOf(model);
+      this.models.splice(index, 1);
       this.length--;
+      options.index = index;
       if (!options.silent) model.trigger('remove', model, this, options);
       this._removeReference(model);
       return model;

--- a/test/collection.js
+++ b/test/collection.js
@@ -95,6 +95,23 @@ $(document).ready(function() {
     equals(atCol.last(), h);
   });
 
+  test("Collection: add model to collection and verify index updates", function() {
+    var f = new Backbone.Model({id: 20, label : 'f'});
+    var g = new Backbone.Model({id: 21, label : 'g'});
+    var h = new Backbone.Model({id: 22, label : 'h'});
+    var col = new Backbone.Collection();
+    
+    var counts = [];
+     
+    col.bind('add', function(model, collection, options) {
+      counts.push(options.index);  
+    });
+    col.add(f); 
+    col.add(g); 
+    col.add(h); 
+    ok(_.isEqual(counts, [0,1,2]));
+  });
+
   test("Collection: add model to collection twice", function() {
     try {
       // no id, same cid
@@ -144,6 +161,23 @@ $(document).ready(function() {
     equals(col.length, 4);
     equals(col.first(), d);
     equals(otherRemoved, null);
+  });
+
+  test("Collection: remove should return correct index events", function() {
+    var f = new Backbone.Model({id: 20, label : 'f'});
+    var g = new Backbone.Model({id: 21, label : 'g'});
+    var h = new Backbone.Model({id: 22, label : 'h'});
+    var col = new Backbone.Collection([f,g,h]);
+    
+    var counts = [];
+     
+    col.bind('remove', function(model, collection, options) {
+      counts.push(options.index);  
+    });
+    col.remove(h); 
+    col.remove(g); 
+    col.remove(f); 
+    ok(_.isEqual(counts, [2,1,0]));
   });
 
   test("Collection: events are unbound on remove", function() {


### PR DESCRIPTION
#673 - Adding index as a property on the options object that gets passed when the add/remove callbacks get triggered on a collection.
