### PR TITLE
Multiple event type binding in Backbone.View's delegateEvents

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1235,14 +1235,17 @@
         if (!_.isFunction(method)) method = this[events[key]];
         if (!method) throw new Error('Method "' + events[key] + '" does not exist');
         var match = key.match(delegateEventSplitter);
-        var eventName = match[1], selector = match[2];
+        var eventTypes = match[1].split(','), selector = match[2];
         method = _.bind(method, this);
-        eventName += '.delegateEvents' + this.cid;
-        if (selector === '') {
-          this.$el.bind(eventName, method);
-        } else {
-          this.$el.delegate(selector, eventName, method);
-        }
+        var self = this;
+        _(eventTypes).each(function(eventName) {
+            eventName += '.delegateEvents' + self.cid;
+            if (selector === '') {
+              self.$el.bind(eventName, method);
+            } else {
+              self.$el.delegate(selector, eventName, method);
+            }
+        });
       }
     },
 


### PR DESCRIPTION
I've often found the need to have multiple event types for one method in a backbone view.

Instead of having to declare a view's events like this:

``` javascript
events: {
    'mousedown .foo': 'doSomething',
    'touchstart .foo': 'doSomething'
}
```

This change now makes it possible to do this:

``` javascript
events: {
    'mousedown,touchstart .foo': 'doSomething'
}
```
