### PR TITLE
Trigger error on originalModel not model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1155,7 +1155,7 @@
       if (onError) {
         onError(model, resp, options);
       } else {
-        model.trigger('error', model, resp, options);
+        originalModel.trigger('error', model, resp, options);
       }
     };
   };


### PR DESCRIPTION
The original model that the 'sync' request was called in should be the object that is taking the 'error' trigger.

After a 'fetch' request on a collection, 'model' is the jQuery xhr object, which does not have a 'trigger' method.

My test case:

``` javascript
var collection = new Backbone.Collection;
collection.url = '/bad-url';
collection.fetch();
```
