### PR TITLE
Allow Backbone.ajax to reflect changes made to $.ajax or Backbone.setDomLibrary()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1370,7 +1370,9 @@
   };
 
   // Set the default ajax method if $ is defined.
-  if ($) Backbone.ajax = $.ajax;
+  if ($) Backbone.ajax = function () {
+    return $.ajax.apply(Backbone, arguments);
+  }
 
   // Wrap an optional error callback with a fallback error event.
   Backbone.wrapError = function(onError, originalModel, options) {


### PR DESCRIPTION
Since 87c9b17aa722fb3d6b34d5b92c564eeba5516334 Backbone.ajax is set (view $.ajax) at initialisation, and so any subsequent calls to `Backbone.setDomLibrary` that overwrite the `$.ajax` method are effectively ignored. 

Also ignored are changes to `$.ajax` - for example those made by test frameworks which mock the $.ajax method.

This change incorporates an extra function call, but allows the Backbone.ajax method to behave as per user expectations.
