### PR TITLE
Fixes issue 498.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -710,7 +710,7 @@
   };
 
   // Cached regex for cleaning hashes.
-  var hashStrip = /^#*/;
+  var hashStrip = /^#/;
 
   // Cached regex for detecting MSIE.
   var isExplorer = /msie [\w.]+/;


### PR DESCRIPTION
Firefox has a bug that auto-decodes the hash fragment
(https://bugzilla.mozilla.org/show_bug.cgi?id=483304), which makes
it impossible to have a hash like '#%23backbone.js'.
