### PR TITLE
`sort` and `sortBy` are incorrectly swopped in collection.comparator docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1420,9 +1420,9 @@ var book = Library.get(110);
     </p>
 
     <p>
-      "sort" comparator functions take a model and return a numeric or string
+      "sortBy" comparator functions take a model and return a numeric or string
       value by which the model should be ordered relative to others.
-      "sortBy" comparator functions take two models, and return <tt>-1</tt> if
+      "sort" comparator functions take two models, and return <tt>-1</tt> if
       the first model should come before the second, <tt>0</tt> if they are of
       the same rank and <tt>1</tt> if the first model should come after.
     </p>


### PR DESCRIPTION
http://documentcloud.github.com/backbone/#Collection-comparator

sort and sortBy are swopped around in colleciton.comparator documents:

"sort" comparator functions take a model and return a numeric or string value by which the model should be ordered relative to others. "sortBy" comparator functions take two models, and return -1 if the first model should come before the second, 0 if they are of the same rank and 1 if the first model should come after.

sortBy takes one argument; sort takes two.
