### PR TITLE
Fix #1161: Documentation for model.collection property 

### DIFF
--- a/index.html
+++ b/index.html
@@ -744,7 +744,9 @@ var Note = Backbone.Model.extend({
     </p>
 
     <p>
-      Including a collection option will create a top level <a href="#FAQ-nested">nested</a> collection.
+      Including a collection option populates the models collection property.
+      This property indicates the collection of which the model is a member and
+      is used in the <a href="#Model-url">url</a> function.
     </p>
 
 <pre>


### PR DESCRIPTION
Lets try this again...

This adds a new line to the documentation for Backbone.Model constructor/initialize to address Issue #1161 This change documents the functionality found at line 196 which will take a collection option and add it as a top level attribute of model

```
if (options && options.collection) this.collection = options.collection;
```

I tried to keep it as simple as possible to avoid causing confusion while still providing insight and more completeness 
