### PR TITLE
Fix #1161: Documentation for automatic nested collection on Backbone.model 

### DIFF
--- a/index.html
+++ b/index.html
@@ -743,6 +743,10 @@ var Note = Backbone.Model.extend({
       the model is created.
     </p>
 
+    <p>
+      Including a collection option will create a top level <a href="#FAQ-nested">nested</a> collection.
+    </p>
+
 <pre>
 new Book({
   title: "One Thousand and One Nights",


### PR DESCRIPTION
This adds a new line to the documentation for Backbone.Model constructor/initialize to address Issue #1161 This change documents the functionality found at line 196 which will take a collection option and add it as a top level attribute of model

```
if (options && options.collection) this.collection = options.collection;
```

I tried to keep it as simple as possible to avoid causing confusion while still providing insight and more completeness 
