### PR TITLE
Added ability to avoid an additional '$()' call in 'setElement' method if current 'element' is already wrapped with '$()'

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1131,7 +1131,7 @@
     // Change the view's element (`this.el` property), including event
     // re-delegation.
     setElement: function(element, delegate) {
-      this.$el = $(element);
+      this.$el = (element instanceof $) ? element : $(element);
       this.el = this.$el[0];
       if (delegate !== false) this.delegateEvents();
       return this;


### PR DESCRIPTION
Here is a good examples:

1)

``` javascript
(function($) {
    var popup = $.sub();

    popup.fn.extend({
        show: function() {
            console.log('show');

            return this;
        },

        hide: function() {
            console.log('hide');

            this.addClass('hide');

            return this;
        }
    });

    $.fn.popup = function() {
        this.addClass('popup');

        return popup(this);
    };
})(jQuery);

var AddUserView = Backbone.View.extend({
    el: $('#addUser-popup').popup(),

    show: function() {
        this.$el.show();
    }
});

var addUserView = new AddUserView({ model: user });

addUserView.show();
```

2)

``` javascript
var AddUserView = Backbone.View.extend({
    show: function() {
        this.$el.show();
    }
});

var popup = $('#addUser-popup').popup();
var addUserView = new AddUserView({ model: user });

addUserView.setElement(popup, false);

addUserView.show();
```

If we try to call 'addUser.show', then 'view' will call '$.show' instead of '$.popup.show', because 'el' is wrapped twice.

It would be nice to pass to 'setElement' method already wrapped 'element' and this patch helps to solve this problem.
