### PR TITLE
Fixes #1026 - Expose `extend` as `Backbone.extend`.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1208,7 +1208,7 @@
   });
 
   // The self-propagating extend function that Backbone classes use.
-  var extend = function (protoProps, classProps) {
+  var extend = Backbone.extend = function (protoProps, classProps) {
     var child = inherits(this, protoProps, classProps);
     child.extend = this.extend;
     return child;


### PR DESCRIPTION
Although extend is already exposed through Model, Collection, etc., I find it strange to use Backbone.Model.extend for something completely unrelated to models.
