### PR TITLE
Eventing

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -834,7 +834,9 @@
     navigate : function(fragment, options) {
       if (!options || options === true) options = {trigger: options};
       var frag = (fragment || '').replace(hashStrip, '');
-      if (this.fragment == frag || this.fragment == decodeURIComponent(frag)) return;
+      var handler = this._getHandler(frag);
+      if (this.fragment == frag || this.fragment == decodeURIComponent(frag)) return handler;
+    
       if (this._hasPushState) {
         if (frag.indexOf(this.options.root) != 0) frag = this.options.root + frag;
         this.fragment = frag;
@@ -850,7 +852,7 @@
         }
       }
       if (options.trigger) this.loadUrl(fragment);
-      return this._getHandler(fragment);
+      return handler;
     },
 
     // Attempt to load the current URL fragment. If a route succeeds with a

--- a/test/router.js
+++ b/test/router.js
@@ -102,6 +102,24 @@ $(document).ready(function() {
 
   });
 
+  test("Router: navigate triggers navigate event when hash unchanged", 3, function() {
+    window.location.hash = '#search/manhattan/p20';
+    var triggered = false;
+    var query = null;
+    var page = null;
+    router.bind('navigate:search', function(q, p) {
+        triggered = true;
+        query = q;
+        page = p;
+    });
+    router.navigate('search/manhattan/p20');
+    equals(triggered, true);
+    equals(query, "manhattan");
+    equals(page, "20");
+
+  });
+
+
   asyncTest("Router: routes via navigate with {replace: true}", function() {
     var historyLength = window.history.length;
     router.navigate('search/manhattan/start_here');


### PR DESCRIPTION
This patch (with test) adds a `navigate:{routeName}` to the Router which is triggered regardless of whether `{trigger:true}` is passed to `myRouter.navigate()` or not. 

I needed a unified way to respond to changes in the url and since `route:{routeName}` is only fired when the callback is invoked (ie, when landing on the page or backbuttoning) there wasn't an easy way to do this.
