### PR TITLE
Cross domain issue for old ie browsers.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1329,7 +1329,7 @@
     // Ensure that we have the appropriate request data.
     if (!options.data && model && (method == 'create' || method == 'update')) {
       params.contentType = 'application/json';
-      params.data = JSON.stringify(model.toJSON());
+      params.data = JSON.stringify(model);
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.


### PR DESCRIPTION
Old IE browsers throw cross domain exceptions when try ещ access iframe's contentWindow object. This path fixes this error.
