### PR TITLE
Collection.add now takes a 'unique' option that will guarantee model uniqueness

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -553,8 +553,10 @@
       options || (options = {});
       model = this._prepareModel(model, options);
       if (!model) return false;
-      var already = this.getByCid(model);
-      if (already) throw new Error(["Can't add the same model to a set twice", already.id]);
+      if (options.unique) {
+        var already = this.getByCid(model) || this.get(model.id);
+        if (already) throw new Error(["Can't add the same model to a set twice", already.id]);
+      }
       this._byId[model.id] = model;
       this._byCid[model.cid] = model;
       var index = options.at != null ? options.at :

--- a/index.html
+++ b/index.html
@@ -1169,7 +1169,8 @@ var alphabetical = Books.sortBy(function(book) {
       <a href="#Collection-model">model</a> property is defined, you may also pass
       raw attributes objects, and have them be vivified as instances of the model.
       Pass <tt>{at: index}</tt> to splice the model into the collection at the
-      specified <tt>index</tt>.
+      specified <tt>index</tt>. Passing <tt>{unique:true}</tt> will guarantee only 
+      unique models will be added to the collection (based on their cid or id).
     </p>
 
 <pre class="runnable">

--- a/test/collection.js
+++ b/test/collection.js
@@ -152,8 +152,33 @@ $(document).ready(function() {
       // no id, same cid
       var a2 = new Backbone.Model({label: a.label});
       a2.cid = a.cid;
-      col.add(a2);
+      col.add(a2, {unique: true});
       ok(false, "duplicate; expected add to fail");
+    } catch (e) {
+      equals(e.message, "Can't add the same model to a set twice,3");
+    }
+  });
+
+  test("Collection: add model with identical cid to collection", function() {
+    // same cid as existing model.
+    try {
+      var a2 = new Backbone.Model({label: a.label});
+      a2.cid = a.cid;
+      var l = col.length;
+      col.add(a2, {unique : true});
+      ok(col.length === l, "duplicate wasn't added.");
+    } catch (e) {
+      equals(e.message, "Can't add the same model to a set twice,3");
+    }
+  });
+
+  test("Collection: add model with identical id to collection", function() {
+    try {
+      // same id as existing model.
+      var a2 = new Backbone.Model({label: a.label, id : a.id});
+      var l = col.length;
+      col.add(a2, {unique : true});
+      ok(col.length === l, "duplicate wasn't added.");
     } catch (e) {
       equals(e.message, "Can't add the same model to a set twice,3");
     }


### PR DESCRIPTION
Currently, when adding a model to a collection, the only way uniqueness is guaranteed is by checking its cid against the existing models in the collection. Unless the models are all client-side created OR the cid is persisted, there is no way to guarantee that no duplicate models appear. 

This becomes a substantial issue when using collections with an API endpoint that returns objects that are uniquely identified using an id. Polling that API endpoint at a set interval, for example, will create many duplicates in the collection.

This pull request adds a property to the options passed to the collection.add method: `{unique : true}` that enforces a uniqueness check that relies on both cid and id (as a fallback.) This way calling add will allow for duplicates by default, but it already does for most part.

I will add a jsFiddle and a link to a blog post about this shortly.

tl;dr set unique:true to guarantee no dupe models in your collection.
