### PR TITLE
Router.remove() for dynamic removal of routes

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -916,6 +916,13 @@
       return this;
     },
 
+    // Manually remove a single route from the router
+    remove: function(route) {
+      if (!Backbone.history) throw new Error("No routes have been added to the router.");
+      if (!_.isRegExp(route)) route = this._routeToRegExp(route);
+      Backbone.history.remove(route);
+    },
+
     // Simple proxy to `Backbone.history` to save a fragment into the history.
     navigate: function(fragment, options) {
       Backbone.history.navigate(fragment, options);
@@ -1069,6 +1076,17 @@
     // may override previous routes.
     route: function(route, callback) {
       this.handlers.unshift({route: route, callback: callback});
+    },
+
+    // Removes a specific route from the history handlers
+    remove: function(route) {
+      for (i = 0, l = this.handlers.length; i < l; i++) {
+        if (_.isEqual(this.handlers[i].route, route)) {
+          delete this.handlers[i];
+          this.handlers.splice(i, 1);
+          l--;
+        }
+      };
     },
 
     // Checks the current URL to see if it has changed, and if it has,

--- a/index.html
+++ b/index.html
@@ -300,6 +300,7 @@
       <li>– <a href="#Router-routes">routes</a></li>
       <li>– <a href="#Router-constructor">constructor / initialize</a></li>
       <li>– <a href="#Router-route">route</a></li>
+      <li>– <a href="#Router-remove">remove</a></li>
       <li>– <a href="#Router-navigate">navigate</a></li>
     </ul>
 
@@ -1874,7 +1875,7 @@ router.on("route:help", function(page) {
       a <tt>"route:name"</tt> event whenever the route is matched.  If the
       <tt>callback</tt> argument is omitted <tt>router[name]</tt> will be used
       instead.
-    </p>
+    </p> 
 
 <pre>
 initialize: function(options) {
@@ -1889,6 +1890,26 @@ initialize: function(options) {
 
 open: function(id) { ... }
 </pre>
+
+    <p id="Router-remove">
+      <b class="header">remove</b><code>router.remove(route)</code>
+      <br />
+      Manually remove a route from the router, if you no longer wish to allow a 
+      previously defined route to trigger a method.
+    </p>   
+
+<pre>
+initialize: function(options) {
+
+  // Matches #page/10, passing "10"
+  this.route("page/:number", "page", function(number){ ... });
+
+  // #page/10 is no longer a valid route
+  this.remove("page/:number");
+
+},
+</pre>
+
 
     <p id="Router-navigate">
       <b class="header">navigate</b><code>router.navigate(fragment, [options])</code>

--- a/test/router.js
+++ b/test/router.js
@@ -278,4 +278,20 @@ $(document).ready(function() {
     }, 50);
   });
 
+  asyncTest("Router: removal of routes", function() {
+    router.navigate('noCallback', {trigger:true});
+    equal(lastRoute, 'noCallback');
+    router.navigate('search/testing', {trigger:true});
+    equal(lastRoute, 'search');
+    equal(lastArgs, 'testing');
+    router.remove('noCallback');
+    router.remove('search/:test');
+    router.navigate('noCallback', {trigger:true});
+    equal(lastRoute, 'anything');
+    router.navigate('search/testing', {trigger:true});
+    equal(lastRoute, 'anything');
+    equal(lastArgs, 'search/testing');
+    start();
+  });
+
 });


### PR DESCRIPTION
I came across a situation in a web application i'm working on, where it made much more sense to allow routes to be dynamically added/removed from a router than to write application logic in several places determining whether the routes content should be redirected or not.

I took a quick look around and found this: https://github.com/documentcloud/backbone/issues/1272 - while I agree that URL's should be permanent in the vast majority of situations, there are some cases where they aren't (redirected unauthenticated content, for one example), and it would make more sense to allow them to pass through to a catch all unless the route exists. If a route is dynamically added, it seems to make sense that it can be dynamically removed as well.

I've made sure to include updates to the docs & test coverage as well.
