### PR TITLE
Fix #1074 - set/clear/unset do not alter options.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -250,7 +250,7 @@
       }
 
       // Extract attributes and options.
-      options || (options = {});
+      options = options ? _.clone(options) : {};
       if (!attrs) return this;
       if (attrs instanceof Model) attrs = attrs.attributes;
       if (options.unset) for (attr in attrs) attrs[attr] = void 0;
@@ -294,14 +294,16 @@
     // Remove an attribute from the model, firing `"change"` unless you choose
     // to silence it. `unset` is a noop if the attribute doesn't exist.
     unset: function(attr, options) {
-      (options || (options = {})).unset = true;
+      options = options ? _.clone(options) : {};
+      options.unset = true;
       return this.set(attr, null, options);
     },
 
     // Clear all attributes on the model, firing `"change"` unless you choose
     // to silence it.
     clear: function(options) {
-      (options || (options = {})).unset = true;
+      options = options ? _.clone(options) : {};
+      options.unset = true;
       return this.set(_.clone(this.attributes), options);
     },
 

--- a/test/model.js
+++ b/test/model.js
@@ -770,4 +770,15 @@ $(document).ready(function() {
     }
   });
 
+  test("#1074 - set/clear/unset do not alter options", function() {
+    var options = {};
+    var model = new Backbone.Model();
+    model.unset('foo', options);
+    strictEqual(_.keys(options).length, 0);
+    model.clear(options);
+    strictEqual(_.keys(options).length, 0);
+    model.set({foo: true}, options)
+    strictEqual(_.keys(options).length, 0);
+  });
+
 });


### PR DESCRIPTION
Conceptually, this patch certainly fixes the issue put forth in #1074.  However, there is a [significant performance cost](http://jsperf.com/cloning-arguments) of approximately 30% associated with it.  I've also been bitten by this type of bug before so I understand the desire to prevent it but 30% is a rather steep price to pay for it.
