### PR TITLE
Fix #1282 - "all" callback list is retrieved for each event.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -150,13 +150,13 @@
     trigger: function(events) {
       var event, node, calls, tail, args, all, rest;
       if (!(calls = this._callbacks)) return this;
-      all = calls.all;
       events = events.split(eventSplitter);
       rest = slice.call(arguments, 1);
 
       // For each event, walk through the linked list of callbacks twice,
       // first to trigger the event, then to trigger any `"all"` callbacks.
       while (event = events.shift()) {
+        all = calls.all;
         if (node = calls[event]) {
           tail = node.tail;
           while ((node = node.next) !== tail) {

--- a/test/events.js
+++ b/test/events.js
@@ -145,6 +145,17 @@ $(document).ready(function() {
     equal(counter, 2, 'unbind does not alter callback list');
   });
 
+  test("#1282 - 'all' callback list is retrieved after each event.", function() {
+    var counter = 0;
+    var obj = _.extend({}, Backbone.Events);
+    var incr = function(){ counter++; };
+    obj.on('x', function() {
+      obj.on('y', incr).on('all', incr);
+    })
+    .trigger('x y');
+    strictEqual(counter, 2);
+  });
+
   test("if no callback is provided, `on` is a noop", 0, function() {
     _.extend({}, Backbone.Events).bind('test').trigger('test');
   });


### PR DESCRIPTION
Assuming that `model.trigger('x y')` should behave like a shortcut for `model.trigger('x').trigger('y')`, the `"all"` callbacks list should be updated after each event is triggered.
