### PR TITLE
add html() and append()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1261,6 +1261,20 @@
     undelegateEvents: function() {
       this.$el.unbind('.delegateEvents' + this.cid);
     },
+    
+    // Replace $el's HTML, by passing another View,
+    // a jQuery/Zepto instance, a DOM Element or a string
+    html: function(element){
+      this.$el.html(element.el || element);
+      return this;
+    },
+
+    // Append an element to $el, by passing another View,
+    // a jQuery/Zepto instance or a DOM Element
+    append: function(element){
+      this.$el.append(element.el || element);
+      return this;
+    },
 
     // Performs the initial configuration of a View with a set of options.
     // Keys with special meaning *(model, collection, id, className)*, are

--- a/test/view.js
+++ b/test/view.js
@@ -106,6 +106,34 @@ $(document).ready(function() {
     equal(counter, 2);
     equal(counter2, 3);
   });
+  
+  test("View: html with string", function(){
+    view.html('<p>Hello world</p>');
+    equal(view.$el.html(), '<p>Hello world</p>');
+  });
+  
+  test("View: html with View", function(){
+    var AnotherView = Backbone.View.extend({
+      className: 'another-view'
+    });
+    
+    view.html(new AnotherView);
+    equal(view.$el.html(), '<div class="another-view"></div>');
+  });
+  
+  test("View: append with element", function(){
+    view.append('<p>Hello world</p>');
+    equal(view.$el.html(), '<p>Hello world</p>');
+  });
+  
+  test("View: append with View", function(){
+    var AnotherView = Backbone.View.extend({
+      className: 'another-view'
+    });
+
+    view.append(new AnotherView);
+    equal(view.$el.html(), '<div class="another-view"></div>');
+  });
 
   test("View: _ensureElement with DOM node el", function() {
     var ViewClass = Backbone.View.extend({


### PR DESCRIPTION
These utility functions allow you to easily replace and append content to $el. They look extremely simple (because they are), but they are conceptually very important. 

append() introduces developers to the idea that complex Views are made up of a subset of other Views. I think this is a really important concept to grasp, as it ensures your JavaScript programs are modular and components are reusable. I use these all the time in Spine :)

For example:

```
var Sidebar = Backbone.View.extend({
  render: function(){
   this.append(new BoxShadow);
   this.append(new Backgrounds);
  }
});
```
