### PR TITLE
Unbind callbacks with a given context

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -78,7 +78,7 @@
     // Remove one or many callbacks. If `callback` is null, removes all
     // callbacks for the event. If `ev` is null, removes all bound callbacks
     // for all events.
-    unbind : function(ev, callback) {
+    unbind : function(ev, callback, context) {
       var calls;
       if (!ev) {
         this._callbacks = {};
@@ -89,7 +89,7 @@
           var list = calls[ev];
           if (!list) return this;
           for (var i = 0, l = list.length; i < l; i++) {
-            if (list[i] && callback === list[i][0]) {
+            if (list[i] && callback === list[i][0] && (!context || context === list[i][1])) {
               list[i] = null;
               break;
             }


### PR DESCRIPTION
Just want to find out whether this finds approval. If so, I will rebase and add specs.

Current behaviour:
Imagine two instances of a `Listener` class. They each bind their `fire` method to an event of an object, assume it's the same for both listeners:

```
object.bind('someEvent', this.fire, this)
```

Now one of the listeners gets removed for some reason. It unbinds:

```
object.unbind('someEvent', this.fire)
```

But actually, the other listener is also unbound, because the `callback` has a value of `Listener.prototype.fire` for both listeners, only the `context` differs.

This commit adds the ability to unbind only the callbacks that have a specified context, so that listeners can be unbound without affecting others. This would give `unbind` the same signature as `bind`, allowing for:

```
object.unbind('someEvent', this.fire, this)
```
