### PR TITLE
Reset events include previous models.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -745,6 +745,7 @@
       for (var i = 0, l = this.models.length; i < l; i++) {
         this._removeReference(this.models[i]);
       }
+      options.previous = this.models;
       this._reset();
       this.add(models, _.extend({silent: true}, options));
       if (!options.silent) this.trigger('reset', this, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -635,4 +635,14 @@ $(document).ready(function() {
     col.fetch(opts);
     col.create(m, opts);
   });
+
+  test("Reset includes previous models in triggered event.", 1, function() {
+    var model = new Backbone.Model();
+    var collection = new Backbone.Collection([model])
+    .on('reset', function(collection, options) {
+      deepEqual(options.previous, [model]);
+    });
+    collection.reset([]);
+  });
+
 });


### PR DESCRIPTION
When handling reset events, it's not possible to find out what models were removed.  By including the previous `models` array in the event, it is possible for the consumer of the event to calculate this.
