### PR TITLE
Add __super__ helper to child's prototype

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1426,6 +1426,7 @@
 
     // Set a convenience property in case the parent's prototype is needed later.
     child.__super__ = parent.prototype;
+    child.prototype.__super__ = child.__super__;
 
     return child;
   };


### PR DESCRIPTION
Add **super** helper to child's prototype in inherits function to prevent always having to do this.constructor.**super**
