### PR TITLE
Models should trigger a success event when saved.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -267,7 +267,7 @@
       var success = options.success;
       options.success = function(resp, status, xhr) {
         if (!model.set(model.parse(resp, xhr), options)) return false;
-        if (success) success(model, resp, xhr);
+        success ? success(model, resp, xhr) : model.trigger('success', model, resp, options);
       };
       options.error = wrapError(options.error, model, options);
       var method = this.isNew() ? 'create' : 'update';


### PR DESCRIPTION
I have a view that is responsible for displaying error and success.  I have another view that is used to manipulate the model.  When I save I need a 'success' event so that I can display a message in the view that is responsible for displaying messages.

This may benefit other backbone users.
