### PR TITLE
Made minor optimization to scoped jQuery/Zepto method $ on the Backbone.View

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -996,7 +996,7 @@
     // jQuery delegate for element lookup, scoped to DOM elements within the
     // current view. This should be prefered to global lookups where possible.
     $: function(selector) {
-      return $(this.el).find(selector);
+      return this.$el.find(selector);
     },
 
     // Initialize is an empty function by default. Override it with your own


### PR DESCRIPTION
The context parameter of the jQuery/Zepto selector method simply gets rewritten internally to basically: `$(context).find(selector)`. This pull requests just makes that optimization up front to avoid the additional object creation and function call.

From Zepto.js (zepto.js), [Line 81](https://github.com/madrobby/zepto/blob/master/src/zepto.js#L81):

``` javascript
if (context !== undefined) return $(context).find(selector);
```

From jQuery (core.js), [Lines 168 – 172](https://github.com/jquery/jquery/blob/master/src/core.js#L168-172):

``` javascript
// HANDLE: $(expr, context)
// (which is just equivalent to: $(context).find(expr)
} else {
    return this.constructor( context ).find( selector );
}
```
