### PR TITLE
Add chaining support to Router methods

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -743,11 +743,13 @@
         this.trigger.apply(this, ['route:' + name].concat(args));
         Backbone.history.trigger('route', this, name, args);
       }, this));
+	  return this;
     },
 
     // Simple proxy to `Backbone.history` to save a fragment into the history.
     navigate: function(fragment, options) {
       Backbone.history.navigate(fragment, options);
+	  return this;
     },
 
     // Bind all defined routes to `Backbone.history`. We have to reverse the


### PR DESCRIPTION
I like to add routes using regexes in batches. This patch allows chaining of `route()` and `navigate()` methods.
