### PR TITLE
Proposed clarification in documentation:

### DIFF
--- a/index.html
+++ b/index.html
@@ -1597,7 +1597,8 @@ Accounts.fetch();
 
 <pre>
 &lt;script&gt;
-  accounts.reset(&lt;%= @accounts.to_json %&gt;);
+  var Accounts = new Backbone.Collection;
+  Accounts.reset(&lt;%= @accounts.to_json %&gt;);
 &lt;/script&gt;
 </pre>
 
@@ -3054,8 +3055,10 @@ Inbox.messages.fetch();
 
 <pre>
 &lt;script&gt;
-  accounts.reset(&lt;%= @accounts.to_json %&gt;);
-  projects.reset(&lt;%= @projects.to_json(:collaborators => true) %&gt;);
+  var Accounts = new Backbone.Collection;
+  Accounts.reset(&lt;%= @accounts.to_json %&gt;);
+  var Projects = new Backbone.Collection;
+  Projects.reset(&lt;%= @projects.to_json(:collaborators => true) %&gt;);
 &lt;/script&gt;
 </pre>
 


### PR DESCRIPTION
`Accounts.reset(<%= ... %>)` to `accounts.reset(<%= ... %>)`
`Projects.reset(<%= ... %>)` to `projects.reset(<%= ... %>)`

As it's popular in JavaScript to capitalize constructors it might be confusing in this context.
