### PR TITLE
The routeStripper is applied too early

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -820,8 +820,8 @@
           fragment = window.location.hash;
         }
       }
-      fragment = decodeURIComponent(fragment.replace(routeStripper, ''));
       if (!fragment.indexOf(this.options.root)) fragment = fragment.substr(this.options.root.length);
+      fragment = decodeURIComponent(fragment.replace(routeStripper, ''));
       return fragment;
     },
 


### PR DESCRIPTION
Because of that the indexOf can never match because the leading / is gone. Placing it right after begets the same effect but works. Note: without this the root functionality seems to be completely broken because either you don't use a leading / and it works in this part of the code but it breaks navigate(), or you do and the reverse breaks.
