### PR TITLE
fix for issue 868

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -871,7 +871,7 @@
     checkUrl : function(e) {
       var current = this.getFragment();
       if (current == this.fragment && this.iframe) current = this.getFragment(this.iframe.location.hash);
-      if (current == this.fragment || current == decodeURIComponent(this.fragment)) return false;
+      if (current == this.fragment || current == this.fragment) return false;
       if (this.iframe) this.navigate(current);
       this.loadUrl() || this.loadUrl(window.location.hash);
     },


### PR DESCRIPTION
I am not sure if it is correct logically, please review.
This patch is preventing URIError: URI malformed exception for me.
You can reproduce the exception by passing "%" symbol into the Backbone.Router
which will trigger Backbone.History.checkUrl call.

Related issue https://github.com/documentcloud/backbone/issues/868
