### PR TITLE
Multiple nested calls to set

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -211,8 +211,10 @@
       }
 
       // Fire the `"change"` event, if the model has been changed.
-      if (!alreadyChanging && !options.silent && this._changed) this.change(options);
-      this._changing = false;
+      if (!alreadyChanging) {
+        if (!options.silent && this._changed) this.change(options);
+        this._changing = false;
+      }
       return this;
     },
 

--- a/test/model.js
+++ b/test/model.js
@@ -449,4 +449,13 @@ $(document).ready(function() {
     a.set({state: 'hello'});
   });
 
+  test("Model: Multiple nested calls to set", function() {
+    var model = new Backbone.Model({});
+    model.bind('change', function() {
+      model.set({b: 1});
+      model.set({a: 1});
+    })
+    .set({a: 1});
+  });
+
 });


### PR DESCRIPTION
Multiple nested calls to `Model.set` should not set `_changing` to `false` (since the model is _still changing_).  In some cases (like the attached test case), doing so can cause an infinite recursion setting the same values over and over.
