### PR TITLE
Return `this` from View.setElement()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1031,6 +1031,7 @@
       this.$el = $(element);
       this.el = this.$el[0];
       if (delegate !== false) this.delegateEvents();
+      return this;
     },
 
     // Set callbacks, where `this.events` is a hash of


### PR DESCRIPTION
Love the new `setElement` method - replaces a bunch of cruft in our application with one simple call whenever a View is reused.

One tiny change I made is to return the View (`this`) from the method so that I can go e.g.:

``` javascript
myView.setElement('#element').render();
```

...instead of making those two calls separately.

Seems like a logical addition to me and I couldn't see a solid reason for not returning anything from the method, correct me if I'm wrong.

Thanks!
