### PR TITLE
Return the return value of the constructor applied in "inherits"

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1405,7 +1405,7 @@
     if (protoProps && protoProps.hasOwnProperty('constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ parent.apply(this, arguments); };
+      child = function(){ return parent.apply(this, arguments); };
     }
 
     // Inherit class (static) properties from parent.


### PR DESCRIPTION
This change will only affect people who override Backbone.Model before extending it, and then return valid objects from the new constructor. Which is to say, not very many people. However this change allows those who are adventurous to implement object identity and caching in their overridden constructor. It is also more in line with the philosophy suggested by "parent.apply(this, arguments)", in that the parent function's behavior is more fully preserved.
