### PR TITLE
For some View which inherits from Backbone.View, if View.prototype.attri...

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -979,6 +979,7 @@
     _ensureElement : function() {
       if (!this.el) {
         var attrs = this.attributes || {};
+        if (_.isFunction(attrs)) attrs = attrs();
         if (this.id) attrs.id = this.id;
         if (this.className) attrs['class'] = this.className;
         this.el = this.make(this.tagName, attrs);


### PR DESCRIPTION
...butes is a method (e.g. one that serializes the View's form elements), invoke it from Backbone.View.prototype._ensureElement before passing it to jQuery.fn.attr in Backbone.View.prototype.make to avoid an exception being thrown when using jQuery 1.7.1+ (jQuery checks for typeof(name) === 'object' rather than 'function', so it attempts to use the function as a string and invokes the *.toLowerCase() method on it)
