### PR TITLE
Fixed the infinite loops when both pushState and hashChange are unavailable.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1132,7 +1132,12 @@
       // If you've told us that you explicitly don't want fallback hashchange-
       // based history, then `navigate` becomes a page refresh.
       } else {
-        return window.location.assign(fullFrag);
+        // To prevent infinite loops when pushState and hashChange are unavailable,
+        // only refresh the page when the full fragment is different from the current fragment.
+      	var currentFrag = window.location.pathname + window.location.search + window.location.hash;
+        if(currentFrag !== fullFrag) {
+          return window.location.assign(fullFrag);
+        }
       }
       if (options.trigger) this.loadUrl(fragment);
     },


### PR DESCRIPTION
When starting the Backbone.History, the page refreshes when both
pashState and hashChange are unavailable. The solution is to navigate
only when the fragment is changed.

This makes it possible to use a Backbone app in an old browser without
adding hashes to the url.
