### PR TITLE
fixes #928 - Save sends correct attrs.

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -1,12 +1,21 @@
 $(document).ready(function() {
 
-  module("Backbone.Collection");
+  var lastRequest = null;
+  var sync = Backbone.sync;
 
-  window.lastRequest = null;
+  module("Backbone.Collection", {
 
-  Backbone.sync = function() {
-    lastRequest = _.toArray(arguments);
-  };
+    setup: function() {
+      Backbone.sync = function() {
+        lastRequest = _.toArray(arguments);
+      };
+    },
+
+    teardown: function() {
+      Backbone.sync = sync;
+    }
+
+  });
 
   var a         = new Backbone.Model({id: 3, label: 'a'});
   var b         = new Backbone.Model({id: 2, label: 'b'});

--- a/test/sync.js
+++ b/test/sync.js
@@ -1,11 +1,21 @@
 $(document).ready(function() {
 
-  module("Backbone.sync", {setup : function() {
-    window.lastRequest = null;
-    $.ajax = function(obj) {
-      lastRequest = obj;
-    };
-  }});
+  var ajax = $.ajax
+  var lastRequest = null;
+
+  module("Backbone.sync", {
+
+    setup : function() {
+      $.ajax = function(obj) {
+        lastRequest = obj;
+      };
+    },
+
+    teardown: function() {
+      $.ajax = ajax;
+    }
+
+  });
 
   var Library = Backbone.Collection.extend({
     url : function() { return '/library'; }
@@ -20,7 +30,6 @@ $(document).ready(function() {
   };
 
   test("sync: read", function() {
-    Backbone.sync = originalSync;
     library.fetch();
     equal(lastRequest.url, '/library');
     equal(lastRequest.type, 'GET');


### PR DESCRIPTION
- Temporarily set model's attrs for `sync`.
- Remove cross-module (global) dependencies in
  Collection, Model, and sync test modules.

Setting the model's attributes temporarily with `{silent: true}` allows `Backbone.sync` to work with the correct attributes.
