### PR TITLE
Validation can determine if the document is about to be saved, and validations can be skipped

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -261,9 +261,10 @@
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
     save : function(attrs, options) {
-      options || (options = {});
+      (options || (options = {})).saving = true;
       if (attrs && !this.set(attrs, options)) return false;
       if (!attrs && this.validate && !this._performValidation({}, options)) return false;
+      delete options.saving;
       var model = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {

--- a/test/model.js
+++ b/test/model.js
@@ -312,6 +312,28 @@ $(document).ready(function() {
     equals(lastError, "Can't change admin status.");
   });
 
+  test("Model: validate only if it's being saved", function() {
+    var lastError, model = new Backbone.Model({name: "Tim"});
+    model.validate = function(attrs, options) {
+      attrs = _.extend(model.attributes, attrs);
+      if (options.saving)
+        if (attrs.name === "") return "Can't have a blank name.";
+    };
+    ok(model.set({name: ''}), 'should allow name to be blank temporarily');
+
+    model.save(null, {error: function(model, error) {
+      lastError = error;
+    }});
+    equals(lastError, "Can't have a blank name.");
+
+    model.set({name: 'Bob'});
+    model.sync = function(method, model, options) {
+      options.success.call(this, {name: ''});
+    };
+    model.save();
+    equals(model.get('name'), "");
+  });
+
   test("Model: save", function() {
     doc.save({title : "Henry V"});
     equals(lastRequest[0], 'update');


### PR DESCRIPTION
Added two new options that can be used during validations:
- skipValidation: true - obviously skips the validation process while updating the model.
- saving: true - this is passed to the validation function automatically when a save call is made on the model. It allows the validation logic to be sensitive to whether or not a save is happening.

The main reason for this is to allow a model to enter an invalid state, but still ensure the object is valid before saving.

For example, a person model is being updated by a user.  I want the change events to fire because I want other views on the page displaying this data to update as the user types. While a user is editing, they might empty the name field which is invalid, but I want to allow that while still ensuring validation fires when the object is about to saved.
