### PR TITLE
Refactor Backbone.Model to not access `attributes` property directly, and add `getData()` method

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -187,7 +187,7 @@
     this.changed = {};
     this._silent = {};
     this._pending = {};
-    this._previousAttributes = this.getData();
+    this._previousAttributes = this._cloneAttributes();
     this.initialize.apply(this, arguments);
   };
 
@@ -215,12 +215,7 @@
 
     // Returns a copy of the model attributes as an object for persistence, serialization, etc.
     toJSON: function() {
-      return this.getData();
-    },
-
-    // Return a copy of the model's `attributes` object.
-    getData: function() {
-      return _.clone(this.attributes);
+      return this._cloneAttributes();
     },
 
     // Get the value of an attribute.
@@ -307,7 +302,7 @@
     // to silence it.
     clear: function(options) {
       (options || (options = {})).unset = true;
-      return this.set(this.getData(), options);
+      return this.set(this._cloneAttributes(), options);
     },
 
     // Fetch the model from the server. If the server's representation of the
@@ -339,7 +334,7 @@
       }
 
       options = options ? _.clone(options) : {};
-      if (options.wait) current = this.getData();
+      if (options.wait) current = this._cloneAttributes();
       var silentOptions = _.extend({}, options, {silent: true});
       if (attrs && !this.set(attrs, options.wait ? silentOptions : options)) {
         return false;
@@ -440,7 +435,7 @@
           if (this._pending[attr] || this._silent[attr]) continue;
           delete this.changed[attr];
         }
-        this._previousAttributes = this.getData();
+        this._previousAttributes = this._cloneAttributes();
       }
       this._changing = false;
       return this;
@@ -493,7 +488,7 @@
     // been passed, call that instead of firing the general `"error"` event.
     _validate: function(attrs, options) {
       if (options.silent || !this.validate) return true;
-      attrs = _.extend(this.getData(), attrs);
+      attrs = _.extend(this._cloneAttributes(), attrs);
       var error = this.validate(attrs, options);
       if (!error) return true;
       if (options && options.error) {
@@ -502,6 +497,11 @@
         this.trigger('error', this, error, options);
       }
       return false;
+    },
+
+    // Return a copy of the model's `attributes` object.
+    _cloneAttributes: function() {
+      return _.clone(this.attributes);
     }
 
   });

--- a/index.html
+++ b/index.html
@@ -241,7 +241,6 @@
       <li>– <a href="#Model-changed">changed</a></li>
       <li>– <a href="#Model-defaults">defaults</a></li>
       <li>– <a href="#Model-toJSON">toJSON</a></li>
-      <li>– <a href="#Model-getData">getData</a></li>
       <li>– <a href="#Model-fetch">fetch</a></li>
       <li>– <a href="#Model-save">save</a></li>
       <li>– <a href="#Model-destroy">destroy</a></li>
@@ -921,22 +920,6 @@ var artist = new Backbone.Model({
 artist.set({birthday: "December 16, 1866"});
 
 alert(JSON.stringify(artist));
-</pre>
-
-    <p id="Model-getData">
-      <b class="header">getData</b><code>model.getData()</code>
-      <br />
-      Return a copy of the model's <a href="#Model-attributes">attributes</a>.  This
-      method is used internally to get a snapshot of the model attribute state.
-    </p>
-
-<pre class="runnable">
-var artist = new Backbone.Model({
-  firstName: "Wassily",
-  lastName: "Kandinsky"
-});
-
-alert(artist.getData().firstName);
 </pre>
 
     <p id="Model-fetch">


### PR DESCRIPTION
_Most_ `Backbone.Model` methods no longer access `attributes` directly.  Instead, most core methods now use `get()` or new `getData()` method.  Using `get()` internally is beneficial to users wanting or plugin developers wanting to override the method, because other methods that rely on it now reflect what the user would expect.  For example:

``` javascript
var Person = Backbone.Model.extend({
  get: function(attr) {
    if (attr === 'fullName') {
      return this.get('firstName') + ' ' + this.get('lastName');
    } else {
      return Backbone.Model.prototype.get.apply(this, arguments);
    }
  }
});

var user = new Person({
  firstName: 'John',
  lastName: 'Smith'
});

alert(user.has('fullName')); // would have returned 'false' before
```

The above example is somewhat unusual for most use cases, but the change is far more relevant for extensions to Models like [Backbone-Nested](http://afeld.github.com/backbone-nested/) and [Ligament](https://github.com/dbrady/ligament.js) because it reduces the number of methods that I- *ahem*, _they_ - need to override to provide expected behavior for methods like `has()` and `escape()`.

In the same way, `getData()` now provides an alternative to cloning the `attributes` directly, but still leaves `toJSON()` available to the user to modify for custom serialization/persistence.
