### PR TITLE
Backbone.Events.proxy

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -149,6 +149,16 @@
         }
       }
       return this;
+    },
+
+    //proxy all events from the source object to the current object
+    proxy: function(source, events) {
+      _.each(events.split(/\s+/), function(eventName) {
+        source.on(eventName, function() {
+          this.trigger.apply(this, [eventName].concat(_.toArray(arguments)));
+        }, this);
+      }, this);
+      return this;
     }
 
   };

--- a/test/events.js
+++ b/test/events.js
@@ -145,4 +145,18 @@ $(document).ready(function() {
     equal(counter, 2, 'unbind does not alter callback list');
   });
 
+  test("Events: proxy events from one object to another", function() {
+    var a = _.extend({}, Backbone.Events);
+    var b = _.extend({}, Backbone.Events);
+    var counter = 0;
+    b.proxy(a, 'event:a event:b')
+      .bind('event:a event:b', function(argOne, argTwo) {
+        equal(argOne, 'one');
+        equal(argTwo, 'two');
+        ++counter;
+      });
+    a.trigger('event:a event:b', 'one', 'two');
+    equal(counter, 2);
+  });
+
 });


### PR DESCRIPTION
Proxy events and arguments from one object to another. Usage:

```
var a = _.extend({}, Backbone.Events);
var b = _.extend({}, Backbone.Events);
b.proxy(a, 'event').bind('event', function() {

});
a.trigger('event');
```
