### PR TITLE
put __super__ on the prototype

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1133,7 +1133,7 @@
     child.prototype.constructor = child;
 
     // Set a convenience property in case the parent's prototype is needed later.
-    child.__super__ = parent.prototype;
+    child.prototype.__super__ = parent.prototype;
 
     return child;
   };


### PR DESCRIPTION
Been doing research on extending Backbone and found this interesting bit:

``` javascript
// Set a convenience property in case the parent's prototype is needed later.
child.__super__ = parent.prototype;
```

At an initial glance it looks as if it could work this `this.__super__.someMethod`, but in reality you must call it off the `constructor` which is assigned directly above.

This patch instead places `__super__` on the prototype.

``` javascript
/* One level of extension, calling Backbone.Model.prototype.initialize */

// Current
this.constructor.__super__.initialize.call(this);

// New
this.__super__.initialize.call(this);

// Manually
Backbone.Model.prototype.initialize.call(this);
```

I figure there must be an intentional reason for why its currently set up the way it is.  Any elaboration would be great.
