### PR TITLE
Use function to create models on collections

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -821,7 +821,7 @@
         var attrs = model;
         options.collection = this;
         model = this.createModel(attrs, options);
-        if (!model._validate(model.attributes, options)) model = false;
+        if (!model || !model._validate(model.attributes, options)) model = false;
       } else if (!model.collection) {
         model.collection = this;
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -594,4 +594,17 @@ $(document).ready(function() {
     equal(c.at(1).customAttr, "b");
   });
 
+  test("Collection: createModel can ignore data by returning a falsy value", function() {
+    var Col = Backbone.Collection.extend({
+      createModel: function(attrs, options) {
+        if (attrs.error) return;
+        return new this.model(attrs, options);
+      }
+    });
+    var c = new Col();
+    c.create({ error: "Bad model data" });
+    c.create({ foo: "bar" });
+    equal(c.length, 1);
+  });
+
 });


### PR DESCRIPTION
instead of just `new this.model(attrs, options)`.  Small change, but his makes model creation on extended Collections more flexible because the function is easily overridable. 
### Use case

Server returns list of different types of data on `collection.fetch()`.

For example files and directories:

``` json
[ 
  {
    "id": "209cc2de7c1023bd551af99297074d8fcc21c2c8" ,
    "name": "myfile",
    "size": 24234,
    "type": "file"
   },   
  {
    "id": "8f07b9f73cda14954483c9d19ee30fd3c44611d1",
    "name": "mydir",
    "type": "dir" 
  }
]
```

For that I'd like to create different models for files and directories like this:

``` javascript
var FileSystem = Backbone.Collection.extend({
  createModel: function(attrs, options) {
    if (attrs.type === "file") {
        return new File(attrs, options);
    }
    else if (attrs.type === "dir") {
        return new Directory(attrs, options);
    }
    else {
        throw new Error("Bad type: " + attrs.type);
    }

  }
});
```

All tests passes after this change.
