### PR TITLE
Collection creation with models should pass the specified options through to reset method instead of overriding them

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -447,7 +447,7 @@
     if (options.comparator) this.comparator = options.comparator;
     this._reset();
     this.initialize.apply(this, arguments);
-    if (models) this.reset(models, {silent: true});
+    if (models) this.reset(models, _.extend(options, {silent: true}));
   };
 
   // Define the Collection's inheritable methods.


### PR DESCRIPTION
This allows the creation of a collection with {parse: true} option to
work as expected.
