### PR TITLE
Added an isHistoryStarted method to Backbone.history

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -866,7 +866,10 @@
 
   // Set up all inheritable **Backbone.History** properties and methods.
   _.extend(Backbone.History.prototype, Backbone.Events, {
-
+    // Expose a method to test for history being started
+    isHistoryStarted: function(){
+        return historyStarted;
+    },
     // The default interval to poll for hash changes, if necessary, is
     // twenty times a second.
     interval: 50,

--- a/test/history.js
+++ b/test/history.js
@@ -1,0 +1,25 @@
+var Router = Backbone.Router.extend({
+    initialize: function(){
+        Backbone.history.start();       
+    }
+});
+
+var RouterWithCheck = Backbone.Router.extend({
+    initialize: function(){
+        if(!Backbone.history.isHistoryStarted()){
+            Backbone.history.start();
+        }
+    }
+});
+
+module("Backbone.history");
+test("Testing history started method", function(){
+    ok(Backbone.history.isHistoryStarted(), 'History should be started');
+    
+    raises(function(){
+            new Router()
+        }, 'Exception should be thrown');
+        
+    
+    ok(new RouterWithCheck(), 'Nothing should happen here really...Just no exception');
+});

--- a/test/test.html
+++ b/test/test.html
@@ -22,6 +22,7 @@
   <script type="text/javascript" src="sync.js"></script>
   <script type="text/javascript" src="speed.js"></script>
   <script type="text/javascript" src="setdomlibrary.js"></script>
+  <script type="text/javascript" src="history.js"></script>
 </head>
 <body>
   <h1 id="qunit-header">Backbone Test Suite</h1>


### PR DESCRIPTION
I kept running into issues where routers that call Backbone.history.start were being reinitialized and would throw exceptions. 

I added a method to Backbone.history that simply returns the historyStarted boolean to be able to check before starting the history.

Tests are included in tests/history.js.
