### PR TITLE
Setting Undefined Attributes

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -239,11 +239,11 @@
       for (attr in attrs) {
         val = attrs[attr];
         if (!_.isEqual(now[attr], val) || (options.unset && (attr in now))) {
-          options.unset ? delete now[attr] : now[attr] = val;
           delete escaped[attr];
           this._changed = true;
           changes[attr] = val;
         }
+        options.unset ? delete now[attr] : now[attr] = val;
       }
 
       // Fire `change:attribute` events.

--- a/test/model.js
+++ b/test/model.js
@@ -537,4 +537,22 @@ $(document).ready(function() {
     ok(model.has('attributes'));
   });
 
+  test("set value regardless of equality/change", function() {
+    var model = new Backbone.Model({x: []});
+    var a = [];
+    model.set({x: a});
+    ok(model.get('x') === a);
+  });
+
+  test("unset fires change for undefined attributes", 1, function() {
+    var model = new Backbone.Model({x: undefined});
+    model.bind('change:x', function(){ ok(true); });
+    model.unset('x');
+  });
+
+  test("set: undefined values", function() {
+    var model = new Backbone.Model({x: undefined});
+    ok('x' in model.attributes);
+  });
+
 });


### PR DESCRIPTION
- undefined attrs should still be set
- unset triggers change for undefined attrs
- values are set regardless of change/equality

Currently, when setting an attribute as `undefined` it is not actually added to `attributes`.  I think the property should be added even if it is undefined.

```
'x' in new Backbone.Model({x: undefined}).attributes; // should be true
```

Also, I think an equal value should still be set, even if `'change'` is not fired.

```
var a = [];
var model = new Backbone.Model({x: []});
model.set({x: a});  // does not fire 'change'
model.get('x') === a;  // should be true
```

I realize this is a significant change in semantics, but I think it's much more intuitive.  Have I overlooked any problems this may cause?
