### PR TITLE
Allow both constructor return values and extension of Object

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1404,6 +1404,9 @@
     // by us to simply call the parent's constructor.
     if (protoProps && protoProps.hasOwnProperty('constructor')) {
       child = protoProps.constructor;
+    } else if (parent === Object) {
+      // native type Object constructor has an undesirable return value
+      child = function(){ parent.apply(this, arguments); };
     } else {
       child = function(){ return parent.apply(this, arguments); };
     }


### PR DESCRIPTION
The primary argument against respecting the return value of constructors appears to be that the undocumented feature "Object.extend = Backbone.Model.extend" is useful. The problem is that "Object.call(this)" returns a new object instead of undefined or "this". We can easily work around this edge case by testing for "parent === Object" and returning the current wrapper which discards the return value of the parent constructor.

This pull request restores an expected behavior of JavaScript that was unnecessarily removed by #555, and resolves issues #1216 and #1094 without regressing #555.
