### PR TITLE
This addresses Issue #955

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -646,6 +646,38 @@
       return this;
     },
 
+    // When you want to update a subset of models for this collection,
+    // adding missing models, update existing and and optionally remove missing models.
+    // If `prune: true` is passed, the collection is pruned of the models not present in
+    // the method's models argument.
+    update : function(models, options) {
+      var i, index, length, dummyModel, model, index, stack = [];
+      options = options ? _.clone(options) : {};
+      models = _.isArray(models) ? models.slice() : [models];
+      if (this.models.length) {
+        for (i = 0, length = this.models.length; i < length; i++) {
+          stack.push(this.models[i].id);
+        }
+      }
+      for (i = 0, length = models.length; i < length; i++) {
+        dummyModel = this._prepareModel(models[i], options);
+        model = this.get(dummyModel);
+        if (model) {
+          model.set(models[i], options);
+          index = _.indexOf(stack, model.id);
+          stack.splice(index, 1);
+        } else {
+          this.add(dummyModel, options);
+        }
+      }
+      if (options.prune) {
+        for (i = 0, length = stack.length; i < length; i++) {
+          this.remove( stack[i] );
+        }
+      }
+      return this;
+    },
+
     // Fetch the default set of models for this collection, resetting the
     // collection when they arrive. If `add: true` is passed, appends the
     // models to the collection instead of resetting.
@@ -655,7 +687,7 @@
       var collection = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {
-        collection[options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
+        collection[options.update ? 'update' : options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
         if (success) success(collection, resp);
       };
       options.error = Backbone.wrapError(options.error, collection, options);

--- a/index.html
+++ b/index.html
@@ -276,6 +276,7 @@
       <li>– <a href="#Collection-parse">parse</a></li>
       <li>– <a href="#Collection-fetch">fetch</a></li>
       <li>– <a href="#Collection-reset">reset</a></li>
+      <li>– <a href="#Collection-update">update</a></li>
       <li>– <a href="#Collection-create">create</a></li>
     </ul>
 
@@ -1225,8 +1226,8 @@ bill.set({name : "Bill Jones"});
       Override this property to specify the model class that the collection
       contains. If defined, you can pass raw attributes objects (and arrays) to
       <a href="#Collection-add">add</a>, <a href="#Collection-create">create</a>,
-      and <a href="#Collection-reset">reset</a>, and the attributes will be
-      converted into a model of the proper type.
+      <a href="#Collection-reset">reset</a> and <a href="#Collection-update">update</a>,
+      after which the attributes will be converted into a model of the proper type.
     </p>
 
 <pre>
@@ -1556,7 +1557,14 @@ Accounts.fetch();
     <p>
       If you'd like to add the incoming models to the current collection, instead
       of replacing the collection's contents, pass <tt>{add: true}</tt> as an
-      option to <b>fetch</b>.
+      option to <b>fetch</b>. Note that the <tt>"reset"</tt> event will not trigger.
+    </p>
+
+    <p>
+      Alternatively, if you'd like to update existing models in the collection instead,
+      pass <tt>{update: true}</tt> as an option to <b>fetch</b>. In addition if you would like
+      to prune models from the collection missing in the response, pass <tt>{prune: true}</tt>
+      to remove them.
     </p>
 
     <p>
@@ -1601,6 +1609,15 @@ Accounts.fetch();
       will empty the entire collection.
     </p>
 
+    <p id="Collection-update">
+      <b class="header">update</b><code>collection.update(models, [options])</code>
+      <br />
+      Updates a model (or an array of models) on the collection; contrary to the <b>reset</b>
+      method, the <b>update</b> method doesn't replace the existing models. On receiving the response,
+      a missing model will be added, triggering an <tt>"add"</tt> event on the collection, whereas an
+      updated model will have its attributes overloaded and trigger a <tt>"change"</tt> event.
+    </p>
+
     <p id="Collection-create">
       <b class="header">create</b><code>collection.create(attributes, [options])</code>
       <br />
@@ -1616,10 +1633,10 @@ Accounts.fetch();
     </p>
 
     <p>
-      Creating a model will cause an immediate <tt>"add"</tt> event to be
-      triggered on the collection, as well as a <tt>"sync"</tt> event, once the
-      model has been successfully created on the server. Pass <tt>{wait: true}</tt>
-      if you'd like to wait for the server before adding the new model to the collection.
+      Creating a model will cause an immediate <tt>"add"</tt> event to trigger on the collection,
+      as well as a <tt>"sync"</tt> event, once the model has been successfully created on the server.
+      Pass <tt>{wait: true}</tt> if you'd like to wait for the server before adding the new model
+      to the collection.
     </p>
 
 <pre>
@@ -2386,18 +2403,18 @@ var model = localBackbone.Model.extend(...);
         <img src="docs/images/wunderkit.png" alt="Wunderkit" class="example_image" />
       </a>
     </div>
-    
+
     <h2 id="examples-khan-academy">Khan Academy</h2>
 
     <p>
-      <a href="http://www.khanacademy.org">Khan Academy</a> is on a mission to 
-      provide a free world-class education to anyone anywhere. With thousands of 
-      videos, hundreds of JavaScript-driven exercises, and big plans for the 
-      future, Khan Academy uses Backbone to keep frontend code modular and organized. 
-      <a href="https://khanacademy.kilnhg.com/Code/Website/Group/stable/Files/javascript/profile-package?rev=tip">User profiles</a> 
-      and <a href="https://khanacademy.kilnhg.com/Code/Website/Group/stable/File/javascript/shared-package/goals.js?rev=tip">goal setting</a> 
-      are implemented with Backbone, jQuery and Handlebars, and most new feature 
-      work is being pushed to the client side, greatly increasing the quality of 
+      <a href="http://www.khanacademy.org">Khan Academy</a> is on a mission to
+      provide a free world-class education to anyone anywhere. With thousands of
+      videos, hundreds of JavaScript-driven exercises, and big plans for the
+      future, Khan Academy uses Backbone to keep frontend code modular and organized.
+      <a href="https://khanacademy.kilnhg.com/Code/Website/Group/stable/Files/javascript/profile-package?rev=tip">User profiles</a>
+      and <a href="https://khanacademy.kilnhg.com/Code/Website/Group/stable/File/javascript/shared-package/goals.js?rev=tip">goal setting</a>
+      are implemented with Backbone, jQuery and Handlebars, and most new feature
+      work is being pushed to the client side, greatly increasing the quality of
       <a href="https://github.com/Khan/khan-api/">the API</a>.
     </p>
 
@@ -2829,14 +2846,14 @@ var model = localBackbone.Model.extend(...);
         <img src="docs/images/ducksboard.png" alt="Ducksboard" class="example_image" />
       </a>
     </div>
-    
+
     <h2 id="examples-picklive">Picklive</h2>
 
     <p>
       <a href="http://twitter.com/timruffles">Tim Ruffles</a> and <a href="http://twitter.com/timparker">Tim Parker</a>
       created the game client for <a href="https://free.picklive.com">Picklive</a>, a real-time fantasy-soccer game.
       The client is written in <a href="http://coffeescript.org">CoffeeScript</a>, organised into
-      modules via <a href="http://requirejs.org">require.js</a>, tested with 
+      modules via <a href="http://requirejs.org">require.js</a>, tested with
       <a href="http://code.google.com/p/js-test-driver">jsTestDriver</a> and uses
       <a href="http://mustache.github.com">Mustache.js</a> for templating. Backbone's model and sync layer separation
       manages the complexity of mixed polling and web-sockets based synchronisation.

--- a/test/collection.js
+++ b/test/collection.js
@@ -427,6 +427,27 @@ $(document).ready(function() {
     ok(_.isEqual(col.last().attributes, a.attributes));
   });
 
+  test("Collection: update", function() {
+    var col = new Backbone.Collection;
+    var models = [a,b,c,d];
+    col.update(models)
+    equals(col.length, 4);
+    var e = new Backbone.Model({id: 5, title: 'e'});
+    e.sync = function(method, model, options) { options.success({}); };
+    col.update([e]);
+    equals(col.length, 5);
+    col.update([e], {prune: true});
+    equals(col.length, 1);
+    col.update(models);
+    equals(col.length, 5);
+    col.update(models, {prune: true});
+    equals(col.length, 4);
+    col.update([]);
+    equals(col.length, 4);
+    col.update([], {prune: true});
+    equals(col.length, 0);
+  });
+
   test("Collection: trigger custom events on models", function() {
     var fired = null;
     a.bind("custom", function() { fired = true; });


### PR DESCRIPTION
I realise this doesn't necessarily fit into the ethos of Backbone, it being a direct mapping to the methodology of RESTful applications, regardless I amongst others thought this could be a very good addition to Backbone. It's especially handy there where serverside collections don't need to match clientside collections but are populated using the `data` option passed in `collection.fetch` which could potentially filter serverside requests. 

The handy endresult of this is that existing models don't get destroyed, whereas the `reset` trigger would dictate you to re-render your views, using  `collection.update` would merely update them and remove obsolete models from your collection.

**update existing models**:

``` javascript
collection.fetch({update: true}); // either 
collection.update(models); // or
```

**update existing models but prune missing**:

``` javascript
collection.fetch({update: true, prune: true}); // either
collection.update(models, {prune: true}); // or
```
