### PR TITLE
fix error message on missing event callback

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1125,7 +1125,7 @@
       for (var key in events) {
         var method = events[key];
         if (!_.isFunction(method)) method = this[events[key]];
-        if (!method) throw new Error('Event "' + events[key] + '" does not exist');
+        if (!method) throw new Error('Method "' + events[key] + '" does not exist');
         var match = key.match(eventSplitter);
         var eventName = match[1], selector = match[2];
         method = _.bind(method, this);


### PR DESCRIPTION
`events: {"foo": "bar"}`

If method `bar` doesn't exist, the exception currently says `Event "bar" does not exist`
