### PR TITLE
Return statements on delegateEvents

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1253,6 +1253,7 @@
           this.$el.delegate(selector, eventName, method);
         }
       }
+      return this;
     },
 
     // Clears all callbacks previously bound to the view with `delegateEvents`.
@@ -1260,6 +1261,7 @@
     // Backbone views attached to the same DOM element.
     undelegateEvents: function() {
       this.$el.unbind('.delegateEvents' + this.cid);
+      return this;
     },
 
     // Performs the initial configuration of a View with a set of options.


### PR DESCRIPTION
Don't know if there was a reason to not have a `return this;` in `delegateEvents`, but I finding this situation coming up a lot, where i wish it chained:

```
this.$el.append(this.subview.delegateEvents().render().$el);
```

Then I added a return to `undelegateEvents` as well for consistency.
