### PR TITLE
Fix Todos example 

### DIFF
--- a/examples/todos/index.html
+++ b/examples/todos/index.html
@@ -5,7 +5,7 @@
     <title>Backbone Demo: Todos</title>
     <link href="todos.css" media="all" rel="stylesheet" type="text/css"/>
     <script src="../../test/vendor/json2.js"></script>
-    <script src="../../test/vendor/jquery-1.5.js"></script>
+    <script src="../../test/vendor/jquery-1.6.4.js"></script>
     <script src="../../test/vendor/underscore-1.2.1.js"></script>
     <script src="../../backbone.js"></script>
     <script src="../backbone-localstorage.js"></script>


### PR DESCRIPTION
Fix Todos example by importing the currently shipped version of jQuery (1.6.4) that is located in /test/vendor.
