### PR TITLE
Use 'application/json' as content-type for all non-GET requests

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1039,9 +1039,13 @@
 
     // Ensure that we have the appropriate request data.
     if (!options.data && model && (method == 'create' || method == 'update')) {
-      params.contentType = 'application/json';
       params.data = JSON.stringify(model.toJSON());
     }
+    
+	// If the request method is anything other than GET, use 'application/json' as contentType
+	if (!options.contentType && (method == 'create' || method == 'update' || method == 'delete')) {
+		params.contentType = 'application/json';
+	}
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.
     if (Backbone.emulateJSON) {

--- a/test/sync.js
+++ b/test/sync.js
@@ -109,6 +109,7 @@ $(document).ready(function() {
     library.first().destroy();
     equals(lastRequest.url, '/library/2-the-tempest');
     equals(lastRequest.type, 'DELETE');
+    equals(lastRequest.contentType, 'application/json');
     equals(lastRequest.data, null);
   });
 
@@ -117,6 +118,7 @@ $(document).ready(function() {
     library.first().destroy();
     equals(lastRequest.url, '/library/2-the-tempest');
     equals(lastRequest.type, 'POST');
+    equals(lastRequest.contentType, 'application/json');
     equals(JSON.stringify(lastRequest.data), '{"_method":"DELETE"}');
     Backbone.emulateHTTP = Backbone.emulateJSON = false;
   });


### PR DESCRIPTION
For consistency, all non-GET requests handled by Backbone.sync should use the 'application/json' content-type. Right now, Backbone does this for PUT and POST (i.e. 'create' and 'update') but not for DELETE ('destroy'). This is important as the developer may modify the DELETE request data to be non-null (either through options.data or using $.ajaxSend) and expect that they can pass in JSON data.

An example case of where this is applicable is when using Rails' authenticity token for non-GET requests to protect against forgery that modifies a user's data on the server.
