### PR TITLE
Collection.addedModels()

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -135,6 +135,26 @@ $(document).ready(function() {
     equal(col.length, 1);
   });
 
+  test("Collection: add silent", function() {
+    var triggered = false,
+      col = new Backbone.Collection([{id: 1}, {id: 2}]);
+    col.bind('add', function(model, collection, options){
+      triggered = true;
+    });
+    col.add({id: 3}, {silent: true});
+    equal(triggered, false);
+    equal(col.addedModels().length, 1);
+    equal(col.addedModels()[0].id, 3);
+    col.added();
+    equal(triggered,true);
+    col.add({id: 4});
+    col.add([{id: 5},{id: 6}], {silent:true});
+    equal(col.addedModels().length, 2);
+    equal(col.addedModels()[1].id, 6);
+    col.reset();
+    equal(col.addedModels(), []);
+  });
+  
   test("Collection: add model to multiple collections", function() {
     var counter = 0;
     var e = new Backbone.Model({id: 10, label : 'e'});


### PR DESCRIPTION
Tracks silently added collections to models, with Collection#added and Collection#addedModels analogous to Model#change and Model#changedAttributes.

Not sure about the API nomenclature, but this is something that's important to us… as with a model, you want to queue a bunch of changes before triggering a particular callback.

My real-world case is a "load more" link, where the view needs to know which models are new and which aren't (in our case, to only append the newer models without re-rendering the old).
