### PR TITLE
Fix #1112 - options.model sets collection.model.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -512,6 +512,7 @@
   // its models in sort order, as they're added and removed.
   var Collection = Backbone.Collection = function(models, options) {
     options || (options = {});
+    if (options.model) this.model = options.model;
     if (options.comparator) this.comparator = options.comparator;
     this._reset();
     this.initialize.apply(this, arguments);

--- a/test/collection.js
+++ b/test/collection.js
@@ -528,4 +528,11 @@ $(document).ready(function() {
     ok(c.get() === undefined);
   });
 
+  test("#1112 - passing options.model sets collection.model", function() {
+    var Model = Backbone.Model.extend({})
+    var c = new Backbone.Collection([{id: 1}], {model: Model});
+    ok(c.model === Model);
+    ok(c.at(0) instanceof Model);
+  });
+
 });


### PR DESCRIPTION
This seems to fit with the loose convention that prototype properties can be overridden by passing options.  I've seen several situations in which this would be handy.
