### PR TITLE
(un)bind does not alter callback list during trigger

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -95,4 +95,18 @@ $(document).ready(function() {
     equals(obj.counter, 3, 'counter should have been incremented three times');
   });
 
+  test("Events: callback list is not altered during trigger", function () {
+    var counter = 0, obj = _.extend({}, Backbone.Events);
+    var incr = function(){ counter++; };
+    obj.bind('event', function(){ obj.bind('event', incr).bind('all', incr); })
+    .trigger('event');
+    equals(counter, 0, 'bind does not alter callback list');
+    obj.unbind()
+    .bind('event', function(){ obj.unbind('event', incr).unbind('all', incr); })
+    .bind('event', incr)
+    .bind('all', incr)
+    .trigger('event');
+    equals(counter, 2, 'unbind does not alter callback list');
+  });
+
 });


### PR DESCRIPTION
After a [comment](https://github.com/documentcloud/backbone/pull/624#issuecomment-2616598) from @kmalakoff in #624, I started thinking about the behavior of events being bound or unbound during a call to trigger and how Backbone's implementation is different than jQuery's.

jQuery appears to freeze the callback list when the event is fired:

```
$({}).bind('event', function(){
  $(this).bind('event', handler);
})
.trigger('event') // doesn't call handler
.unbind()
.bind('event', function(){
  $(this).unbind('event', handler);
})
.bind('event', handler)
.trigger('event');  // calls handler
```

Backbone, on the other hand, alters the callback list during trigger:

```
model.bind('event', function(){
  model.bind('event', handler);
})
.trigger('event') // calls handler
.unbind()
.bind('event', function(){
  model.unbind('event', handler);
})
.bind('event', handler)
.trigger('event');  // doesn't call handler
```

I'm not sure which way is correct, but I think that freezing the callback list is simpler and more intuitive.  By sharing data between multiple versions of a callback list, we can achieve this while [preserving performance characteristics](http://jsperf.com/backbone-events-linked-list/5).
