### PR TITLE
Rails like url templates in Backbone.Model.urlRoot and Backbone.Collection.url

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -127,15 +127,15 @@ $(document).ready(function() {
     var g = new Backbone.Model({id: 21, label : 'g'});
     var h = new Backbone.Model({id: 22, label : 'h'});
     var col = new Backbone.Collection();
-    
+
     var counts = [];
-     
+
     col.bind('add', function(model, collection, options) {
-      counts.push(options.index);  
+      counts.push(options.index);
     });
-    col.add(f); 
-    col.add(g); 
-    col.add(h); 
+    col.add(f);
+    col.add(g);
+    col.add(h);
     ok(_.isEqual(counts, [0,1,2]));
   });
 
@@ -209,15 +209,15 @@ $(document).ready(function() {
     var g = new Backbone.Model({id: 21, label : 'g'});
     var h = new Backbone.Model({id: 22, label : 'h'});
     var col = new Backbone.Collection([f,g,h]);
-    
+
     var counts = [];
-     
+
     col.bind('remove', function(model, collection, options) {
-      counts.push(options.index);  
+      counts.push(options.index);
     });
-    col.remove(h); 
-    col.remove(g); 
-    col.remove(f); 
+    col.remove(h);
+    col.remove(g);
+    col.remove(f);
     ok(_.isEqual(counts, [2,1,0]));
   });
 
@@ -312,6 +312,18 @@ $(document).ready(function() {
     ok(colE.length == 0);
     ok(colF.length == 0);
     equals(null, e.collection);
+  });
+
+  test("Collection: url templates", function(){
+    var ColE = Backbone.Collection.extend({
+      url:["/just/string", "/videos/:video_id", "/albums/:album_id/videos/:video_id"]
+    });
+    var colE = new ColE(null, {params:{video_id:1}});
+    equals(colE._getUrl(), '/videos/1');
+    colE = new ColE(null, {params:{video_id:1,album_id:2}});
+    equals(colE._getUrl(), '/albums/2/videos/1');
+    colE = new ColE();
+    equals(colE._getUrl(), '/just/string');
   });
 
   test("Collection: fetch", function() {

--- a/test/model.js
+++ b/test/model.js
@@ -87,6 +87,20 @@ $(document).ready(function() {
     equals(model.url(), '/collection/%2B1%2B');
   });
 
+  test("Model: url when using urlRoot with template ", function() {
+    var Model = Backbone.Model.extend({
+      urlRoot: ["/just/string", "/videos/:video_id", '/albums/:album_id/videos/:video_id']
+    });
+    var model = new Model(null, {params:{video_id:1}});
+    equals(model.url(), "/videos/1");
+    model = new Model(null, {params:{video_id:1,album_id:2}});
+    equals(model.url(), "/albums/2/videos/1");
+    model = new Model({video_id:1}, {params:{album_id:2}});
+    equals(model.url(), "/albums/2/videos/1");
+    model = new Model();
+    equals(model.url(), "/just/string");
+  });
+
   test("Model: clone", function() {
     attrs = { 'foo': 1, 'bar': 2, 'baz': 3};
     a = new Backbone.Model(attrs);


### PR DESCRIPTION
Example in model: 

```
 var Comment = Backbone.Model.extend({
   urlRoot: ["/comments", "/videos/:video_id/comments", "/albums/:album_id/videos/:video_id/comments"]
 })

 // url() -> /comments/1
 new Comment()
 // url() -> /videos/2/comments/1
 new Comment(..., {params:{video_id:2}})
 // url() -> /albums/3/videos/2/comments/1
 new Comment(..., {params:{video_id:2, album_id:3}}) or
 new Comment({id:1,video_id:2, album_id:3})
```

Example in Collection: 

```
 var Comments = Backbone.Collection.extend({
   url: ["/comments", "/videos/:video_id/comments", "/albums/:album_id/videos/:video_id/comments"]
 })

 // url -> /comments/1
 new Comments()
 // url -> /videos/2/comments/1
 new Comments(..., {params:{video_id:2}})
 // url -> /albums/3/videos/2/comments/1
 new Comments(..., {params:{video_id:2, album_id:3}})
```
