### PR TITLE
Fix parsing in `getFragment`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -815,8 +815,9 @@
           fragment = window.location.hash;
         }
       }
-      fragment = decodeURIComponent(fragment.replace(routeStripper, ''));
-      if (!fragment.indexOf(this.options.root)) fragment = fragment.substr(this.options.root.length);
+      fragment = decodeURIComponent(fragment);
+      if (fragment.indexOf(this.options.root) > -1) fragment = fragment.substr(this.options.root.length);
+      fragment = fragment.replace(routeStripper, '');
       return fragment;
     },
 


### PR DESCRIPTION
Two issues:
- `fragment.indexOf` logic was incorrect. Changed to check for > -1.
- Slash was being stripped off the fragment before `indexOf` took place.
  Since `root` is in the format "/publich/search/", `routeStripper` must
  take place after checking `indexOf`.

It appears this bug was introduced in #786.

Fix #905
