### PR TITLE
Make collection.pluck expand id according to idAttribute

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -464,7 +464,10 @@
 
     // Pluck an attribute from each model in the collection.
     pluck : function(attr) {
-      return _.map(this.models, function(model){ return model.get(attr); });
+      return _.map(this.models, function(model){
+        attr = (attr === 'id') ? model.idAttribute : attr;
+        return model.get(attr);
+      });
     },
 
     // When you have more items than you want to add or remove individually,

--- a/test/collection.js
+++ b/test/collection.js
@@ -92,6 +92,16 @@ $(document).ready(function() {
     equals(col.pluck('label').join(' '), 'd c b a');
   });
 
+  test("Collection: pluck with non-default ids", function() {
+    var col = new Backbone.Collection();
+    var MongoModel = Backbone.Model.extend({
+      idAttribute: '_id'
+    });
+    var model = new MongoModel({_id: 100});
+    col.add(model);
+    equals(col.pluck('id')[0], 100);
+  });
+
   test("Collection: add", function() {
     var added = opts = secondAdded = null;
     e = new Backbone.Model({id: 10, label : 'e'});


### PR DESCRIPTION
Using `collection.pluck('id')` with Mongo based _id as `idAttribute` i would expect Backbone to automatically map this for me so the backend doesn't shine through.
