### PR TITLE
Collection add ignores comparator when "at" option is passed

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -623,7 +623,7 @@
       this.length += length;
       index = options.at != null ? options.at : this.models.length;
       splice.apply(this.models, [index, 0].concat(models));
-      if (this.comparator) this.sort({silent: true});
+      if (this.comparator && options.at == null) this.sort({silent: true});
       if (options.silent) return this;
       for (i = 0, length = this.models.length; i < length; i++) {
         if (!cids[(model = this.models[i]).cid]) continue;

--- a/test/collection.js
+++ b/test/collection.js
@@ -125,6 +125,19 @@ $(document).ready(function() {
       equal(col.at(i).get('at'), i);
     }
   });
+  
+  test("Collection: add; at should have preference over comparator", function() {
+    var Col = Backbone.Collection.extend({
+      comparator: function(a,b) {
+        return a.id > b.id ? -1 : 1;
+      }
+    });
+    
+    var col = new Col([{id: 2}, {id: 3}]);
+    col.add(new Backbone.Model({id: 1}), {at:   1});
+    
+    equal(col.pluck('id').join(' '), '3 1 2');
+  });
 
   test("Collection: can't add model to collection twice", function() {
     var col = new Backbone.Collection([{id: 1}, {id: 2}, {id: 1}, {id: 2}, {id: 3}]);


### PR DESCRIPTION
When adding models to a collection, the "at" option is ignored if the collection implements a comparator, which I think shouldn't be the case, in order to be able to force an insertion at an arbitrary place.
