### PR TITLE
variadic set/save

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -182,9 +182,9 @@
     // Set a hash of model attributes on the object, firing `"change"` unless you
     // choose to silence it.
     set : function(attrs, options) {
-      if (attrs && !_.isObject(attrs)) {
+      if (attrs != null && !_.isObject(attrs)) {
         var args = slice.call(arguments), attrs = {};
-        while ((options = args.shift()) && !_.isObject(options)) attrs[options] = args.shift();
+        while ((options = args.shift()) != null && !_.isObject(options)) attrs[options] = args.shift();
       }
 
       // Extract attributes and options.
@@ -292,9 +292,9 @@
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
     save : function(attrs, options) {
-      if (attrs && !_.isObject(attrs)) {
+      if (attrs != null && !_.isObject(attrs)) {
         var args = slice.call(arguments), attrs = {};
-        while ((options = args.shift()) && !_.isObject(options)) attrs[options] = args.shift();
+        while ((options = args.shift()) != null && !_.isObject(options)) attrs[options] = args.shift();
       }
       options || (options = {});
       if (attrs && !this.set(attrs, options)) return false;

--- a/test/model.js
+++ b/test/model.js
@@ -140,7 +140,7 @@ $(document).ready(function() {
   });
 
   test("Model: set and unset", function() {
-    expect(10);
+    expect(12);
     attrs = {id: 'id', foo: 1, bar: 2, baz: 3};
     a = new Backbone.Model(attrs);
     var changeCount = 0;
@@ -161,9 +161,11 @@ $(document).ready(function() {
 
     var options = {};
     a.bind('change', function(model, _options){ ok(options === _options); });
-    a.set('foo', 5, 'bar', 6, options);
+    a.set('foo', 5, 'bar', 6, '', 7, 0, 8, options);
     equals(a.get('foo'), 5);
     equals(a.get('bar'), 6);
+    equals(a.get(''), 7);
+    equals(a.get('0'), 8);
   });
 
   test("Model: multiple unsets", function() {
@@ -293,7 +295,6 @@ $(document).ready(function() {
       options.success.call(this, {admin: true});
     };
     model.save(null, {error: function(model, error) {
-      console.log('erroring!');
       lastError = error;
     }});
 


### PR DESCRIPTION
`set` and `save` should accept arguments of the form:

```
(attrs, [options])
(key, val, [key, val, [...]], [options])
```

I know this enhancement has already been submitted in #716, #738, #570, #680, and probably others I've missed.  However, I believe this implementation has several added benefits including simplicity, performance, and handling multiple key-value pairs.
