### PR TITLE
Adds string cleanup before decoding

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -820,6 +820,7 @@
 
   // Cached regex for cleaning leading hashes and slashes .
   var routeStripper = /^[#/]/;
+  var invalidUriDecode = /[%][a-zA-Z0-9]{0,1}/;
 
   // Cached regex for detecting MSIE.
   var isExplorer = /msie [\w.]+/;
@@ -846,7 +847,7 @@
           fragment = window.location.hash;
         }
       }
-      fragment = decodeURIComponent(fragment);
+      fragment = decodeURIComponent(fragment.replace(invalidUriDecode, ''));
       if (!fragment.indexOf(this.options.root)) fragment = fragment.substr(this.options.root.length);
       return fragment.replace(routeStripper, '');
     },

--- a/test/router.js
+++ b/test/router.js
@@ -208,4 +208,12 @@ $(document).ready(function() {
     equal(history.getFragment('/root/foo'), 'foo');
   });
 
+  asyncTest("#945 - URI malformed error when decoding %25 ", function() {
+    window.location.hash = '/search?q=foo%25&baz';
+    setTimeout(function() {
+      start();
+      window.location.hash = '/search?q=bar';
+    }, 10);
+  });
+
 });


### PR DESCRIPTION
Cleans the fragment before decoding to avoid scenarios as described in: https://github.com/documentcloud/backbone/issues/945
