### PR TITLE
Add `model.normalize`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -255,6 +255,9 @@
       if (attrs instanceof Model) attrs = attrs.attributes;
       if (options.unset) for (attr in attrs) attrs[attr] = void 0;
 
+      // Normalize attributes
+      if (this.normalize) this.normalize(attrs, options);
+
       // Run validation.
       if (!this._validate(attrs, options)) return false;
 

--- a/test/model.js
+++ b/test/model.js
@@ -522,6 +522,22 @@ $(document).ready(function() {
     a.set({state: 'hello'});
   });
 
+  test("Model: normalize", function() {
+    var Model = Backbone.Model.extend({
+      normalize: function(attrs) {
+        attrs.num = parseInt(attrs.num);
+      }
+    });
+    var model = new Model({ num: '10' });
+    strictEqual(model.get('num'), 10);
+
+    model.set('num', '20');
+    strictEqual(model.get('num'), 20);
+
+    model.set({ num: '30' });
+    strictEqual(model.get('num'), 30);
+  });
+
   test("hasChanged/set should use same comparison", function() {
     expect(2);
     var changed = 0, model = new Backbone.Model({a: null});


### PR DESCRIPTION
`model.normaize` can normaize attributes before each `set()`.

For example.

```
var Model = Backbone.Model.extend({
  normalize: function(attrs) {
    attrs.num = parseInt(attrs.num);
    attrs.dateObj = new Date(dateStr);
  }
});

var model = new Model({
  num: '10',
  dateStr: '2012-03-01'
});

model.get('num') === 10; // not string
model.get('dateObj') instanceof Date;

model.set('num', '20');
model.get('num') === 20;
```
