### PR TITLE
Optionally merging updated model state on collection add.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -607,7 +607,7 @@
       // Remove duplicates.
       i = dups.length;
       while (i--) {
-        models.splice(dups[i], 1);
+        dups[i] = models.splice(dups[i], 1)[0];
       }
 
       // Listen to added models' events, and index models for lookup by
@@ -630,6 +630,14 @@
         options.index = i;
         model.trigger('add', model, this, options);
       }
+
+      if (options.merge) {
+        for (i = 0, length = dups.length; i < length; i++) {
+          model = this._byId[dups[i].id] || this._byCid[dups[i].cid];
+          model.set(dups[i], options);
+        }
+      }
+
       return this;
     },
 


### PR DESCRIPTION
The current behaviour of `Backbone.Collection.add` is to discard models that have matching ids. This makes it difficult to fetch and insert a set of models that may contain both new and updated models. Maybe there's a different way to perform this task, but it wasn't obvious to me.

This patch adds a merge flag to `Backbone.Collection.add`, which causes models with identical ids be passed as arguments to `Backbone.Model.set` instead of being discarded. In the case of true duplicates, the current behaviour is preserved (no change to the collection, no additional events fired), but updates to models retain the object in the collection, but update its attributes (firing the corresponding change events, unless silent).
