### PR TITLE
Add support for sending only updated attributes on Backbone.sync

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -265,7 +265,7 @@
       var model = this;
       // If a partialUpdate is required, create a member on the options
 	  // hash called updateAttrs and set it to attrs
-	  if (options.partialUpdate != "undefined" && options.partialUpdate) {
+	  if (options.partialUpdate != undefined && options.partialUpdate) {
 	    options.updateAttrs = attrs;
 	  }
       var success = options.success;
@@ -1048,7 +1048,7 @@
 	  
 	  // If doing a partial model update, then grab the updateAttrs 
       // member from options.
-      params.data = (options.partialUpdate != "undefined" && options.partialUpdate)
+      params.data = (options.partialUpdate != undefined && options.partialUpdate)
                   ? params.data = JSON.stringify(options.updateAttrs)
                   : params.data = JSON.stringify(model.toJSON());
     }

--- a/test/sync.js
+++ b/test/sync.js
@@ -57,6 +57,18 @@ $(document).ready(function() {
     equals(data.author, 'William Shakespeare');
     equals(data.length, 123);
   });
+  
+  test("sync: partial update", function() {
+    library.first().save({id: '1-the-tempest', author: 'William Shakespeare'}, {partialUpdate: true});
+    equals(lastRequest.url, '/library/1-the-tempest');
+    equals(lastRequest.type, 'PUT');
+    equals(lastRequest.dataType, 'json');
+    var data = JSON.parse(lastRequest.data);
+    equals(data.id, '1-the-tempest');
+    equals(data.title, undefined);
+    equals(data.author, 'William Shakespeare');
+    equals(data.length, undefined);
+  });
 
   test("sync: update with emulateHTTP and emulateJSON", function() {
     Backbone.emulateHTTP = Backbone.emulateJSON = true;


### PR DESCRIPTION
For large models that are being updated with only a few attributes, it can be useful to send only the changed data to the server for persistence. This reduces data traffic and request time and can simplify server-side code.

To enable this partial update, users can pass `{partialUpdate: true}` in options hash of Model.save:

``` javascript
var book = new Backbone.Model({
  title: "The Rough Riders",
  author: "Theodore Roosevelt"
});

book.save(); // request.data => {"title": "The Rough Riders", "author": "Theodore Roosevelt"}

book.save({author: "Teddy"}); // request.data => {"title": "The Rough Riders", "author": "Teddy"}

book.save({author: "Mr. Roosevelt"}, {partialUpdate: true}); // request.data => {"author": "Mr. Roosevelt"}
```
