### PR TITLE
Fix #1179 - isValid returns true in the absence of validate.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -529,7 +529,7 @@
     // Check if the model is currently in a valid state. It's only possible to
     // get into an *invalid* state if you're using silent changes.
     isValid: function() {
-      return !this.validate(this.attributes);
+      return !this.validate || !this.validate(this.attributes);
     },
 
     // Run validation against the next complete set of model attributes,

--- a/test/model.js
+++ b/test/model.js
@@ -784,4 +784,10 @@ $(document).ready(function() {
     }
   });
 
+  test("#1179 - isValid returns true in the absence of validate.", function() {
+    var model = new Backbone.Model();
+    model.validate = null;
+    ok(model.isValid());
+  });
+
 });


### PR DESCRIPTION
As stated in #1179, `_validate` returns true in the absence of `validate`.  This suggests that models without `validate` are valid models and that `isValid` should return true instead of throwing a TypeError.
