### PR TITLE
Set correct Content-Type header when syncing

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1258,7 +1258,7 @@
     options || (options = {});
 
     // Default JSON-request options.
-    var params = {type: type, dataType: 'json'};
+    var params = {type: type, dataType: 'json', contentType: 'application/json'};
 
     // Ensure that we have a URL.
     if (!options.url) {


### PR DESCRIPTION
Since Backbone's default sync always send JSON to the server, the Content-Type request header should be application/json. Jquery uses application/x-www-form-urlencoded by default. This patch overrides the default and sets it up to indicate json.
