### PR TITLE
changed view._configure to return options instead of setting this.options

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1152,7 +1152,7 @@
   // if an existing element is not provided...
   var View = Backbone.View = function(options) {
     this.cid = _.uniqueId('view');
-    this._configure(options || {});
+    options = this._configure(options || {});
     this._ensureElement();
     this.initialize.apply(this, arguments);
     this.delegateEvents();
@@ -1266,7 +1266,7 @@
         var attr = viewOptions[i];
         if (options[attr]) this[attr] = options[attr];
       }
-      this.options = options;
+      return options;
     },
 
     // Ensure that the View has a DOM element to render into.

--- a/test/view.js
+++ b/test/view.js
@@ -16,8 +16,8 @@ $(document).ready(function() {
   test("View: constructor", function() {
     equal(view.el.id, 'test-view');
     equal(view.el.className, 'test-view');
-    equal(view.options.id, 'test-view');
-    equal(view.options.className, 'test-view');
+    equal(view.id, 'test-view');
+    equal(view.className, 'test-view');
   });
 
   test("View: jQuery", function() {


### PR DESCRIPTION
An example of how I think view options should be dealt with, from #1277.

This way, the user can decide whether they want to copy options over to the view. Initialize is called with the defaulted options and then if you want to save anything you should can store it in an appropriate place. Eg. some options might be states, I'd want to store them in `this.state`, or some options might be other collections/models, I'd want to set them as `this.aSecondCollection` instead of everything going under `this.options`.

It also promotes not accessing things via `this.options` when getters/setters exist instead.

Curious to know what everyone thinks.
