### PR TITLE
Adding the MIT license statement

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 Copyright (c) 2010-2012 Jeremy Ashkenas, DocumentCloud
+Backbone may be freely distributed under the MIT license.
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
It's great that there is a LICENSE file at the root of the project, but it doesn't reference the MIT license. This fixes that by copying verbatim the licensing line from backbone.js.
