### PR TITLE
Adding History.segment() for URL segment retrieval

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -991,6 +991,13 @@
       return fragment.replace(routeStripper, '');
     },
 
+    // Simple function for grabbing a segment from the URL, providing a default
+    // if it does not exist, or null if there is no segment or default.
+    segment : function(index, fallback) {
+      var segments = this.getFragment().split('/');
+      return segments[index - 1] || fallback;
+    },
+
     // Start the hash change handling, returning `true` if the current URL matches
     // an existing route, and `false` otherwise.
     start: function(options) {

--- a/index.html
+++ b/index.html
@@ -308,6 +308,8 @@
     </a>
     <ul class="toc_section">
       <li>– <a href="#History-start">start</a></li>
+      <li>– <a href="#History-getFragment">getFragment</a></li>
+      <li>– <a href="#History-segment">segment</a></li>
     </ul>
 
     <a class="toc_title" href="#Sync">
@@ -1984,6 +1986,27 @@ $(function(){
   Backbone.history.start({pushState: true});
 });
 </pre>
+
+    <p id="History-getFragment">
+      <b class="header">getFragment</b><code>Backbone.history.getFragment()</code>
+      <br />
+      Returns the cross-browser normalized URL fragment, either from the URL, the hash, or the override. 
+      This can only be used after Backbone.history.start() is called.
+    </p>
+    
+    <p id="History-segment">
+      <b class="header">segment</b><code>Backbone.history.segment(index, [default])</code>
+      <br />
+      A convenience function for grabbing a specific segment from the URL. Segments are not zero indexed
+      so <tt>Backbone.history.segment(1)</tt>, for the hash <tt>#one/two/three</tt> returns 'one'.
+    </p>
+    
+    <p>
+      <tt>Backbone.history.segment()</tt> uses <tt>Backbone.history.getFragment()</tt>, 
+      so the URL is cleaned and normalized between the hash and pushState options. If the URL 
+      segment is empty, the second argument will be returned, or null if none was provided.
+      This can only be used after Backbone.history.start() is called.
+    </p>
 
     <h2 id="Sync">Backbone.sync</h2>
 

--- a/test/router.js
+++ b/test/router.js
@@ -278,4 +278,16 @@ $(document).ready(function() {
     }, 50);
   });
 
+  asyncTest("History: grab specific url segments", function(){
+    router.navigate('url/item/4', {trigger: true});
+    setTimeout(function(){
+      equal(Backbone.history.segment(1), 'url');
+      equal(Backbone.history.segment(2), 'item');
+      equal(Backbone.history.segment(3), '4');
+      equal(Backbone.history.segment(4), null);
+      equal(Backbone.history.segment(4, '1'), '1');
+      start();
+    }, 50);
+  });
+
 });


### PR DESCRIPTION
I've found myself grabbing specific URL segments outside of the router class (mainly when routing with *splats), and I've been using something similar to this in different places, so I thought it might be helpful to add this to Backbone.History as a convenience function.

Backbone.history.segment(index, [default]);

Usage for http://example.com/main/page/2 or http://example.com#main/page/2

`Backbone.history.segment(1) === 'main'`
`Backbone.history.segment(3) === '2'`
`Backbone.history.segment(4) === null`
`Backbone.history.segment(4, 'error') === 'error'`

Documentation and tests are included.

I've also added documentation for Backbone.history.getFragment(), which I noticed while looking through the history api, and is a great function to know about.
