### PR TITLE
hasChanged/set should use the same comparison

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -325,7 +325,7 @@
     // Determine if the model has changed since the last `"change"` event.
     // If you specify an attribute name, determine if that attribute has changed.
     hasChanged : function(attr) {
-      if (attr) return this._previousAttributes[attr] != this.attributes[attr];
+      if (attr) return !_.isEqual(this._previousAttributes[attr], this.attributes[attr]);
       return this._changed;
     },
 

--- a/test/model.js
+++ b/test/model.js
@@ -480,4 +480,17 @@ $(document).ready(function() {
     equal(counter, 1, 'change is only triggered once');
   });
 
+  test("hasChanged/set should use same comparison", function() {
+    expect(2);
+    var changed = 0, model = new Backbone.Model({a: null});
+    model.bind('change', function() {
+      ok(this.hasChanged('a'));
+    })
+    .bind('change:a', function() {
+      changed++;
+    })
+    .set({a: undefined});
+    equal(changed, 1);
+  });
+
 });


### PR DESCRIPTION
When setting a value, if hasChanged and set disagree about equality then hasChanged will return true without firing a 'changed:*' event (or vice versa).  Using the same comparison (_.isEqual) solves this problem.
