### PR TITLE
return false if this.el is not in DOM 

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1000,7 +1000,7 @@
     // matching element, and re-assign it to `el`. Otherwise, create
     // an element from the `id`, `className` and `tagName` properties.
     _ensureElement : function() {
-      if (!this.el) {
+      if (!this.el || !this.el.length) {
         var attrs = this.attributes || {};
         if (this.id) attrs.id = this.id;
         if (this.className) attrs['class'] = this.className;


### PR DESCRIPTION
Given I create a view like the following:

``` javascript
new MyView({ el: $("#my-element") });
```

When I render that view and no element with ID my-element exists on the page
Then _ensureElement should create the element for me

Instead _ensureElement doesn't create anything because !this.el still returns true.
