### PR TITLE
Add route chaining

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -897,9 +897,10 @@
       if (!callback) callback = this[name];
       Backbone.history.route(route, _.bind(function(fragment) {
         var args = this._extractParameters(route, fragment);
-        callback && callback.apply(this, args);
+        var chain = callback && callback.apply(this, args);
         this.trigger.apply(this, ['route:' + name].concat(args));
         Backbone.history.trigger('route', this, name, args);
+        return chain;
       }, this));
       return this;
     },
@@ -1078,8 +1079,7 @@
       var fragment = this.fragment = this.getFragment(fragmentOverride);
       var matched = _.any(this.handlers, function(handler) {
         if (handler.route.test(fragment)) {
-          handler.callback(fragment);
-          return true;
+          return !handler.callback(fragment);
         }
       });
       return matched;

--- a/test/router.js
+++ b/test/router.js
@@ -41,6 +41,8 @@ $(document).ready(function() {
       "contacts/new":               "newContact",
       "contacts/:id":               "loadContact",
       "splat/*args/end":            "splat",
+      "chained/before":             "chainedBefore",
+      "chained/*after":             "chainedAfter",
       "*first/complex-:part/*rest": "complex",
       ":entity?*args":              "query",
       "*anything":                  "anything"
@@ -78,6 +80,15 @@ $(document).ready(function() {
 
     splat : function(args) {
       this.args = args;
+    },
+
+    chainedBefore : function() {
+      this.chainedBefore = true;
+      return true;
+    },
+
+    chainedAfter : function() {
+      this.chainedAfter = true;
     },
 
     complex : function(first, part, rest) {
@@ -188,6 +199,16 @@ $(document).ready(function() {
     setTimeout(function() {
       equal(router.args, 'long-list/of/splatted_99args');
       start();
+    }, 10);
+  });
+
+  asyncTest("Router: routes (chained)", 2, function() {
+    window.location.hash = 'chained/before';
+    setTimeout(function() {
+      equal(router.chainedBefore, true);
+      equal(router.chainedAfter, true);
+      start();
+      window.location.hash = '';
     }, 10);
   });
 


### PR DESCRIPTION
This patch adds the ability to chain route handlers by simply returning a non-false value from a route handler.

Example:

``` javascript

var ChainedRouter = Backbone.Router.extend({
    routes: {
        'frontpage/:item': 'showItem',
        'frontpage': 'showFrontpage'
    },

    showItem: function(item) {
        console.log('Showing item:', item);

        this.model.set({item: item});

        return true;
    },

    showFrontpage: function() {
        console.log('Showing frontpage');

        this.model.set({view: 'frontpage'});
    }
})
```

It doesn't alter the current behavior in any way, test case attached.

This feature could be expanded to how [express.js does passing of route control](http://expressjs.com/guide.html#passing-route control) by passing a `next` function argument to each handler with optional additional arguments for the next matching handler.
