### PR TITLE
More compatible reference to global scope

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -10,7 +10,9 @@
   // -------------
 
   // Save a reference to the global object.
-  var root = this;
+  var root = (function () {
+    return this || (0 || eval)('this');
+  }());
 
   // Save the previous value of the `Backbone` variable.
   var previousBackbone = root.Backbone;


### PR DESCRIPTION
Given some environments for including Backbone into a project, the access to the global object is not always as expected. For example, in ECMAScript 5 strict mode, and when the Backbone library is being wrapped.

I use the snippet added by this pull request in some libraries, but it's not my work. I really wish I could find the blog post which outlined the full reasoning behind it. [This answer on Stack Overflow](http://stackoverflow.com/a/6930376/9021) touches some of the same reasons, though the answer given there is different. That method doesn't pass JSLint (and this method does).
