### PR TITLE
small patch to allow passing options through reset to model initializer

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -648,7 +648,7 @@
         this._removeReference(this.models[i]);
       }
       this._reset();
-      this.add(models, {silent: true, parse: options.parse});
+      this.add(models, _.extend({silent: true}, options));
       if (!options.silent) this.trigger('reset', this, options);
       return this;
     },

--- a/test/collection.js
+++ b/test/collection.js
@@ -420,6 +420,20 @@ $(document).ready(function() {
     ok(_.isEqual(col.last().attributes, a.attributes));
   });
 
+  test("Collection: reset passes caller options", function() {
+    var Model = Backbone.Model.extend({
+      initialize: function(attrs, options) {
+        this.model_parameter = options.model_parameter;
+      }
+    });
+    var col = new (Backbone.Collection.extend({ model: Model }))();
+    col.reset([{ astring: "green", anumber: 1 }, { astring: "blue", anumber: 2 }], { model_parameter: 'model parameter' });
+    equal(col.length, 2);
+    col.each(function(model) {
+      equal(model.model_parameter, 'model parameter');
+    });
+  });
+
   test("Collection: trigger custom events on models", function() {
     var fired = null;
     a.bind("custom", function() { fired = true; });


### PR DESCRIPTION
I noticed that `reset` was not passing options through to `add`.  this breaks what I think could be a nice idiom of passing (non-attribute) model initialization fields transparently through bulk methods without having to implement annoying setters just for the sake of initialization.  test included.

Example:

``` javascript
var Model = Backbone.Model.extend({
  initialize: function(attrs, options) {
    this.model_parameter = options.model_parameter;
  }
});
var col = new (Backbone.Collection.extend({ model: Model }))();
// now we can pass initialization data using a conventional Backbone collection method as opposed
// to hand rolling a loop and custom initializing every model
col.reset([{ astring: "green", anumber: 1 }, { astring: "blue", anumber: 2 }], { model_parameter: 'model parameter' });
```
