### PR TITLE
Needs method for calling overrided parent methods

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1410,6 +1410,12 @@
     // `parent`'s constructor function.
     ctor.prototype = parent.prototype;
     child.prototype = new ctor();
+    
+    // this is for calling overrided parent methods
+    child.prototype.inherited = function( methodName, args ){
+        if ( parent[methodName] )
+            return parent[methodName].apply( this, args );
+    };
 
     // Add prototype properties (instance properties) to the subclass,
     // if supplied.


### PR DESCRIPTION
Added method .inherited( methodName, args ) in extend method.
Using:

<pre>
var AbstractLayout = Backbone.View.extend({
    getChildren: function(){
        return this.children;
    }
});

var ConcreteLayout = AbstractLayout.extend({
    getChildren: function(){
        return this.inherited( 'getChildren', arguments ).filter( funtion( child ){
            return Boolean( child.visible )
        });
    }
})

var layout = new ConcreteLayout,
    children = layout.getChildren();
</pre>
