### PR TITLE
Use the same type of URL for installation instructions.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ end
 
 desc "test the CoffeeScript integration"
 task :test do
-  check 'coffee', 'CoffeeScript', 'https://github.com/jashkenas/coffee-script'
+  check 'coffee', 'CoffeeScript', 'http://coffeescript.org/'
   system "coffee test/*.coffee"
 end
 


### PR DESCRIPTION
Currently docco points to the github web page, while
coffee-script points directly to the HTTP git URL.
