### PR TITLE
ID for Backbone.Model loaded from properties

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -564,9 +564,9 @@
     _add : function(model, options) {
       model = this._prepareModel(model, options);
       if (!model) return false;
-      var already = this.getByCid(model);
-      if (already) throw new Error(["Can't add the same model to a set twice", already.id]);
-      this._byId[model.id] = model;
+      var already = this.getByCid(model) || this.get(model.get(model.id));
+      if (already) throw new Error(["Can't add the same model to a set twice", (already.get(already.id) || already.id)]);
+      this._byId[model.get(model.id)] = model;
       this._byCid[model.cid] = model;
       if (options.at != null) {
         this.models.splice(options.at, 0, model);


### PR DESCRIPTION
Changing the Backbone.Model.id for an String allows the user to get an id from the model properties.
It makes easier to prevent data retrieved from the Backbone.Collection.fetch be added twice once that this way you can use the id from the db to the model.
I had some difficulties with this retrieving data directly from mongodb, so this way I could use '_id' provided by mongo as model id.
hope it's useful.
