### PR TITLE
Check for existing event handler via bound added

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -115,6 +115,17 @@
         while (node = node.next) if (callback = node.callback) callback.apply(node.context || this, args);
       }
       return this;
+    },
+
+    // Checks wether the given event and callback are already bound
+    bound : function(ev, callback) {
+      var calls = this._callbacks || (this._callbacks = {}), node;
+      if (node = calls[ev]) {
+        while (node = node.next) {
+          if (node.callback === callback) return true;
+        }
+      }
+      return false;
     }
 
   };

--- a/test/events.js
+++ b/test/events.js
@@ -95,4 +95,19 @@ $(document).ready(function() {
     equals(obj.counter, 3, 'counter should have been incremented three times');
   });
 
+  test("Events: bind callback and check for it via bound", function() {
+    var obj = {};
+    _.extend(obj, Backbone.Events);
+    var callback = function() {};
+    var anotherCallback = function() {};
+    equals(obj.bound('event', callback), false, 'callback should not be found');
+    obj.bind('event', callback);
+    equals(obj.bound('event', callback), true, 'callback should be found');
+    equals(obj.bound('event', anotherCallback), false, 'anotherCallback should not be found');
+    obj.bind('event', anotherCallback);
+    equals(obj.bound('event', anotherCallback), true, 'anotherCallback should be found');
+    obj.unbind('event', callback);
+    equals(obj.bound('event', callback), false, 'callback should not be found');
+  });
+
 });


### PR DESCRIPTION
It would be useful to be able to check for an already bound event-handler, so I added bound to Backbone.Events.
