### PR TITLE
Forced options to be an object on collection.fetch

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -690,7 +690,7 @@
     // collection when they arrive. If `add: true` is passed, appends the
     // models to the collection instead of resetting.
     fetch: function(options) {
-      options = options ? _.clone(options) : {};
+      options = (options && _.isObject(options) && !_.isArray(options)) ? _.clone(options) : {};
       if (options.parse === undefined) options.parse = true;
       var collection = this;
       var success = options.success;

--- a/test/collection.js
+++ b/test/collection.js
@@ -330,6 +330,16 @@ $(document).ready(function() {
     equal(lastRequest.options.parse, false);
   });
 
+  test("Collection: fetch with non-object options argumen should trigger reset", function() {
+    var fired = null;
+    var col2 = new Backbone.Collection();
+    col2.bind("reset", function() { fired = true; });
+    col2.fetch(["test"]);
+    lastRequest.options.success();
+    equal(fired, true);
+    lastRequest = null;
+  });
+
   test("Collection: create", function() {
     var model = col.create({label: 'f'}, {wait: true});
     equal(lastRequest.method, 'create');


### PR DESCRIPTION
On collection.fetch, the argument being sent through will default to an empty object if the object sent through is not an object.  This is because if you call `collection.fetch` with an array as an argument (for example in a callback) then the "reset" event is not triggered.
