### PR TITLE
clean up tests to use fresh object instances for each run and not set globals

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -3,9 +3,19 @@ $(document).ready(function() {
   var lastRequest = null;
   var sync = Backbone.sync;
 
+  var a, b, c, d, e, col, otherCol;
+
   module("Backbone.Collection", {
 
     setup: function() {
+      a         = new Backbone.Model({id: 3, label: 'a'});
+      b         = new Backbone.Model({id: 2, label: 'b'});
+      c         = new Backbone.Model({id: 1, label: 'c'});
+      d         = new Backbone.Model({id: 0, label: 'd'});
+      e         = null;
+      col       = new Backbone.Collection([a,b,c,d]);
+      otherCol  = new Backbone.Collection();
+
       Backbone.sync = function(method, model, options) {
         lastRequest = {
           method: method,
@@ -20,14 +30,6 @@ $(document).ready(function() {
     }
 
   });
-
-  var a         = new Backbone.Model({id: 3, label: 'a'});
-  var b         = new Backbone.Model({id: 2, label: 'b'});
-  var c         = new Backbone.Model({id: 1, label: 'c'});
-  var d         = new Backbone.Model({id: 0, label: 'd'});
-  var e         = null;
-  var col       = new Backbone.Collection([a,b,c,d]);
-  var otherCol  = new Backbone.Collection();
 
   test("Collection: new and sort", function() {
     equal(col.first(), a, "a should be first");
@@ -77,15 +79,16 @@ $(document).ready(function() {
   });
 
   test("Collection: at", function() {
-    equal(col.at(2), b);
+    equal(col.at(2), c);
   });
 
   test("Collection: pluck", function() {
-    equal(col.pluck('label').join(' '), 'd c b a');
+    equal(col.pluck('label').join(' '), 'a b c d');
   });
 
   test("Collection: add", function() {
-    var added = opts = secondAdded = null;
+    var added, opts, secondAdded;
+    added = opts = secondAdded = null;
     e = new Backbone.Model({id: 10, label : 'e'});
     otherCol.add(e);
     otherCol.bind('add', function() {
@@ -206,18 +209,19 @@ $(document).ready(function() {
   });
 
   test("Collection: remove", function() {
-    var removed = otherRemoved = null;
+    var removed = null;
+    var otherRemoved = null;
     col.bind('remove', function(model, col, options) {
       removed = model.get('label');
-      equal(options.index, 4);
+      equal(options.index, 3);
     });
     otherCol.bind('remove', function(model, col, options) {
       otherRemoved = true;
     });
-    col.remove(e);
-    equal(removed, 'e');
-    equal(col.length, 4);
-    equal(col.first(), d);
+    col.remove(d);
+    equal(removed, 'd');
+    equal(col.length, 3);
+    equal(col.first(), a);
     equal(otherRemoved, null);
   });
 
@@ -378,14 +382,14 @@ $(document).ready(function() {
   });
 
   test("Collection: toJSON", function() {
-    equal(JSON.stringify(col), '[{"id":0,"label":"d"},{"id":1,"label":"c"},{"id":2,"label":"b"},{"id":3,"label":"a"}]');
+    equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });
 
   test("Collection: Underscore methods", function() {
-    equal(col.map(function(model){ return model.get('label'); }).join(' '), 'd c b a');
+    equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
     equal(col.any(function(model){ return model.id === 100; }), false);
     equal(col.any(function(model){ return model.id === 0; }), true);
-    equal(col.indexOf(b), 2);
+    equal(col.indexOf(b), 1);
     equal(col.size(), 4);
     equal(col.rest().length, 3);
     ok(!_.include(col.rest()), a);
@@ -398,7 +402,7 @@ $(document).ready(function() {
             .filter(function(o){ return o.id % 2 === 0; })
             .map(function(o){ return o.id * 2; })
             .value(),
-         [0, 4]);
+         [4, 0]);
   });
 
   test("Collection: reset", function() {
@@ -412,12 +416,12 @@ $(document).ready(function() {
     col.reset(models);
     equal(resetCount, 2);
     equal(col.length, 4);
-    equal(col.last(), a);
+    equal(col.last(), d);
     col.reset(_.map(models, function(m){ return m.attributes; }));
     equal(resetCount, 3);
     equal(col.length, 4);
-    ok(col.last() !== a);
-    ok(_.isEqual(col.last().attributes, a.attributes));
+    ok(col.last() !== d);
+    ok(_.isEqual(col.last().attributes, d.attributes));
   });
 
   test("Collection: trigger custom events on models", function() {

--- a/test/model.js
+++ b/test/model.js
@@ -8,9 +8,24 @@ $(document).ready(function() {
   var ajax = $.ajax;
   var urlRoot = null;
 
+  var proxy = Backbone.Model.extend();
+  var klass = Backbone.Collection.extend({
+    url : function() { return '/collection'; }
+  });
+  var doc, collection;
+
   module("Backbone.Model", {
 
     setup: function() {
+      doc = new proxy({
+        id     : '1-the-tempest',
+        title  : "The Tempest",
+        author : "Bill Shakespeare",
+        length : 123
+      });
+      collection = new klass();
+      collection.add(doc);
+
       Backbone.sync = function(method, model, options) {
         lastRequest = {
           method: method,
@@ -31,23 +46,6 @@ $(document).ready(function() {
     }
 
   });
-
-  var attrs = {
-    id     : '1-the-tempest',
-    title  : "The Tempest",
-    author : "Bill Shakespeare",
-    length : 123
-  };
-
-  var proxy = Backbone.Model.extend();
-  var doc = new proxy(attrs);
-
-  var klass = Backbone.Collection.extend({
-    url : function() { return '/collection'; }
-  });
-
-  var collection = new klass();
-  collection.add(doc);
 
   test("Model: initialize", function() {
     var Model = Backbone.Model.extend({
@@ -116,9 +114,8 @@ $(document).ready(function() {
   });
 
   test("Model: clone", function() {
-    attrs = { 'foo': 1, 'bar': 2, 'baz': 3};
-    a = new Backbone.Model(attrs);
-    b = a.clone();
+    var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
+    var b = a.clone();
     equal(a.get('foo'), 1);
     equal(a.get('bar'), 2);
     equal(a.get('baz'), 3);
@@ -131,14 +128,11 @@ $(document).ready(function() {
   });
 
   test("Model: isNew", function() {
-    attrs = { 'foo': 1, 'bar': 2, 'baz': 3};
-    a = new Backbone.Model(attrs);
+    var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
     ok(a.isNew(), "it should be new");
-    attrs = { 'foo': 1, 'bar': 2, 'baz': 3, 'id': -5 };
-    a = new Backbone.Model(attrs);
+    a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3, 'id': -5 });
     ok(!a.isNew(), "any defined ID is legal, negative or positive");
-    attrs = { 'foo': 1, 'bar': 2, 'baz': 3, 'id': 0 };
-    a = new Backbone.Model(attrs);
+    a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3, 'id': 0 });
     ok(!a.isNew(), "any defined ID is legal, including zero");
     ok( new Backbone.Model({          }).isNew(), "is true when there is no id");
     ok(!new Backbone.Model({ 'id': 2  }).isNew(), "is false for a positive integer");
@@ -163,8 +157,7 @@ $(document).ready(function() {
   });
 
   test("Model: has", function() {
-    attrs = {};
-    a = new Backbone.Model(attrs);
+    var a = new Backbone.Model();
     equal(a.has("name"), false);
     _([true, "Truth!", 1, false, '', 0]).each(function(value) {
       a.set({'name': value});
@@ -180,8 +173,7 @@ $(document).ready(function() {
 
   test("Model: set and unset", function() {
     expect(8);
-    attrs = {id: 'id', foo: 1, bar: 2, baz: 3};
-    a = new Backbone.Model(attrs);
+    var a = new Backbone.Model({id: 'id', foo: 1, bar: 2, baz: 3});
     var changeCount = 0;
     a.on("change:foo", function() { changeCount += 1; });
     a.set({'foo': 2});
@@ -387,8 +379,7 @@ $(document).ready(function() {
   });
 
   test("Model: non-persisted destroy", function() {
-    attrs = { 'foo': 1, 'bar': 2, 'baz': 3};
-    a = new Backbone.Model(attrs);
+    var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
     a.sync = function() { throw "should not be called"; };
     a.destroy();
     ok(true, "non-persisted model should not call sync");

--- a/test/router.js
+++ b/test/router.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
 
   var router = null;
-  var lsatRoute = null;
+  var lastRoute = null;
   var lastArgs = [];
 
   function onRoute(router, route, args) {

--- a/test/sync.js
+++ b/test/sync.js
@@ -3,12 +3,25 @@ $(document).ready(function() {
   var ajax = $.ajax
   var lastRequest = null;
 
+  var Library = Backbone.Collection.extend({
+    url : function() { return '/library'; }
+  });
+  var library;
+
+  var attrs = {
+    title  : "The Tempest",
+    author : "Bill Shakespeare",
+    length : 123
+  };
+
   module("Backbone.sync", {
 
     setup : function() {
+      library = new Library();
       $.ajax = function(obj) {
         lastRequest = obj;
       };
+      library.create(attrs, {wait: false});
     },
 
     teardown: function() {
@@ -16,18 +29,6 @@ $(document).ready(function() {
     }
 
   });
-
-  var Library = Backbone.Collection.extend({
-    url : function() { return '/library'; }
-  });
-
-  var library = new Library();
-
-  var attrs = {
-    title  : "The Tempest",
-    author : "Bill Shakespeare",
-    length : 123
-  };
 
   test("sync: read", function() {
     library.fetch();
@@ -45,7 +46,6 @@ $(document).ready(function() {
   });
 
   test("sync: create", function() {
-    library.create(attrs, {wait: false});
     equal(lastRequest.url, '/library');
     equal(lastRequest.type, 'POST');
     equal(lastRequest.dataType, 'json');
@@ -108,6 +108,7 @@ $(document).ready(function() {
   });
 
   test("sync: read model", function() {
+    library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().fetch();
     equal(lastRequest.url, '/library/2-the-tempest');
     equal(lastRequest.type, 'GET');
@@ -115,6 +116,7 @@ $(document).ready(function() {
   });
 
   test("sync: destroy", function() {
+    library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().destroy({wait: true});
     equal(lastRequest.url, '/library/2-the-tempest');
     equal(lastRequest.type, 'DELETE');
@@ -122,6 +124,7 @@ $(document).ready(function() {
   });
 
   test("sync: destroy with emulateHTTP", function() {
+    library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     Backbone.emulateHTTP = Backbone.emulateJSON = true;
     library.first().destroy();
     equal(lastRequest.url, '/library/2-the-tempest');

--- a/test/view.js
+++ b/test/view.js
@@ -1,10 +1,16 @@
 $(document).ready(function() {
 
-  module("Backbone.View");
+  var view;
 
-  var view = new Backbone.View({
-    id        : 'test-view',
-    className : 'test-view'
+  module("Backbone.View", {
+
+    setup: function() {
+      view = new Backbone.View({
+        id        : 'test-view',
+        className : 'test-view'
+      });
+    }
+
   });
 
   test("View: constructor", function() {
@@ -38,7 +44,8 @@ $(document).ready(function() {
   });
 
   test("View: delegateEvents", function() {
-    var counter = counter2 = 0;
+    var counter = 0;
+    var counter2 = 0;
     view.setElement(document.body);
     view.increment = function(){ counter++; };
     view.$el.bind('click', function(){ counter2++; });
@@ -71,7 +78,8 @@ $(document).ready(function() {
   });
 
   test("View: undelegateEvents", function() {
-    var counter = counter2 = 0;
+    var counter = 0;
+    var counter2 = 0;
     view.setElement(document.body);
     view.increment = function(){ counter++; };
     $(view.el).unbind('click');


### PR DESCRIPTION
The tests were written to expect a certain ordering, where one test would rely on certain modifications that the previous test made to the model/view/router instance.  Strict ordering in tests is bad practice because it's not clear what state the object is in, so this pull request recreates the object being tested for each run.  While I was at it, I also fixed the tests that were creating global variables.

There was one `noglobals` problem I wasn't able to figure out... would love some insight about where/why that is being set.

![global error](http://cl.ly/3i0P2d1e0q0I162r0g1c/Screen%20Shot%202012-03-12%20at%204.02.01%20AM.png)
