### PR TITLE
Router: Use implicit callback if none provided

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -697,6 +697,7 @@
     route : function(route, name, callback) {
       Backbone.history || (Backbone.history = new Backbone.History);
       if (!_.isRegExp(route)) route = this._routeToRegExp(route);
+      if (!callback) callback = this[name];
       Backbone.history.route(route, _.bind(function(fragment) {
         var args = this._extractParameters(route, fragment);
         callback && callback.apply(this, args);

--- a/test/router.js
+++ b/test/router.js
@@ -19,9 +19,14 @@ $(document).ready(function() {
 
     initialize : function(options) {
       this.testing = options.testing;
+      this.route('implicit', 'implicit');
     },
 
     counter: function() {
+      this.count++;
+    },
+
+    implicit: function() {
       this.count++;
     },
 
@@ -112,6 +117,12 @@ $(document).ready(function() {
     router.navigate('search/counter', {trigger: true});
     router.navigate('counter', {trigger: true});
     equals(router.count, 2);
+  });
+
+  test("Router: use implicit callback if none provided", function() {
+    router.count = 0;
+    router.navigate('implicit', {trigger: true})
+    equals(router.count, 1);
   });
 
   asyncTest("Router: routes via navigate with {replace: true}", function() {


### PR DESCRIPTION
I find it a bit redundant to do

```
this.route('...', 'foo', this.foo);
```

and I think we could shorten this to

```
this.route('...', 'foo');
```
