### PR TITLE
stringify the data passed into sync

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1330,6 +1330,12 @@
     if (!options.data && model && (method == 'create' || method == 'update')) {
       params.contentType = 'application/json';
       params.data = JSON.stringify(model.toJSON());
+    } else if (options.data && typeof(options.data) == 'object'){
+      // If data was explicitly passed in, and it is an object, then stringify it and set the header correctly.
+      params.contentType = 'application/json';
+      params.data = JSON.stringify(options.data);
+      // Remove from the options object because the options are merged with the params for the xhr call
+      delete options.data
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.


### PR DESCRIPTION
I made this change because my backend understood a JSON POST body, but had some awkwardness in the API that required using my own sync methods in some models/collections (but still ultimately calling Backbone's sync). I was constantly setting the data collection to JSON, but due to Backbone not stringifying or setting the header correctly when the callee passed in data, I had code all over the place that was doing the same thing again and again.

It seems like Backbone's sync could be a little nicer by stringifying the passed in data and setting the header correctly even for those who want to send in their own data.
