### PR TITLE
Fix #1366 - Do not prepend root to history.fragment.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1101,25 +1101,24 @@
     navigate: function(fragment, options) {
       if (!History.started) return false;
       if (!options || options === true) options = {trigger: options};
-      var frag = (fragment || '').replace(routeStripper, '');
-      if (this.fragment == frag) return;
-      var fullFrag = (frag.indexOf(this.options.root) != 0 ? this.options.root : '') + frag;
+      fragment = (fragment || '').replace(routeStripper, '');
+      if (this.fragment === fragment) return;
+      this.fragment = fragment;
+      var fullFrag = (fragment.indexOf(this.options.root) != 0 ? this.options.root : '') + fragment;
 
       // If pushState is available, we use it to set the fragment as a real URL.
       if (this._hasPushState) {
-        this.fragment = fullFrag;
         window.history[options.replace ? 'replaceState' : 'pushState']({}, document.title, fullFrag);
 
       // If hash changes haven't been explicitly disabled, update the hash
       // fragment to store history.
       } else if (this._wantsHashChange) {
-        this.fragment = frag;
-        this._updateHash(window.location, frag, options.replace);
-        if (this.iframe && (frag != this.getFragment(this.getHash(this.iframe)))) {
+        this._updateHash(window.location, fragment, options.replace);
+        if (this.iframe && (fragment != this.getFragment(this.getHash(this.iframe)))) {
           // Opening and closing the iframe tricks IE7 and earlier to push a history entry on hash-tag change.
           // When replace is true, we don't want this.
           if(!options.replace) this.iframe.document.open().close();
-          this._updateHash(this.iframe.location, frag, options.replace);
+          this._updateHash(this.iframe.location, fragment, options.replace);
         }
 
       // If you've told us that you explicitly don't want fallback hashchange-

--- a/test/router.js
+++ b/test/router.js
@@ -4,6 +4,9 @@ $(document).ready(function() {
   var lastRoute = null;
   var lastArgs = [];
 
+  var pushState = window.history && window.history.pushState;
+  var pathname = window.location.pathname;
+
   function onRoute(router, route, args) {
     lastRoute = route;
     lastArgs = args;
@@ -24,6 +27,7 @@ $(document).ready(function() {
     teardown: function() {
       Backbone.history.stop();
       Backbone.history.off('route', onRoute);
+      if (pushState) window.history.pushState({}, document.title, pathname);
     }
 
   });
@@ -277,5 +281,15 @@ $(document).ready(function() {
         }, 50);
     }, 50);
   });
+
+  if (pushState) {
+    test('History does not prepend root to fragment.', 1, function() {
+      Backbone.History.started = false;
+      var history = new Backbone.History();
+      history.start({pushState: true});
+      history.navigate('x');
+      strictEqual(history.fragment, 'x');
+    });
+  }
 
 });


### PR DESCRIPTION
Since the `pushState` branch of `navigate` used `fullFrag` (the fragment to navigate to with the root prepended) it was used to replace the stored fragment.  I believe this is incorrect since `history.fragment` should always be the rootless fragment.  I tested the pushState behavior by returning to the original pathname in `teardown` and skipping the test in non-pushState browsers.

I also removed the use of `frag` in `navigate` (the fragment with the leading `#` or `/` removed) as I believe it is superfluous.

A test is still needed for #1206 since I've likely affected that functionality.  I'll submit one later when I come up with a good way to test it.  :)
