### PR TITLE
Making unbind and trigger more compatible with each other

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -87,7 +87,7 @@
     unbind : function(ev, callback) {
       var calls, node, prev;
       if (!ev) {
-        this._callbacks = {};
+        this._callbacks = null;
       } else if (calls = this._callbacks) {
         if (!callback) {
           calls[ev] = {};


### PR DESCRIPTION
This means that after unbinding every event, a trigger call will return faster, because !(calls = this._callbacks) will evaluate to true.
