### PR TITLE
Pass through return value of constructor when inheriting

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1392,7 +1392,7 @@
     if (protoProps && protoProps.hasOwnProperty('constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ parent.apply(this, arguments); };
+      child = function(){ return parent.apply(this, arguments); };
     }
 
     // Inherit class (static) properties from parent.


### PR DESCRIPTION
`constructor()` should be able to return objects, but this doesn't work when inheriting.
