### PR TITLE
Fix to make Backbone.sync options parameter optional again

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1246,6 +1246,9 @@
   Backbone.sync = function(method, model, options) {
     var type = methodMap[method];
 
+    // Default options to an empty object.
+    options = options || {};
+
     // Default JSON-request options.
     var params = {type: type, dataType: 'json'};
 


### PR DESCRIPTION
Added a default value for the options parameter in the Backbone.sync function to bring it in line with the documentation.
