### PR TITLE
Make changed properties available in "change" event

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -400,7 +400,7 @@
       }
       while (this._moreChanges) {
         this._moreChanges = false;
-        this.trigger('change', this, options);
+        this.trigger('change', this, this._changed, options);
       }
       this._previousAttributes = _.clone(this.attributes);
       delete this._changed;

--- a/test/model.js
+++ b/test/model.js
@@ -304,7 +304,7 @@ $(document).ready(function() {
   test("Model: change with options", function() {
     var value;
     var model = new Backbone.Model({name: 'Rob'});
-    model.on('change', function(model, options) {
+    model.on('change', function(model, changed, options) {
       value = options.prefix + model.get('name');
     });
     model.set({name: 'Bob'}, {silent: true});


### PR DESCRIPTION
When the change event fired I figured it would tell me what attributes had changed, but the information was strangely absent. I merely made this._changed available to the user via the change callback.
