### PR TITLE
Update remaining call to _updateLocationHash to _updateHash

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -843,7 +843,7 @@
           // Opening and closing the iframe tricks IE7 and earlier to push a history entry on hash-tag change.
           // When replace is true, we don't want this.
           if(!options.replace) this.iframe.document.open().close();
-          this._updateLocationHash(this.iframe.location, frag, options.replace);
+          this._updateHash(this.iframe.location, frag, options.replace);
         }
       }
       if (options.trigger) this.loadUrl(fragment);


### PR DESCRIPTION
Merge commit 1332246b8f3b6672d3c3f19dd21c99765f4f8282 includes a rename-method refactoring operation, but is not complete. As is, all browsers using the iFrame workaround (IE{6,7}) will emit an error when using Router#Navigate with replace: true.

This commit completes it.
