### PR TITLE
use `$` as DOM abstraction library

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -38,7 +38,7 @@
   if (!_ && (typeof require !== 'undefined')) _ = require('underscore');
 
   // For Backbone's purposes, jQuery, Zepto, or Ender owns the `$` variable.
-  var $ = root.jQuery || root.Zepto || root.ender;
+  var $ = root.jQuery || root.Zepto || root.ender || root.$;
 
   // Runs Backbone.js in *noConflict* mode, returning the `Backbone` variable
   // to its previous owner. Returns a reference to this Backbone object.


### PR DESCRIPTION
#551 discusses providing a method for telling Backbone what DOM abstraction library to use.  I propose that this is not necessary and can be done very simply by using the current value of `root.$`.  Since jQuery, Zepto, and Ender expose themselves as `$` already this is a backwards compatible change in most cases.  Using `root.$` to represent a DOM abstraction library is already a de facto standard besides being simple and intuitive.
