### PR TITLE
Fixes #959

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -251,7 +251,6 @@
         if (!_.isEqual(now[attr], val)) delete escaped[attr];
         options.unset ? delete now[attr] : now[attr] = val;
         if (!options.silent && this._changing && !_.isEqual(this._changed[attr], val)) {
-          this.trigger('change:' + attr, this, val, options);
           this._moreChanges = true;
         }
         delete this._changed[attr];
@@ -394,12 +393,12 @@
       if (this._changing || !this.hasChanged()) return this;
       this._changing = true;
       this._moreChanges = true;
-      for (var attr in this._changed) {
-        this.trigger('change:' + attr, this, this._changed[attr], options);
-      }
       while (this._moreChanges) {
         this._moreChanges = false;
         this.trigger('change', this, options);
+      }
+      for (var attr in this._changed) {
+        this.trigger('change:' + attr, this, this._changed[attr], options);
       }
       this._previousAttributes = _.clone(this.attributes);
       delete this._changed;

--- a/test/model.js
+++ b/test/model.js
@@ -701,9 +701,13 @@ $(document).ready(function() {
 
   test("#959 Setting an attribute with options silent:true during change event propagation should not lock the application in infinite loop", function() {
     var count = 0;
+    var acount = 0;
+    var bcount = 0;
     var Model = Backbone.Model.extend({
       initialize: function() {
         this.bind('change', _.bind(this.silentlySetAttribute, this));
+        this.bind('change:a', _.bind(this.aChange, this));
+        this.bind('change:b', _.bind(this.bChange, this));
         this.set({'a': 1});
       },
       silentlySetAttribute: function() {
@@ -712,10 +716,23 @@ $(document).ready(function() {
           return;
         } 
         this.set({'a': Math.random() * 1000}, {silent: true});
+        this.set({'b': Math.random() * 1000}, {silent: true});
+      },
+      aChange: function() {
+        acount++;
+      },
+      bChange: function() {
+        bcount++;
       }
     });
     var m = new Model();
     equal(count, 1, "Callback should be called once");
+    equal(acount, 1, "change:a call count should be 1");
+    equal(bcount, 1, "change:b call count should be 1");
+    m.set('a', 10, { silent: true });
+    equal(acount, 1, "change:a call count should be 1");
+    m.change();
+    equal(acount, 2, "change:a call count should be 2");
   });
 
 });


### PR DESCRIPTION
Fixes #959 by preventing triggering attr change event triggered during the change propagation if `options.silent` is set to true as otherwise it keeps resetting `this._moreChanges` to true and locks application in infinite loop (at line 400 `while (this._moreChanges)`)
