### PR TITLE
Issue #730 - Calling .clear results in changedAttributes being empty

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -263,11 +263,14 @@
     clear : function(options) {
       options || (options = {});
       var attr;
-      var old = this.attributes;
+      var old = this.attributes, unset = (this._unsetAttributes || (this._unsetAttributes = []));
 
       // Run validation.
       var validObj = {};
-      for (attr in old) validObj[attr] = void 0;
+      for (attr in old) {
+        validObj[attr] = void 0;
+        unset.push(attr);
+      }
       if (!options.silent && this.validate && !this._performValidation(validObj, options)) return false;
 
       this.attributes = {};

--- a/test/model.js
+++ b/test/model.js
@@ -201,6 +201,11 @@ $(document).ready(function() {
     var changed;
     var model = new Backbone.Model({name : "Model"});
     model.bind("change:name", function(){ changed = true; });
+    model.bind("change", function() {
+      var keys = _.keys(model.changedAttributes());
+      equals(keys.indexOf('name') > -1, true);
+      equals(keys.indexOf('id') > -1, true)
+    });
     model.clear();
     equals(changed, true);
     equals(model.get('name'), undefined);


### PR DESCRIPTION
Issue #730 - Calling .clear leaves changedAttributes empty because it iterates over properties in now. Extending the use of _unsetAttributes to collect all clear attributes as well
