### PR TITLE
Set defaults correctly when a model is provided

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -153,6 +153,7 @@
   Backbone.Model = function(attributes, options) {
     var defaults;
     attributes || (attributes = {});
+    if (attributes instanceof Backbone.Model) attributes = attributes.attributes;
     if (options && options.parse) attributes = this.parse(attributes);
     if (defaults = getValue(this, 'defaults')) {
       attributes = _.extend({}, defaults, attributes);

--- a/test/model.js
+++ b/test/model.js
@@ -537,4 +537,12 @@ $(document).ready(function() {
     ok(model.has('attributes'));
   });
 
+  test("pass model to constructor with defaults", function() {
+    var Model = Backbone.Model.extend({defaults: {a: 1}});
+    var model = new Model(new Model({b: 2}));
+    equal(model.get('a'), 1);
+    equal(model.get('b'), 2);
+    equal(_.keys(model.attributes).length, 2);
+  });
+
 });


### PR DESCRIPTION
Passing another model to Backbone.Model causes incorrect
assignment of attributes if defaults are supplied.  By
checking for instances of Backbone.Model beforehand we
can avoid the issue like we do in set.
