### PR TITLE
Updated `Collection.sort()` doc to clarify priority maintenance

### DIFF
--- a/index.html
+++ b/index.html
@@ -1612,7 +1612,7 @@ alert(chapters.pluck('title'));
       <br />
       Force a collection to re-sort itself. You don't need to call this under
       normal circumstances, as a collection with a <a href="#Collection-comparator">comparator</a> function
-      will maintain itself in proper sort order at all times. Calling <b>sort</b>
+      will sort itself whenever a model is added. Calling <b>sort</b>
       triggers the collection's <tt>"reset"</tt> event, unless silenced by passing
       <tt>{silent: true}</tt>
     </p>


### PR DESCRIPTION
I was a bit confused by the current doc as I assumed, based on the way it is worded, that the collection would sort itself on the 'change' event also. I'm guessing this isn't intended as it could be pretty costly performance wise, so this updates the doc according.
