### PR TITLE
Fix proposal for Model and Collection initializers 

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -189,11 +189,12 @@
   var Model = Backbone.Model = function(attributes, options) {
     var defaults;
     attributes || (attributes = {});
-    if (options && options.parse) attributes = this.parse(attributes);
+    options || (options = {});
+    if (options.parse) attributes = this.parse(attributes);
     if (defaults = getValue(this, 'defaults')) {
       attributes = _.extend({}, defaults, attributes);
     }
-    if (options && options.collection) this.collection = options.collection;
+    if (options.collection) this.collection = options.collection;
     this.attributes = {};
     this._escapedAttributes = {};
     this.cid = _.uniqueId('c');
@@ -206,7 +207,7 @@
     this._silent = {};
     this._pending = {};
     this._previousAttributes = _.clone(this.attributes);
-    this.initialize.apply(this, arguments);
+    this.initialize.apply(this, [attributes, options].concat(slice.call(arguments, 2)));
   };
 
   // Attach all inheritable methods to the Model prototype.
@@ -561,7 +562,7 @@
     if (options.model) this.model = options.model;
     if (options.comparator) this.comparator = options.comparator;
     this._reset();
-    this.initialize.apply(this, arguments);
+    this.initialize.apply(this, [models, options].concat(slice.call(arguments, 2)));
     if (models) this.reset(models, {silent: true, parse: options.parse});
   };
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -578,4 +578,14 @@ $(document).ready(function() {
     ok(c.at(0) instanceof Model);
   });
 
+  test("options in initialize should never be undefined", 2, function() {
+    var Collection = Backbone.Collection.extend({
+      initialize: function(models, options) {
+        ok(_.isObject(options));
+        equal(options.test, undefined);
+      }
+    });
+    var col = new Collection;
+  });
+
 });

--- a/test/model.js
+++ b/test/model.js
@@ -784,4 +784,25 @@ $(document).ready(function() {
     }
   });
 
+  test("options in initialize should never be undefined", 1, function() {
+    var Model = Backbone.Model.extend({
+      initialize: function(attributes, options) {
+        ok(_.isObject(options));
+      }
+    });
+    var model = new Model;
+  });
+
+  test("attributes in initialize should always return current state of @attributes on initialize, including defaults", 2, function() {
+    var Model = Backbone.Model.extend({
+      defaults: {
+        test: true
+      },
+      initialize: function(attributes, options) {
+        ok(_.isObject(attributes));
+        ok(attributes.test);
+      }
+    });
+    var model = new Model;
+  });
 });


### PR DESCRIPTION
It would be more convenient if options for the Model and Collection initializers were never empty so we can avoid doing checks for if they are set at all but rather be able to check for presence of any options that we might or might not expect

Also believe that it would probably have higher value if rather then passing undefiend if attributes weren't set it would pass the current state of attributes on initialization including anything that would be set by extending the attributes object with defaults or an empty object.

The question is - is the default value for attributes, and options undefined or rather empty object? I caught myself often putting default value of empty object (especially with coffee script and it's default value for attribute syntax) - I think it would be convenient if setting the default as empty object or current state would work out of the box. 

(Includes tests)
