### PR TITLE
Group listeners to allow collective removal

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -198,4 +198,32 @@ $(document).ready(function() {
     obj.trigger('event');
   });
 
+  test("remove all callbacks tagged with a group",function() {
+    var obj = _.extend({}, Backbone.Events);
+    var obj2 = _.extend({}, Backbone.Events);
+    var calls = 0;
+    var handlers = {
+      one: function() { calls += 1 },
+      two: function() { calls += 1 },
+    };
+    obj.on("event",handlers.one,null,"groupOne")
+    obj.on("event",handlers.two,null,"groupOne")
+    obj2.on("event",handlers.one,null,"groupOne")
+    obj2.on("event",handlers.two,null,"groupOne")
+
+    obj.trigger("event");
+    obj2.trigger("event")
+    ok(4 === calls);
+
+    // can handle callbacks being unbound elsewhere
+    obj.off("event",handlers.one,null)
+
+    calls = 0;
+    Backbone.Events.groupOff("groupOne")
+
+    obj.trigger("event");
+    obj2.trigger("event")
+    ok(0 === calls);
+  });
+
 });


### PR DESCRIPTION
Simple implementation of a cross-object grouping for listeners, so they can be removed in one go. Useful in views' `remove` or `destroy` methods to remove all event handlers from multiple subscriptions on models/collections.

Best case now is when you've bound context for every listener `sub.off(null,null,context)`, but you still need as many unbinds as you've objects listened too.

There could be neater implementations out there (sketch below), but just wanted to see if there was any interest in the simpler implementation in this request.

```
Backbone.Event.group("groupName",function() {
    subOne.on("news",this.handler)
    subTwo.on("other",this.other)
})
Backbone.Event.groupOff("groupName")
```

Thanks
