### PR TITLE
.escape should return null instead of "" if the attribute is null.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -246,7 +246,10 @@
       var html;
       if (html = this._escapedAttributes[attr]) return html;
       var val = this.get(attr);
-      return this._escapedAttributes[attr] = _.escape(val == null ? '' : '' + val);
+      if (val == null) {
+        return val;
+      }
+      return this._escapedAttributes[attr] = _.escape('' + val);
     },
 
     // Returns `true` if the attribute contains a value that is not null

--- a/test/model.js
+++ b/test/model.js
@@ -153,7 +153,7 @@ $(document).ready(function() {
     doc.set({audience: 10101});
     equal(doc.escape('audience'), '10101');
     doc.unset('audience');
-    equal(doc.escape('audience'), '');
+    equal(doc.escape('audience'), null);
   });
 
   test("Model: has", function() {


### PR DESCRIPTION
The .escape function on Backbone.Model is returning an empty string if the attribute value is null. It should return null to match the original value. This can cause issues where you're checking the existence of an attribute before acting on it.
