### PR TITLE
Updated toJSON with extended functionality (deep toJSON)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -192,7 +192,11 @@
 
     // Return a copy of the model's `attributes` object.
     toJSON: function() {
-      return _.clone(this.attributes);
+      var deep = {}, temp;
+      for (prop in this.attributes) {
+        if ((temp = this.attributes[prop]) && (temp instanceof Backbone.Model || temp instanceof Backbone.Collection)) deep[prop] = temp.toJSON();
+      }  
+      return _.extend({}, this.attributes, deep);
     },
 
     // Get the value of an attribute.

--- a/test/model.js
+++ b/test/model.js
@@ -699,4 +699,24 @@ $(document).ready(function() {
     }
   });
 
+  test("Model: deep toJSON", function() {
+
+    var m = new Backbone.Model({foo:"One", bar:"Two"});
+    var iCollection = new Backbone.Collection([{id:"1"}, {id:"2"}]);
+    var iModel = new Backbone.Model({innerFoo:"One", innerBar:"Two"});
+
+    m.set("innerModel", iModel);
+    m.set("innerCol", iCollection);
+
+    var json = m.toJSON();
+
+    deepEqual(json, {
+        foo:"One",
+        bar: "Two",
+        innerModel: { innerFoo : "One", innerBar : "Two" },
+        innerCol: [{id:"1"},{id:"2"}]
+    });
+
+  });
+
 });


### PR DESCRIPTION
The toJSON method in Backbone.Model ignores that there might be other models or collection in it.

To do justice to the name "toJSON" i wrote 4 extra lines where i check if the instances are either of type Backbone.Model or Backbone.Collection. 

A Test is also added.
