### PR TITLE
Is duplicate function

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -528,6 +528,11 @@
     _reset : function(options) {
       this.length = 0;
       this.models = [];
+      this._resetIndices();
+    },
+
+    // Reset all internal indices. Called when the collection is reset.
+    _resetIndices : function() {
       this._byId  = {};
       this._byCid = {};
     },
@@ -562,8 +567,7 @@
       if (!model) return false;
       var already = this._getDuplicate(model);
       if (already) throw new Error(["Can't add the same model to a set twice", already.id]);
-      this._byId[model.id] = model;
-      this._byCid[model.cid] = model;
+      this._indexModel(model);
       var index = options.at != null ? options.at :
                   this.comparator ? this.sortedIndex(model, this.comparator) :
                   this.length;
@@ -575,14 +579,19 @@
       return model;
     },
 
+    // Internal implementation of updating the internal indices for a single model
+    _indexModel : function(model) {
+      this._byId[model.id] = model;
+      this._byCid[model.cid] = model;
+    },
+
     // Internal implementation of removing a single model from the set, updating
     // hash indexes for `id` and `cid` lookups.
     _remove : function(model, options) {
       options || (options = {});
       model = this.getByCid(model) || this.get(model);
       if (!model) return null;
-      delete this._byId[model.id];
-      delete this._byCid[model.cid];
+      this._removeFromIndices(model);
       var index = this.indexOf(model);
       this.models.splice(index, 1);
       this.length--;
@@ -590,6 +599,12 @@
       if (!options.silent) model.trigger('remove', model, this, options);
       this._removeReference(model);
       return model;
+    },
+
+    // Internal implementation of removing a single model from the internal indices
+    _removeFromIndices : function(model) {
+      delete this._byId[model.id];
+      delete this._byCid[model.cid];
     },
 
     // Internal method to remove a model's ties to a collection.


### PR DESCRIPTION
In order to make it less painful for end users to define what makes a model unique within a backbone collection I propose these two changes.

The first commit introduces the following changes:
- In _add(), extract the code checking for an existing model into _getDuplicate().
  
  This funciton will then first check the presence of getByUniqueId() and if not defined will fallback to the existing check with getByCid().
  
  The use of getByUniqueId() allows end users to override the check for duplicity currently used if it doesn't suit their use case.
- The 2nd commit, is a result of the changes introduced by the first commit and is primarily a refactoring to extract the code that maintains the internal indices so that anyone defining getByUniqueId can additionally redefine the index functions to maintain their own indices.

I'd appreciate any feedback....
