### PR TITLE
Fixes #1168  History.navigate returns loadUrl return value when `{trigger: true}`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1121,7 +1121,7 @@
       } else {
         window.location.assign(this.options.root + fragment);
       }
-      if (options.trigger) this.loadUrl(fragment);
+      if (options.trigger) return this.loadUrl(fragment);
     },
 
     // Update the hash location, either replacing the current entry, or adding

--- a/test/router.js
+++ b/test/router.js
@@ -147,6 +147,13 @@ $(document).ready(function() {
     });
   });
 
+  test("Router: navigate returns loadUrl value when {trigger: true}", 2, function() {
+    loadUrlReturn = Backbone.history.navigate('seach/manhattan/p10', {trigger: true});
+    equal(loadUrlReturn, true);
+    loadUrlReturn = Backbone.history.navigate('seach/manhattan/p10');
+    equal(loadUrlReturn, undefined);
+  });
+
   test("Router: doesn't fire routes to the same place twice", function() {
     equal(router.count, 0);
     router.navigate('counter', {trigger: true});


### PR DESCRIPTION
This addresses #1168 and returns the return value of loadUrl

As I wrote in the issue, I am not necessarily convinced this is a change that should be made, but I went ahead and added a test and the change.
