### PR TITLE
Normalize fragment when hashChange: false in navigate

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1120,8 +1120,7 @@
       // based history, then `navigate` becomes a page refresh.
       } else {
         if (frag.indexOf(this.options.root) != 0) frag = this.options.root + frag;
-        this.fragment = frag;
-        window.location.assign(frag);
+        return window.location.assign(frag);
       }
       if (options.trigger) this.loadUrl(fragment);
     },


### PR DESCRIPTION
I am running on master for a project so I can take advantage of the change from PR #1185.  However, today I realized I was having an issue with navigate on that project.  

I franticly scrambled thinking that my pull request was actually broken, but realized it was just my own user error in my app.  I was calling navigate with a leading slash, which got the root ('/') added in front for '//item/slug'.  when the browser did not have pushState and had hashChange: false this bad url would be sent to window.location.assign, which causes incorrect behavior because of the leading double slash.

As I said, this is actually user error, and removing the leading slash causes it to function as expected.  However, I noticed that when using pushState, there is a short idiom using `frag` to deal with this (which is why the problem only occurs in non pushState browsers)

The attached change uses that same pattern to protect this case as well
