### PR TITLE
option to have pushState but no hashchange

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -758,7 +758,7 @@
       var fragment          = this.getFragment();
       var docMode           = document.documentMode;
       var oldIE             = (isExplorer.exec(navigator.userAgent.toLowerCase()) && (!docMode || docMode <= 7));
-      if (oldIE) {
+      if (oldIE && ! this._orBust) {
         this.iframe = $('<iframe src="javascript:0" tabindex="-1" />').hide().appendTo('body')[0].contentWindow;
         this.navigate(fragment);
       }
@@ -771,7 +771,7 @@
         }
       } else if ('onhashchange' in window && !oldIE) {
         $(window).bind('hashchange', this.checkUrl);
-      } else {
+      } else if (! this._orBust ) {
         setInterval(this.checkUrl, this.interval);
       }
 


### PR DESCRIPTION
I wrote this recently, and then I saw issue #803.  I think this is an applicable solution.  It doesn't provide a separate option to turn off hashchange without enabling pushState as discussed in the issue, but I'm not sure if anybody would ever disable both.
## To use.

If you want pushState in browsers that support it and regular page loads in older browsers, pass the `pushStateOrBust` to `Backbone.history.start`.
## Notes.

I think the name `pushStateOrBust` is a bad name, but I couldn't think up a better one.  Feel free to change it.
