### PR TITLE
Should the documentation for `model.toJSON` not call that function?

### DIFF
--- a/index.html
+++ b/index.html
@@ -937,7 +937,7 @@ var artist = new Backbone.Model({
 
 artist.set({birthday: "December 16, 1866"});
 
-alert(JSON.stringify(artist));
+alert(JSON.stringify(artist.toJSON()));
 </pre>
 
     <p id="Model-fetch">


### PR DESCRIPTION
My assumption is that `JSON.stringify(object)` will call that object's underlying toJSON implementation, but perhaps being explicit would be clearer?
