### PR TITLE
Fix for custom sync functions

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -756,6 +756,9 @@
       } else if (!model.collection) {
         model.collection = this;
       }
+      if (this.sync && !model.sync) {
+        model.sync = this.sync;
+      }
       return model;
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -2,17 +2,18 @@ $(document).ready(function() {
 
   var lastRequest = null;
   var sync = Backbone.sync;
+  var syncFunction = function(method, model, options) {
+    lastRequest = {
+      method: method,
+      model: model,
+      options: options
+    };
+  };
 
   module("Backbone.Collection", {
 
     setup: function() {
-      Backbone.sync = function(method, model, options) {
-        lastRequest = {
-          method: method,
-          model: model,
-          options: options
-        };
-      };
+      Backbone.sync = syncFunction;
     },
 
     teardown: function() {
@@ -331,11 +332,15 @@ $(document).ready(function() {
   });
 
   test("Collection: create", function() {
+    col.sync = syncFunction;
     var model = col.create({label: 'f'}, {wait: true});
     equal(lastRequest.method, 'create');
     equal(lastRequest.model, model);
     equal(model.get('label'), 'f');
     equal(model.collection, col);
+    equal(model.sync, col.sync);
+    ok(model.sync);
+    col.sync = false;
   });
 
   test("Collection: create enforces validation", function() {


### PR DESCRIPTION
I have noticed that if you have one collection with a custom sync function, then models created in that collection don't get that sync function, and therefore will try to persist themselves using the default method.

I've adjusted the _prepareModel function so that if coll.sync is set, it's also set on created models, and added test cases demonstrating it works.
