### PR TITLE
Implemented Spine-like elements configuration

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -869,6 +869,7 @@
     this.cid = _.uniqueId('view');
     this._configure(options || {});
     this._ensureElement();
+    this._assignElements( options && options.elements ? options.elements : {} );
     this.delegateEvents();
     this.initialize.apply(this, arguments);
   };
@@ -957,6 +958,41 @@
     // Clears all callbacks previously bound to the view with `delegateEvents`.
     undelegateEvents : function() {
       $(this.el).unbind('.delegateEvents' + this.cid);
+    },
+    
+    
+    // Helper to set a bunch of instance variables referencing various elements.
+    //
+    // *{"instance variable name": "selector"}*
+    //
+    //    {
+    //        title: 'h1',
+    //        banner: '#banner'
+    //    }
+    // 
+    // Can be used with jQuery element too:
+    // 
+    //    {
+    //        title: $('h1'),
+    //        banner: $('#banner', 'div.wrapper')
+    //    }
+    // 
+    // And passed by option's parameter when instatiates the view:
+    // 
+    // var carousel = new CarouselView({ 
+    //   elements: { 
+    //     holder: '#carousel-holder' 
+    //   } 
+    // });
+    _assignElements : function(elements) {
+      var elems = $.extend({}, this.elements, elements)
+        , el    = $(this.el).get(0)
+        , scope = el == window || el == document ? 'html' : el
+      ;
+      for(var key in elems) {
+        var elem  = $(elems[key], scope);
+        this[key] = elem.length ? elem : $([]);
+      }
     },
 
     // Performs the initial configuration of a View with a set of options.

--- a/index.html
+++ b/index.html
@@ -263,6 +263,7 @@
       <li>– <a href="#View-remove">remove</a></li>
       <li>– <a href="#View-make">make</a></li>
       <li>– <a href="#View-delegateEvents">delegateEvents</a></li>
+      <li>– <a href="#View-assignElements">assignElements</a></li>
     </ul>
 
     <a class="toc_title" href="#Utility">
@@ -1765,7 +1766,7 @@ model.save();  // POST to "/collection/id", with "_method=PUT" + header.
       <br />
       Get started with views by creating a custom view class. You'll want to
       override the <a href="#View-render">render</a> function, specify your
-      declarative <a href="#View-delegateEvents">events</a>, and perhaps the
+      declarative <a href="#View-delegateEvents">events</a>, <tt>elements</tt>, and perhaps the
       <tt>tagName</tt>, <tt>className</tt>, or <tt>id</tt> of the View's root
       element.
     </p>
@@ -1776,6 +1777,10 @@ var DocumentRow = Backbone.View.extend({
   tagName: "li",
 
   className: "document-row",
+  
+  elements: {
+    external_links: "a[target=_blank]"
+  },
 
   events: {
     "click .icon":          "open",
@@ -1992,6 +1997,36 @@ var DocumentView = Backbone.View.extend({
 
   select: function() {
     this.model.set({selected: true});
+  },
+
+  ...
+
+});
+</pre>
+
+    <p id="View-assignElements">
+      <b class="header">assignElements</b><code>assignElements([elements])</code>
+      <br />
+      Use the property <tt>elements</tt> to provide a declarative way to set the appropriate elements as properties on the instance.
+      Each property will respond like a jQuery's object.
+    </p>
+    <p>
+      Setting the carousel's controls(next, prev) could be like this:
+    </p>
+
+<pre>
+var CarouselView = Backbone.View.extend({
+
+  el: "div#carousel",
+
+  elements: {
+    next: "a.next",
+    prev: "a.prev"
+  },
+  
+  initialize: function() {
+    this.next.fadeIn(300);
+    this.prev.fadeOut(300);
   },
 
   ...

--- a/test/view.js
+++ b/test/view.js
@@ -154,5 +154,81 @@ $(document).ready(function() {
     $('body').trigger('fake$event');
     equals(count, 2);
   });
+  
+  test("View: assign elements with string", function() {
+    var View = Backbone.View.extend({
+      el: 'body',
+      elements: {
+        header: 'h1',
+        banner: 'h2#qunit-banner'
+      },
+      initialize: function() {
+        equals(this.header.first().get(0), $('h1', 'body').first().get(0));
+        equals(this.banner.first().get(0), $('h2#qunit-banner', 'body').first().get(0));
+      }
+    });
+    var view = new View;
+  });
+  
+  test("View: assign elements with jQuery elements $()", function() {
+    var View = Backbone.View.extend({
+      el: 'body',
+      elements: {
+        header: $('h1'),
+        banner: $('h2#qunit-banner', 'body')
+      },
+      initialize: function() {
+        equals(this.header.first().get(0), $('h1', 'body').first().get(0));
+        equals(this.banner.first().get(0), $('h2#qunit-banner', 'body').first().get(0));
+      }
+    });
+    var view = new View;
+  });
+  
+  test("View: assign elements passing elements by parameters", function() {
+    var View = Backbone.View.extend({
+      el: 'body',
+      initialize: function() {
+        equals(this.header.first().get(0), $('h1', 'body').first().get(0));
+        equals(this.banner.first().get(0), $('h2#qunit-banner', 'body').first().get(0));
+      }
+    });
+    var view = new View({
+      elements: {
+        header: 'h1',
+        banner: 'h2#qunit-banner'
+      }
+    });
+  });
+  
+  test("View: assign elements with string when el is document", function() {
+    var View = Backbone.View.extend({
+      el: $(document),
+      elements: {
+        header: 'h1',
+        banner: 'h2#qunit-banner'
+      },
+      initialize: function() {
+        equals(this.header.first().get(0), $('h1', 'body').first().get(0));
+        equals(this.banner.first().get(0), $('h2#qunit-banner', 'body').first().get(0));
+      }
+    });
+    var view = new View;
+  });
+  
+  test("View: assign elements with string when el is window", function() {
+    var View = Backbone.View.extend({
+      el: $(window),
+      elements: {
+        head: 'head',
+        body: 'body'
+      },
+      initialize: function() {
+        equals(this.head.get(0), $('head').get(0));
+        equals(this.body.get(0), $('body').get(0));
+      }
+    });
+    var view = new View;
+  });
 
 });


### PR DESCRIPTION
Issue: #569 - Use the property elements to provide a declarative way to set the appropriate elements as properties on the instance. Each property will respond like a jQuery's object.

Sending:
- Tests
- Implementation
- Documentation
