### PR TITLE
fix instances of it's to its for proper grammar

### DIFF
--- a/index.html
+++ b/index.html
@@ -529,7 +529,7 @@
       </li>
       <li>
         <tt>model.set</tt> will no longer trigger change events when setting a value
-        with <tt>{silent: true}</tt> then setting it back to it's original value.
+        with <tt>{silent: true}</tt> then setting it back to its original value.
         Similarly, after changing an attribute silently, that <tt>change:attribute</tt>
         event <i>will</i> fire during the next change.
       </li>
@@ -863,7 +863,7 @@ alert("Cake id: " + cake.id);
       <br />
       The <b>changed</b> property is the internal hash containing all the attributes
       that have changed since the last <tt>"change"</tt> event was triggered.
-      Please do not update <b>changed</b> directly.  It's state is maintained internally
+      Please do not update <b>changed</b> directly.  Its state is maintained internally
       by <a href="#Model-set">set</a> and <a href="#Model-change">change</a>.
       A copy of <b>changed</b> can be acquired from
       <a href="#Model-changedAttributes">changedAttributes</a>.
@@ -2267,7 +2267,7 @@ var model = localBackbone.Model.extend(...);
       <b class="header">setDomLibrary</b><code>Backbone.setDomLibrary(jQueryNew);</code>
       <br />
       If you have multiple copies of <tt>jQuery</tt> on the page, or simply want
-      to tell Backbone to use a particular object as it's DOM / Ajax library,
+      to tell Backbone to use a particular object as its DOM / Ajax library,
       this is the function for you.
     </p>
 


### PR DESCRIPTION
I touched up a few instances where it looks like "it's" was being used when "its" should be used.

For funsies:  http://theoatmeal.com/comics/apostrophe
