### PR TITLE
Issue 1173: (todo example) model ids are not properly indexed by collections on creation

### DIFF
--- a/examples/backbone-localstorage.js
+++ b/examples/backbone-localstorage.js
@@ -30,7 +30,7 @@ _.extend(Store.prototype, {
   // Add a model, giving it a (hopefully)-unique GUID, if it doesn't already
   // have an id of it's own.
   create: function(model) {
-    if (!model.id) model.id = model.attributes.id = guid();
+    if (!model.id) model.set(model.idAttribute, guid());
     this.data[model.id] = model;
     this.save();
     return model;


### PR DESCRIPTION
the current `create` method modifies the `model.idAttribute` directly, causing the collection to be unaware of the change in `idAttribute`.

Changed to using `model.set()`
