### PR TITLE
Use window.location.pathname as the fragment when _wantsHashChange == false

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -978,7 +978,7 @@
     // the hash, or the override.
     getFragment: function(fragment, forcePushState) {
       if (fragment == null) {
-        if (this._hasPushState || forcePushState) {
+        if (this._hasPushState || !this._wantsHashChange || forcePushState) {
           fragment = window.location.pathname;
           var search = window.location.search;
           if (search) fragment += search;


### PR DESCRIPTION
In Issue #803 the hashChange option was added to allow you to opt of of the hash change.  

I am using this option in a project currently to allow the following usage, which seems to be the main use case for this option.  I essentially send all routes to the same page and the router then loads the correct views etc for the route.  This setup allows the app to have all real urls even in ie without any hashes.  In IE and other non pushState browser, the browser refreshes on navigate and the router does its thing.

The problem is the if I go to '/route' in my app in ie, it passes an empty fragment (since there is no hash fragment) and causes my empty route to catch on all pages

This comment from #803 also addresses this issue and has a similar but slightly different approach.  

https://github.com/documentcloud/backbone/issues/803#issuecomment-3874429

Currently when you are in a browser without pushState, the `getFragment` function calls `getHash` and returns that value.  This proposed change means that instead you will get window.location.pathname as the fragment sent to the router.  

I _believe_ this is the correct behavior, and if you still actually want to get the hash values you could use the `getHash` method directly

I would also love any feedback on how I could go about testing this.  I was trying to figure out a good way to test, but since its pulling from window.location.pathname I was kinda stumped
