### PR TITLE
Unified registration as browser/AMD/CommonJS module.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -12,7 +12,7 @@
     factory(root, exports, require('underscore'));
   } else if (typeof define === 'function' && define.amd) {
     // AMD
-    define('backbone', ['underscore', 'jquery', 'exports'], function(_, $, exports) {
+    define(['underscore', 'jquery', 'exports'], function(_, $, exports) {
       factory(root, exports, _, $);
     });
   } else {


### PR DESCRIPTION
This is an improvement over the #688 based on feedback from @tbranyen and @jdalton. It is a much simpler registration approach.

One of the simplifications over #688 was to not to try to load jquery in a node/commonjs environment since the current Backbone code does not do that.

This pull request supersedes #688, I will close 688.
