### PR TITLE
Switch order of delegateEvents and initialize in View constructor

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -879,8 +879,8 @@
     this.cid = _.uniqueId('view');
     this._configure(options || {});
     this._ensureElement();
-    this.delegateEvents();
     this.initialize.apply(this, arguments);
+    this.delegateEvents();
   };
 
   // Cached regex to split keys for `delegate`.


### PR DESCRIPTION
I believe that events should be bound to a view's element after the initialize function runs and not before hand.

I encountered a strange bug when I manually set `this.el` in my view's initialize function. The reason I needed to set `this.el` in initialize (rather than simply use `el: some_element` in `MyView.extend`) is that it chooses a DOM Element based on an argument to initialize. This allowed me to include the element in my HTML template, and only lazily load this reusable view.

I couldn't think of any cases in which it would be detrimental to delegate events earlier, but please let me know whether (and how) this behavior is intended and necessary.
## Use Case

Here's a distilled example to clarify this issue:

``` javascript
var ReusableView = Backbone.View.Extend({
  className: "reusable_view",
  events: {
    "click": "doSomething"
  },
  initialize: function(someElement) {
    this.el = someElement;
  }
});

new ReusableView(domElementOne);
new ReusableView(domElementTwo);
```

Clicking on `domElementOne` or `domElementTwo` does nothing. The `doSomething` callback was bound to some element generated by `Backbone.View.make`, which was then immediately replaced by my initialize function.

Thanks!
