### PR TITLE
Bugfix: replace hash should not append hash mark to javascript:0

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -853,7 +853,7 @@
     // a new one to the browser history.
     _updateHash: function(location, fragment, replace) {
       if (replace) {
-        location.replace(location.toString().replace(/#.*$/, '') + '#' + fragment);
+        location.replace(location.toString().replace(/(javascript:|#).*$/, "") + "#" + fragment);
       } else {
         location.hash = fragment;
       }


### PR DESCRIPTION
This bug only exists in IE7, and appears to only have the side-effect of showing alert dialogs. This pull request fixes the alerts. IE7 navigate replace: true functionality tested and working in IE7 and modern browsers.
