### PR TITLE
adding the `expected` argument to all tests

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -31,7 +31,7 @@ $(document).ready(function() {
 
   });
 
-  test("Collection: new and sort", function() {
+  test("Collection: new and sort", 7, function() {
     equal(col.first(), a, "a should be first");
     equal(col.last(), d, "d should be last");
     col.comparator = function(a, b) {
@@ -47,13 +47,13 @@ $(document).ready(function() {
     equal(col.length, 4);
   });
 
-  test("Collection: get, getByCid", function() {
+  test("Collection: get, getByCid", 3, function() {
     equal(col.get(0), d);
     equal(col.get(2), b);
     equal(col.getByCid(col.first().cid), col.first());
   });
 
-  test("Collection: get with non-default ids", function() {
+  test("Collection: get with non-default ids", 2, function() {
     var col = new Backbone.Collection();
     var MongoModel = Backbone.Model.extend({
       idAttribute: '_id'
@@ -65,7 +65,7 @@ $(document).ready(function() {
     equal(col.get(101), model);
   });
 
-  test("Collection: update index when id changes", function() {
+  test("Collection: update index when id changes", 3, function() {
     var col = new Backbone.Collection();
     col.add([
       {id : 0, name : 'one'},
@@ -78,15 +78,15 @@ $(document).ready(function() {
     equal(col.get(101).get('name'), 'one');
   });
 
-  test("Collection: at", function() {
+  test("Collection: at", 1, function() {
     equal(col.at(2), c);
   });
 
-  test("Collection: pluck", function() {
+  test("Collection: pluck", 1, function() {
     equal(col.pluck('label').join(' '), 'a b c d');
   });
 
-  test("Collection: add", function() {
+  test("Collection: add", 11, function() {
     var added, opts, secondAdded;
     added = opts = secondAdded = null;
     e = new Backbone.Model({id: 10, label : 'e'});
@@ -118,7 +118,7 @@ $(document).ready(function() {
     equal(atCol.last(), h);
   });
 
-  test("Collection: add multiple models", function() {
+  test("Collection: add multiple models", 6, function() {
     var col = new Backbone.Collection([{at: 0}, {at: 1}, {at: 9}]);
     col.add([{at: 2}, {at: 3}, {at: 4}, {at: 5}, {at: 6}, {at: 7}, {at: 8}], {at: 2});
     for (var i = 0; i <= 5; i++) {
@@ -126,7 +126,7 @@ $(document).ready(function() {
     }
   });
 
-  test("Collection: add; at should have preference over comparator", function() {
+  test("Collection: add; at should have preference over comparator", 1, function() {
     var Col = Backbone.Collection.extend({
       comparator: function(a,b) {
         return a.id > b.id ? -1 : 1;
@@ -144,14 +144,14 @@ $(document).ready(function() {
     equal(col.pluck('id').join(' '), '1 2 3');
   });
 
-  test("Collection: can't add different model with same id to collection twice", function() {
+  test("Collection: can't add different model with same id to collection twice", 1, function() {
     var col = new Backbone.Collection;
     col.unshift({id: 101});
     col.add({id: 101});
     equal(col.length, 1);
   });
 
-  test("Collection: merge in duplicate models with {merge: true}", function() {
+  test("Collection: merge in duplicate models with {merge: true}", 2, function() {
     var col = new Backbone.Collection;
     col.add([{id: 1, name: 'Moe'}, {id: 2, name: 'Curly'}, {id: 3, name: 'Larry'}]);
     col.add({id: 1, name: 'Moses'});
@@ -160,7 +160,7 @@ $(document).ready(function() {
     equal(col.first().get('name'), 'Moses');
   });
 
-  test("Collection: add model to multiple collections", function() {
+  test("Collection: add model to multiple collections", 10, function() {
     var counter = 0;
     var e = new Backbone.Model({id: 10, label : 'e'});
     e.bind('add', function(model, collection) {
@@ -188,7 +188,7 @@ $(document).ready(function() {
     equal(e.collection, colE);
   });
 
-  test("Collection: add model with parse", function() {
+  test("Collection: add model with parse", 1, function() {
     var Model = Backbone.Model.extend({
       parse: function(obj) {
         obj.value += 1;
@@ -202,7 +202,7 @@ $(document).ready(function() {
     equal(col.at(0).get('value'), 2);
   });
 
-  test("Collection: add model to collection with sort()-style comparator", function() {
+  test("Collection: add model to collection with sort()-style comparator", 3, function() {
     var col = new Backbone.Collection;
     col.comparator = function(a, b) {
       return a.get('name') < b.get('name') ? -1 : 1;
@@ -218,7 +218,7 @@ $(document).ready(function() {
     equal(col.indexOf(tom), 2);
   });
 
-  test("Collection: comparator that depends on `this`", function() {
+  test("Collection: comparator that depends on `this`", 1, function() {
     var col = new Backbone.Collection;
     col.negative = function(num) {
       return -num;
@@ -230,7 +230,7 @@ $(document).ready(function() {
     equal(col.pluck('id').join(' '), '3 2 1');
   });
 
-  test("Collection: remove", function() {
+  test("Collection: remove", 5, function() {
     var removed = null;
     var otherRemoved = null;
     col.bind('remove', function(model, col, options) {
@@ -247,20 +247,20 @@ $(document).ready(function() {
     equal(otherRemoved, null);
   });
 
-  test("Collection: shift and pop", function() {
+  test("Collection: shift and pop", 2, function() {
     var col = new Backbone.Collection([{a: 'a'}, {b: 'b'}, {c: 'c'}]);
     equal(col.shift().get('a'), 'a');
     equal(col.pop().get('c'), 'c');
   });
 
-  test("Collection: slice", function() {
+  test("Collection: slice", 2, function() {
     var col = new Backbone.Collection([{a: 'a'}, {b: 'b'}, {c: 'c'}]);
     var array = col.slice(1, 3);
     equal(array.length, 2);
     equal(array[0].get('b'), 'b');
   });
 
-  test("Collection: events are unbound on remove", function() {
+  test("Collection: events are unbound on remove", 3, function() {
     var counter = 0;
     var dj = new Backbone.Model();
     var emcees = new Backbone.Collection([dj]);
@@ -273,7 +273,7 @@ $(document).ready(function() {
     equal(counter, 1);
   });
 
-  test("Collection: remove in multiple collections", function() {
+  test("Collection: remove in multiple collections", 7, function() {
     var modelData = {
       id : 5,
       title : 'Othello'
@@ -297,7 +297,7 @@ $(document).ready(function() {
     equal(passed, true);
   });
 
-  test("Collection: remove same model in multiple collection", function() {
+  test("Collection: remove same model in multiple collection", 16, function() {
     var counter = 0;
     var e = new Backbone.Model({id: 5, title: 'Othello'});
     e.bind('remove', function(model, collection) {
@@ -331,7 +331,7 @@ $(document).ready(function() {
     equal(counter, 2);
   });
 
-  test("Collection: model destroy removes from all collections", function() {
+  test("Collection: model destroy removes from all collections", 3, function() {
     var e = new Backbone.Model({id: 5, title: 'Othello'});
     e.sync = function(method, model, options) { options.success({}); };
     var colE = new Backbone.Collection([e]);
@@ -342,7 +342,7 @@ $(document).ready(function() {
     equal(undefined, e.collection);
   });
 
-  test("Colllection: non-persisted model destroy removes from all collections", function() {
+  test("Colllection: non-persisted model destroy removes from all collections", 3, function() {
     var e = new Backbone.Model({title: 'Othello'});
     e.sync = function(method, model, options) { throw "should not be called"; };
     var colE = new Backbone.Collection([e]);
@@ -353,7 +353,7 @@ $(document).ready(function() {
     equal(undefined, e.collection);
   });
 
-  test("Collection: fetch", function() {
+  test("Collection: fetch", 4, function() {
     col.fetch();
     equal(lastRequest.method, 'read');
     equal(lastRequest.model, col);
@@ -363,7 +363,7 @@ $(document).ready(function() {
     equal(lastRequest.options.parse, false);
   });
 
-  test("Collection: create", function() {
+  test("Collection: create", 4, function() {
     var model = col.create({label: 'f'}, {wait: true});
     equal(lastRequest.method, 'create');
     equal(lastRequest.model, model);
@@ -371,7 +371,7 @@ $(document).ready(function() {
     equal(model.collection, col);
   });
 
-  test("Collection: create enforces validation", function() {
+  test("Collection: create enforces validation", 1, function() {
     var ValidatingModel = Backbone.Model.extend({
       validate: function(attrs) {
         return "fail";
@@ -384,7 +384,7 @@ $(document).ready(function() {
     equal(col.create({"foo":"bar"}), false);
   });
 
-  test("Collection: a failing create runs the error callback", function() {
+  test("Collection: a failing create runs the error callback", 1, function() {
     var ValidatingModel = Backbone.Model.extend({
       validate: function(attrs) {
         return "fail";
@@ -400,7 +400,7 @@ $(document).ready(function() {
     equal(flag, true);
   });
 
-  test("collection: initialize", function() {
+  test("collection: initialize", 1, function() {
     var Collection = Backbone.Collection.extend({
       initialize: function() {
         this.one = 1;
@@ -410,11 +410,11 @@ $(document).ready(function() {
     equal(coll.one, 1);
   });
 
-  test("Collection: toJSON", function() {
+  test("Collection: toJSON", 1, function() {
     equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });
 
-  test("Collection: where", function() {
+  test("Collection: where", 6, function() {
     var coll = new Backbone.Collection([
       {a: 1},
       {a: 1},
@@ -430,7 +430,7 @@ $(document).ready(function() {
     equal(coll.where({a: 1, b: 2}).length, 1);
   });
 
-  test("Collection: Underscore methods", function() {
+  test("Collection: Underscore methods", 13, function() {
     equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
     equal(col.any(function(model){ return model.id === 100; }), false);
     equal(col.any(function(model){ return model.id === 0; }), true);
@@ -450,7 +450,7 @@ $(document).ready(function() {
          [4, 0]);
   });
 
-  test("Collection: reset", function() {
+  test("Collection: reset", 10, function() {
     var resetCount = 0;
     var models = col.models;
     col.bind('reset', function() { resetCount += 1; });
@@ -469,7 +469,7 @@ $(document).ready(function() {
     ok(_.isEqual(col.last().attributes, d.attributes));
   });
 
-  test("Collection: reset passes caller options", function() {
+  test("Collection: reset passes caller options", 3, function() {
     var Model = Backbone.Model.extend({
       initialize: function(attrs, options) {
         this.model_parameter = options.model_parameter;
@@ -483,14 +483,14 @@ $(document).ready(function() {
     });
   });
 
-  test("Collection: trigger custom events on models", function() {
+  test("Collection: trigger custom events on models", 1, function() {
     var fired = null;
     a.bind("custom", function() { fired = true; });
     a.trigger("custom");
     equal(fired, true);
   });
 
-  test("Collection: add does not alter arguments", function(){
+  test("Collection: add does not alter arguments", 2, function(){
     var attrs = {};
     var models = [attrs];
     new Backbone.Collection().add(models);
@@ -511,7 +511,7 @@ $(document).ready(function() {
     col.create({prop: 'value'});
   });
 
-  test("#574, remove its own reference to the .models array.", function() {
+  test("#574, remove its own reference to the .models array.", 2, function() {
     var col = new Backbone.Collection([
       {id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}
     ]);
@@ -520,7 +520,7 @@ $(document).ready(function() {
     equal(col.length, 0);
   });
 
-  test("#861, adding models to a collection which do not pass validation", function() {
+  test("#861, adding models to a collection which do not pass validation", 1, function() {
     raises(function() {
       var Model = Backbone.Model.extend({
         validate: function(attrs) {
@@ -540,8 +540,7 @@ $(document).ready(function() {
     });
   });
 
-  test("Collection: index with comparator", function() {
-    expect(4);
+  test("Collection: index with comparator", 4, function() {
     var counter = 0;
     var col = new Backbone.Collection([{id: 2}, {id: 4}], {
       comparator: function(model){ return model.id; }
@@ -558,8 +557,7 @@ $(document).ready(function() {
     col.add([{id: 3}, {id: 1}]);
   });
 
-  test("Collection: throwing during add leaves consistent state", function() {
-    expect(4);
+  test("Collection: throwing during add leaves consistent state", 4, function() {
     var col = new Backbone.Collection();
     col.bind('test', function() { ok(false); });
     col.model = Backbone.Model.extend({
@@ -573,7 +571,7 @@ $(document).ready(function() {
     equal(col.length, 0);
   });
 
-  test("Collection: multiple copies of the same model", function() {
+  test("Collection: multiple copies of the same model", 3, function() {
     var col = new Backbone.Collection();
     var model = new Backbone.Model();
     col.add([model, model]);
@@ -583,20 +581,20 @@ $(document).ready(function() {
     equal(col.last().id, 1);
   });
 
-  test("#964 - collection.get return in consistent", function() {
+  test("#964 - collection.get return inconsistent", 2, function() {
     var c = new Backbone.Collection();
     ok(c.get(null) === undefined);
     ok(c.get() === undefined);
   });
 
-  test("#1112 - passing options.model sets collection.model", function() {
+  test("#1112 - passing options.model sets collection.model", 2, function() {
     var Model = Backbone.Model.extend({});
     var c = new Backbone.Collection([{id: 1}], {model: Model});
     ok(c.model === Model);
     ok(c.at(0) instanceof Model);
   });
 
-  test("null and undefined are invalid ids.", function() {
+  test("null and undefined are invalid ids.", 2, function() {
     var model = new Backbone.Model({id: 1});
     var collection = new Backbone.Collection([model]);
     model.set({id: null});
@@ -606,11 +604,11 @@ $(document).ready(function() {
     ok(!collection.get('undefined'));
   });
 
-  test("Collection: falsy comparator", function(){
+  test("Collection: falsy comparator", 4, function(){
     var Col = Backbone.Collection.extend({
       comparator: function(model){ return model.id; }
     });
-    var col = new Col
+    var col = new Col();
     var colFalse = new Col(null, {comparator: false});
     var colNull = new Col(null, {comparator: null});
     var colUndefined = new Col(null, {comparator: undefined});
@@ -620,8 +618,7 @@ $(document).ready(function() {
     ok(colUndefined.comparator);
   });
 
-  test("#1355 - `options` is passed to success callbacks", function(){
-    expect(2);
+  test("#1355 - `options` is passed to success callbacks", 2, function(){
     var m = new Backbone.Model({x:1});
     var col = new Backbone.Collection();
     var opts = {

--- a/test/events.js
+++ b/test/events.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
 
   module("Backbone.Events");
 
-  test("Events: on and trigger", function() {
+  test("Events: on and trigger", 2, function() {
     var obj = { counter: 0 };
     _.extend(obj,Backbone.Events);
     obj.on('event', function() { obj.counter += 1; });
@@ -15,7 +15,7 @@ $(document).ready(function() {
     equal(obj.counter, 5, 'counter should be incremented five times.');
   });
 
-  test("Events: binding and triggering multiple events", function() {
+  test("Events: binding and triggering multiple events", 4, function() {
     var obj = { counter: 0 };
     _.extend(obj,Backbone.Events);
 
@@ -35,7 +35,7 @@ $(document).ready(function() {
     equal(obj.counter, 5);
   });
 
-  test("Events: trigger all for each event", function() {
+  test("Events: trigger all for each event", 3, function() {
     var a, b, obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
     obj.on('all', function(event) {
@@ -49,7 +49,7 @@ $(document).ready(function() {
     equal(obj.counter, 2);
   });
 
-  test("Events: on, then unbind all functions", function() {
+  test("Events: on, then unbind all functions", 1, function() {
     var obj = { counter: 0 };
     _.extend(obj,Backbone.Events);
     var callback = function() { obj.counter += 1; };
@@ -60,7 +60,7 @@ $(document).ready(function() {
     equal(obj.counter, 1, 'counter should have only been incremented once.');
   });
 
-  test("Events: bind two callbacks, unbind only one", function() {
+  test("Events: bind two callbacks, unbind only one", 2, function() {
     var obj = { counterA: 0, counterB: 0 };
     _.extend(obj,Backbone.Events);
     var callback = function() { obj.counterA += 1; };
@@ -73,7 +73,7 @@ $(document).ready(function() {
     equal(obj.counterB, 2, 'counterB should have been incremented twice.');
   });
 
-  test("Events: unbind a callback in the midst of it firing", function() {
+  test("Events: unbind a callback in the midst of it firing", 1, function() {
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
     var callback = function() {
@@ -87,7 +87,7 @@ $(document).ready(function() {
     equal(obj.counter, 1, 'the callback should have been unbound.');
   });
 
-  test("Events: two binds that unbind themeselves", function() {
+  test("Events: two binds that unbind themeselves", 2, function() {
     var obj = { counterA: 0, counterB: 0 };
     _.extend(obj,Backbone.Events);
     var incrA = function(){ obj.counterA += 1; obj.unbind('event', incrA); };
@@ -101,9 +101,7 @@ $(document).ready(function() {
     equal(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
 
-  test("Events: bind a callback with a supplied context", function () {
-    expect(1);
-
+  test("Events: bind a callback with a supplied context", 1, function () {
     var TestClass = function () {
       return this;
     };
@@ -112,15 +110,11 @@ $(document).ready(function() {
     };
 
     var obj = _.extend({},Backbone.Events);
-
     obj.bind('event', function () { this.assertTrue(); }, (new TestClass));
-
     obj.trigger('event');
-
   });
 
-  test("Events: nested trigger with unbind", function () {
-    expect(1);
+  test("Events: nested trigger with unbind", 1, function () {
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
     var incr1 = function(){ obj.counter += 1; obj.unbind('event', incr1); obj.trigger('event'); };
@@ -131,7 +125,7 @@ $(document).ready(function() {
     equal(obj.counter, 3, 'counter should have been incremented three times');
   });
 
-  test("Events: callback list is not altered during trigger", function () {
+  test("Events: callback list is not altered during trigger", 2, function () {
     var counter = 0, obj = _.extend({}, Backbone.Events);
     var incr = function(){ counter++; };
     obj.bind('event', function(){ obj.bind('event', incr).bind('all', incr); })
@@ -145,7 +139,7 @@ $(document).ready(function() {
     equal(counter, 2, 'unbind does not alter callback list');
   });
 
-  test("#1282 - 'all' callback list is retrieved after each event.", function() {
+  test("#1282 - 'all' callback list is retrieved after each event.", 1, function() {
     var counter = 0;
     var obj = _.extend({}, Backbone.Events);
     var incr = function(){ counter++; };
@@ -178,7 +172,7 @@ $(document).ready(function() {
     obj.trigger('x y');
   });
 
-  test("off is chainable", function() {
+  test("off is chainable", 3, function() {
     var obj = _.extend({}, Backbone.Events);
     // With no events
     ok(obj.off() === obj);

--- a/test/model.js
+++ b/test/model.js
@@ -47,7 +47,7 @@ $(document).ready(function() {
 
   });
 
-  test("Model: initialize", function() {
+  test("Model: initialize", 3, function() {
     var Model = Backbone.Model.extend({
       initialize: function() {
         this.one = 1;
@@ -59,7 +59,7 @@ $(document).ready(function() {
     equal(model.collection, collection);
   });
 
-  test("Model: initialize with attributes and options", function() {
+  test("Model: initialize with attributes and options", 1, function() {
     var Model = Backbone.Model.extend({
       initialize: function(attributes, options) {
         this.one = options.one;
@@ -69,7 +69,7 @@ $(document).ready(function() {
     equal(model.one, 1);
   });
 
-  test("Model: initialize with parsed attributes", function() {
+  test("Model: initialize with parsed attributes", 1, function() {
     var Model = Backbone.Model.extend({
       parse: function(obj) {
         obj.value += 1;
@@ -80,7 +80,7 @@ $(document).ready(function() {
     equal(model.get('value'), 2);
   });
 
-  test("Model: url", function() {
+  test("Model: url", 3, function() {
     doc.urlRoot = null;
     equal(doc.url(), '/collection/1-the-tempest');
     doc.collection.url = '/collection/';
@@ -90,7 +90,7 @@ $(document).ready(function() {
     doc.collection = collection;
   });
 
-  test("Model: url when using urlRoot, and uri encoding", function() {
+  test("Model: url when using urlRoot, and uri encoding", 2, function() {
     var Model = Backbone.Model.extend({
       urlRoot: '/collection'
     });
@@ -100,7 +100,7 @@ $(document).ready(function() {
     equal(model.url(), '/collection/%2B1%2B');
   });
 
-  test("Model: url when using urlRoot as a function to determine urlRoot at runtime", function() {
+  test("Model: url when using urlRoot as a function to determine urlRoot at runtime", 2, function() {
     var Model = Backbone.Model.extend({
       urlRoot: function() {
         return '/nested/' + this.get('parent_id') + '/collection';
@@ -113,7 +113,7 @@ $(document).ready(function() {
     equal(model.url(), '/nested/1/collection/2');
   });
 
-  test("Model: clone", function() {
+  test("Model: clone", 8, function() {
     var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
     var b = a.clone();
     equal(a.get('foo'), 1);
@@ -127,7 +127,7 @@ $(document).ready(function() {
     equal(b.get('foo'), 1, "Changing a parent attribute does not change the clone.");
   });
 
-  test("Model: isNew", function() {
+  test("Model: isNew", 6, function() {
     var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
     ok(a.isNew(), "it should be new");
     a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3, 'id': -5 });
@@ -139,12 +139,12 @@ $(document).ready(function() {
     ok(!new Backbone.Model({ 'id': -5 }).isNew(), "is false for a negative integer");
   });
 
-  test("Model: get", function() {
+  test("Model: get", 2, function() {
     equal(doc.get('title'), 'The Tempest');
     equal(doc.get('author'), 'Bill Shakespeare');
   });
 
-  test("Model: escape", function() {
+  test("Model: escape", 5, function() {
     equal(doc.escape('title'), 'The Tempest');
     doc.set({audience: 'Bill & Bob'});
     equal(doc.escape('audience'), 'Bill &amp; Bob');
@@ -156,7 +156,7 @@ $(document).ready(function() {
     equal(doc.escape('audience'), '');
   });
 
-  test("Model: has", function() {
+  test("Model: has", 10, function() {
     var a = new Backbone.Model();
     equal(a.has("name"), false);
     _([true, "Truth!", 1, false, '', 0]).each(function(value) {
@@ -171,8 +171,7 @@ $(document).ready(function() {
     });
   });
 
-  test("Model: set and unset", function() {
-    expect(8);
+  test("Model: set and unset", 8, function() {
     var a = new Backbone.Model({id: 'id', foo: 1, bar: 2, baz: 3});
     var changeCount = 0;
     a.on("change:foo", function() { changeCount += 1; });
@@ -195,7 +194,7 @@ $(document).ready(function() {
     equal(a.id, undefined, "Unsetting the id should remove the id property.");
   });
 
-  test("Model: multiple unsets", function() {
+  test("Model: multiple unsets", 1, function() {
     var i = 0;
     var counter = function(){ i++; };
     var model = new Backbone.Model({a: 1});
@@ -206,7 +205,7 @@ $(document).ready(function() {
     equal(i, 2, 'Unset does not fire an event for missing attributes.');
   });
 
-  test("Model: unset and changedAttributes", function() {
+  test("Model: unset and changedAttributes", 2, function() {
     var model = new Backbone.Model({a: 1});
     model.unset('a', {silent: true});
     var changedAttributes = model.changedAttributes();
@@ -216,7 +215,7 @@ $(document).ready(function() {
     ok('a' in changedAttributes, 'changedAttributes should contain unset properties when running changedAttributes again after an unset.');
   });
 
-  test("Model: using a non-default id attribute.", function() {
+  test("Model: using a non-default id attribute.", 5, function() {
     var MongoModel = Backbone.Model.extend({idAttribute : '_id'});
     var model = new MongoModel({id: 'eye-dee', _id: 25, title: 'Model'});
     equal(model.get('id'), 'eye-dee');
@@ -227,13 +226,13 @@ $(document).ready(function() {
     equal(model.isNew(), true);
   });
 
-  test("Model: set an empty string", function() {
+  test("Model: set an empty string", 1, function() {
     var model = new Backbone.Model({name : "Model"});
     model.set({name : ''});
     equal(model.get('name'), '');
   });
 
-  test("Model: clear", function() {
+  test("Model: clear", 3, function() {
     var changed;
     var model = new Backbone.Model({id: 1, name : "Model"});
     model.on("change:name", function(){ changed = true; });
@@ -246,7 +245,7 @@ $(document).ready(function() {
     equal(model.get('name'), undefined);
   });
 
-  test("Model: defaults", function() {
+  test("Model: defaults", 4, function() {
     var Defaulted = Backbone.Model.extend({
       defaults: {
         "one": 1,
@@ -269,7 +268,7 @@ $(document).ready(function() {
     equal(model.get('two'), null);
   });
 
-  test("Model: change, hasChanged, changedAttributes, previous, previousAttributes", function() {
+  test("Model: change, hasChanged, changedAttributes, previous, previousAttributes", 12, function() {
     var model = new Backbone.Model({name : "Tim", age : 10});
     equal(model.changedAttributes(), false);
     model.on('change', function() {
@@ -290,14 +289,14 @@ $(document).ready(function() {
 
   });
 
-  test("Model: changedAttributes", function() {
+  test("Model: changedAttributes", 3, function() {
     var model = new Backbone.Model({a: 'a', b: 'b'});
     equal(model.changedAttributes(), false);
     equal(model.changedAttributes({a: 'a'}), false);
     equal(model.changedAttributes({a: 'b'}).a, 'b');
   });
 
-  test("Model: change with options", function() {
+  test("Model: change with options", 2, function() {
     var value;
     var model = new Backbone.Model({name: 'Rob'});
     model.on('change', function(model, options) {
@@ -310,7 +309,7 @@ $(document).ready(function() {
     equal(value, 'Ms. Sue');
   });
 
-  test("Model: change after initialize", function () {
+  test("Model: change after initialize", 1, function () {
     var changed = 0;
     var attrs = {id: 1, label: 'c'};
     var obj = new Backbone.Model(attrs);
@@ -319,7 +318,7 @@ $(document).ready(function() {
     equal(changed, 0);
   });
 
-  test("Model: save within change event", function () {
+  test("Model: save within change event", 1, function () {
     var model = new Backbone.Model({firstName : "Taylor", lastName: "Swift"});
     model.on('change', function () {
       model.save();
@@ -328,7 +327,7 @@ $(document).ready(function() {
     model.set({lastName: 'Hicks'});
   });
 
-  test("Model: validate after save", function() {
+  test("Model: validate after save", 1, function() {
     var lastError, model = new Backbone.Model();
     model.validate = function(attrs) {
       if (attrs.admin) return "Can't change admin status.";
@@ -343,7 +342,7 @@ $(document).ready(function() {
     equal(lastError, "Can't change admin status.");
   });
 
-  test("Model: isValid", function() {
+  test("Model: isValid", 5, function() {
     var model = new Backbone.Model({valid: true});
     model.validate = function(attrs) {
       if (!attrs.valid) return "invalid";
@@ -355,13 +354,13 @@ $(document).ready(function() {
     equal(model.isValid(), false);
   });
 
-  test("Model: save", function() {
+  test("Model: save", 2, function() {
     doc.save({title : "Henry V"});
     equal(lastRequest.method, 'update');
     ok(_.isEqual(lastRequest.model, doc));
   });
 
-  test("Model: save in positional style", function() {
+  test("Model: save in positional style", 1, function() {
     var model = new Backbone.Model();
     model.sync = function(method, model, options) {
       options.success();
@@ -372,13 +371,13 @@ $(document).ready(function() {
 
 
 
-  test("Model: fetch", function() {
+  test("Model: fetch", 2, function() {
     doc.fetch();
     equal(lastRequest.method, 'read');
     ok(_.isEqual(lastRequest.model, doc));
   });
 
-  test("Model: destroy", function() {
+  test("Model: destroy", 3, function() {
     doc.destroy();
     equal(lastRequest.method, 'delete');
     ok(_.isEqual(lastRequest.model, doc));
@@ -387,14 +386,14 @@ $(document).ready(function() {
     equal(newModel.destroy(), false);
   });
 
-  test("Model: non-persisted destroy", function() {
+  test("Model: non-persisted destroy", 1, function() {
     var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
     a.sync = function() { throw "should not be called"; };
     a.destroy();
     ok(true, "non-persisted model should not call sync");
   });
 
-  test("Model: validate", function() {
+  test("Model: validate", 7, function() {
     var lastError;
     var model = new Backbone.Model();
     model.validate = function(attrs) {
@@ -415,7 +414,7 @@ $(document).ready(function() {
     equal(model.get('a'), 100);
   });
 
-  test("Model: validate on unset and clear", function() {
+  test("Model: validate on unset and clear", 6, function() {
     var error;
     var model = new Backbone.Model({name: "One"});
     model.validate = function(attrs) {
@@ -437,7 +436,7 @@ $(document).ready(function() {
     equal(model.get('name'), undefined);
   });
 
-  test("Model: validate with error callback", function() {
+  test("Model: validate with error callback", 8, function() {
     var lastError, boundError;
     var model = new Backbone.Model();
     model.validate = function(attrs) {
@@ -461,7 +460,7 @@ $(document).ready(function() {
     equal(boundError, undefined);
   });
 
-  test("Model: defaults always extend attrs (#459)", function() {
+  test("Model: defaults always extend attrs (#459)", 2, function() {
     var Defaulted = Backbone.Model.extend({
       defaults: {one: 1},
       initialize : function(attrs, opts) {
@@ -472,7 +471,7 @@ $(document).ready(function() {
     var emptyattrs = new Defaulted();
   });
 
-  test("Model: Inherit class properties", function() {
+  test("Model: Inherit class properties", 6, function() {
     var Parent = Backbone.Model.extend({
       instancePropSame: function() {},
       instancePropDiff: function() {}
@@ -496,6 +495,7 @@ $(document).ready(function() {
     notEqual(Child.prototype.instancePropDiff, undefined);
   });
 
+  //FIXME: can't predict the number of expectations
   test("Model: Nested change events don't clobber previous attributes", function() {
     var A = Backbone.Model.extend({
       initialize: function() {
@@ -522,8 +522,7 @@ $(document).ready(function() {
     a.set({state: 'hello'});
   });
 
-  test("hasChanged/set should use same comparison", function() {
-    expect(2);
+  test("hasChanged/set should use same comparison", 2, function() {
     var changed = 0, model = new Backbone.Model({a: null});
     model.on('change', function() {
       ok(this.hasChanged('a'));
@@ -551,13 +550,13 @@ $(document).ready(function() {
     model.set({a: 'a', b: 'b', c: 'c'});
   });
 
-  test("#871, set with attributes property", function() {
+  test("#871, set with attributes property", 1, function() {
     var model = new Backbone.Model();
     model.set({attributes: true});
     ok(model.has('attributes'));
   });
 
-  test("set value regardless of equality/change", function() {
+  test("set value regardless of equality/change", 1, function() {
     var model = new Backbone.Model({x: []});
     var a = [];
     model.set({x: a});
@@ -570,7 +569,7 @@ $(document).ready(function() {
     model.unset('x');
   });
 
-  test("set: undefined values", function() {
+  test("set: undefined values", 1, function() {
     var model = new Backbone.Model({x: undefined});
     ok('x' in model.attributes);
   });
@@ -582,7 +581,7 @@ $(document).ready(function() {
     model.change();
   });
 
-  test("hasChanged is false after original values are set", function() {
+  test("hasChanged is false after original values are set", 2, function() {
     var model = new Backbone.Model({x: 1});
     model.on('change:x', function(){ ok(false); });
     model.set({x: 2}, {silent: true});
@@ -591,27 +590,27 @@ $(document).ready(function() {
     ok(!model.hasChanged());
   });
 
-  test("save with `wait` succeeds without `validate`", function() {
+  test("save with `wait` succeeds without `validate`", 1, function() {
     var model = new Backbone.Model();
     model.save({x: 1}, {wait: true});
     ok(lastRequest.model === model);
   });
 
-  test("`hasChanged` for falsey keys", function() {
+  test("`hasChanged` for falsey keys", 2, function() {
     var model = new Backbone.Model();
     model.set({x: true}, {silent: true});
     ok(!model.hasChanged(0));
     ok(!model.hasChanged(''));
   });
 
-  test("`previous` for falsey keys", function() {
+  test("`previous` for falsey keys", 2, function() {
     var model = new Backbone.Model({0: true, '': true});
     model.set({0: false, '': false}, {silent: true});
     equal(model.previous(0), true);
     equal(model.previous(''), true);
   });
 
-  test("`save` with `wait` sends correct attributes", function() {
+  test("`save` with `wait` sends correct attributes", 5, function() {
     var changed = 0;
     var model = new Backbone.Model({x: 1, y: 2});
     model.on('change:x', function() { changed++; });
@@ -624,13 +623,13 @@ $(document).ready(function() {
     equal(changed, 1);
   });
 
-  test("a failed `save` with `wait` doesn't leave attributes behind", function() {
+  test("a failed `save` with `wait` doesn't leave attributes behind", 1, function() {
     var model = new Backbone.Model;
     model.save({x: 1}, {wait: true});
     equal(model.get('x'), void 0);
   });
 
-  test("`save` with `wait` results in correct attributes if success is called during sync", function() {
+  test("`save` with `wait` results in correct attributes if success is called during sync", 2, function() {
     var changed = 0;
     var model = new Backbone.Model({x: 1, y: 2});
     model.sync = function(method, model, options) {
@@ -648,7 +647,7 @@ $(document).ready(function() {
     model.save({x: 1}, {wait: true});
   });
 
-  test("nested `set` during `'change:attr'`", function() {
+  test("nested `set` during `'change:attr'`", 2, function() {
     var events = [];
     var model = new Backbone.Model();
     model.on('all', function(event) { events.push(event); });
@@ -750,7 +749,7 @@ $(document).ready(function() {
     model.change();
   });
 
-  test("multiple nested changes with silent", function() {
+  test("multiple nested changes with silent", 2, function() {
     var changes = [];
     var model = new Backbone.Model();
     model.on('change:b', function(model, val) { changes.push(val); });
@@ -794,28 +793,27 @@ $(document).ready(function() {
     }
   });
 
-  test("#1179 - isValid returns true in the absence of validate.", function() {
+  test("#1179 - isValid returns true in the absence of validate.", 1, function() {
     var model = new Backbone.Model();
     model.validate = null;
     ok(model.isValid());
   });
 
-  test("#1122 - clear does not alter options.", function() {
+  test("#1122 - clear does not alter options.", 1, function() {
     var model = new Backbone.Model();
     var options = {};
     model.clear(options);
     ok(!options.unset);
   });
 
-  test("#1122 - unset does not alter options.", function() {
+  test("#1122 - unset does not alter options.", 1, function() {
     var model = new Backbone.Model();
     var options = {};
     model.unset('x', options);
     ok(!options.unset);
   });
 
-  test("#1355 - `options` is passed to success callbacks", function() {
-    expect(3);
+  test("#1355 - `options` is passed to success callbacks", 3, function() {
     var model = new Backbone.Model();
     var opts = {
       success: function( model, resp, options ) {

--- a/test/noconflict.js
+++ b/test/noconflict.js
@@ -2,7 +2,7 @@ $(document).ready(function() {
 
   module("Backbone.noConflict");
 
-  test('Backbone.noConflict', function() {
+  test('Backbone.noConflict', 2, function() {
     var noconflictBackbone = Backbone.noConflict();
     equal(window.Backbone, undefined, 'Returned window.Backbone');
     window.Backbone = noconflictBackbone;

--- a/test/router.js
+++ b/test/router.js
@@ -97,7 +97,7 @@ $(document).ready(function() {
 
   });
 
-  test("Router: initialize", function() {
+  test("Router: initialize", 1, function() {
     equal(router.testing, 101);
   });
 
@@ -145,7 +145,7 @@ $(document).ready(function() {
     });
   });
 
-  test("Router: doesn't fire routes to the same place twice", function() {
+  test("Router: doesn't fire routes to the same place twice", 6, function() {
     equal(router.count, 0);
     router.navigate('counter', {trigger: true});
     equal(router.count, 1);
@@ -163,13 +163,13 @@ $(document).ready(function() {
     equal(router.count, 3);
   });
 
-  test("Router: use implicit callback if none provided", function() {
+  test("Router: use implicit callback if none provided", 1, function() {
     router.count = 0;
     router.navigate('implicit', {trigger: true});
     equal(router.count, 1);
   });
 
-  asyncTest("Router: routes via navigate with {replace: true}", function() {
+  asyncTest("Router: routes via navigate with {replace: true}", 2, function() {
     var historyLength = window.history.length;
     router.navigate('search/manhattan/start_here');
     router.navigate('search/manhattan/then_here');
@@ -183,7 +183,7 @@ $(document).ready(function() {
     }, 500);
   });
 
-  asyncTest("Router: routes (splats)", function() {
+  asyncTest("Router: routes (splats)", 1, function() {
     window.location.hash = 'splat/long-list/of/splatted_99args/end';
     setTimeout(function() {
       equal(router.args, 'long-list/of/splatted_99args');
@@ -238,7 +238,7 @@ $(document).ready(function() {
     }
   });
 
-  test("#933, #908 - leading slash", function() {
+  test("#933, #908 - leading slash", 2, function() {
     var history = new Backbone.History();
     history.options = {root: '/root'};
     equal(history.getFragment('/root/foo'), 'foo');
@@ -246,7 +246,7 @@ $(document).ready(function() {
     equal(history.getFragment('/root/foo'), 'foo');
   });
 
-  test("#1003 - History is started before navigate is called", function() {
+  test("#1003 - History is started before navigate is called", 1, function() {
     var history = new Backbone.History();
     history.navigate = function(){
       ok(Backbone.History.started);
@@ -257,7 +257,7 @@ $(document).ready(function() {
     if (!history.iframe) ok(true);
   });
 
-  test("Router: route callback gets passed non-decoded values", function() {
+  test("Router: route callback gets passed non-decoded values", 3, function() {
     var route = 'has%2Fslash/complex-has%23hash/has%20space';
     Backbone.history.navigate(route, {trigger: true});
     equal(router.first, 'has%2Fslash');

--- a/test/sync.js
+++ b/test/sync.js
@@ -30,7 +30,7 @@ $(document).ready(function() {
 
   });
 
-  test("sync: read", function() {
+  test("sync: read", 4, function() {
     library.fetch();
     equal(lastRequest.url, '/library');
     equal(lastRequest.type, 'GET');
@@ -38,14 +38,14 @@ $(document).ready(function() {
     ok(_.isEmpty(lastRequest.data));
   });
 
-  test("sync: passing data", function() {
+  test("sync: passing data", 3, function() {
     library.fetch({data: {a: 'a', one: 1}});
     equal(lastRequest.url, '/library');
     equal(lastRequest.data.a, 'a');
     equal(lastRequest.data.one, 1);
   });
 
-  test("sync: create", function() {
+  test("sync: create", 6, function() {
     equal(lastRequest.url, '/library');
     equal(lastRequest.type, 'POST');
     equal(lastRequest.dataType, 'json');
@@ -55,7 +55,7 @@ $(document).ready(function() {
     equal(data.length, 123);
   });
 
-  test("sync: update", function() {
+  test("sync: update", 7, function() {
     library.first().save({id: '1-the-tempest', author: 'William Shakespeare'});
     equal(lastRequest.url, '/library/1-the-tempest');
     equal(lastRequest.type, 'PUT');
@@ -67,7 +67,7 @@ $(document).ready(function() {
     equal(data.length, 123);
   });
 
-  test("sync: update with emulateHTTP and emulateJSON", function() {
+  test("sync: update with emulateHTTP and emulateJSON", 7, function() {
     Backbone.emulateHTTP = Backbone.emulateJSON = true;
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     equal(lastRequest.url, '/library/2-the-tempest');
@@ -81,7 +81,7 @@ $(document).ready(function() {
     Backbone.emulateHTTP = Backbone.emulateJSON = false;
   });
 
-  test("sync: update with just emulateHTTP", function() {
+  test("sync: update with just emulateHTTP", 6, function() {
     Backbone.emulateHTTP = true;
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     equal(lastRequest.url, '/library/2-the-tempest');
@@ -94,7 +94,7 @@ $(document).ready(function() {
     Backbone.emulateHTTP = false;
   });
 
-  test("sync: update with just emulateJSON", function() {
+  test("sync: update with just emulateJSON", 6, function() {
     Backbone.emulateJSON = true;
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     equal(lastRequest.url, '/library/2-the-tempest');
@@ -107,7 +107,7 @@ $(document).ready(function() {
     Backbone.emulateJSON = false;
   });
 
-  test("sync: read model", function() {
+  test("sync: read model", 3, function() {
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().fetch();
     equal(lastRequest.url, '/library/2-the-tempest');
@@ -115,7 +115,7 @@ $(document).ready(function() {
     ok(_.isEmpty(lastRequest.data));
   });
 
-  test("sync: destroy", function() {
+  test("sync: destroy", 3, function() {
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().destroy({wait: true});
     equal(lastRequest.url, '/library/2-the-tempest');
@@ -123,7 +123,7 @@ $(document).ready(function() {
     equal(lastRequest.data, null);
   });
 
-  test("sync: destroy with emulateHTTP", function() {
+  test("sync: destroy with emulateHTTP", 3, function() {
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     Backbone.emulateHTTP = Backbone.emulateJSON = true;
     library.first().destroy();
@@ -133,7 +133,7 @@ $(document).ready(function() {
     Backbone.emulateHTTP = Backbone.emulateJSON = false;
   });
 
-  test("sync: urlError", function() {
+  test("sync: urlError", 2, function() {
     var model = new Backbone.Model();
     raises(function() {
       model.fetch();

--- a/test/view.js
+++ b/test/view.js
@@ -13,27 +13,27 @@ $(document).ready(function() {
 
   });
 
-  test("View: constructor", function() {
+  test("View: constructor", 4, function() {
     equal(view.el.id, 'test-view');
     equal(view.el.className, 'test-view');
     equal(view.options.id, 'test-view');
     equal(view.options.className, 'test-view');
   });
 
-  test("View: jQuery", function() {
+  test("View: jQuery", 2, function() {
     view.setElement(document.body);
     ok(view.$('#qunit-header a').get(0).innerHTML.match(/Backbone Test Suite/));
     ok(view.$('#qunit-header a').get(1).innerHTML.match(/Backbone Speed Suite/));
   });
 
-  test("View: make", function() {
+  test("View: make", 3, function() {
     var div = view.make('div', {id: 'test-div'}, "one two three");
     equal(div.tagName.toLowerCase(), 'div');
     equal(div.id, 'test-div');
     equal($(div).text(), 'one two three');
   });
 
-  test("View: make can take falsy values for content", function() {
+  test("View: make can take falsy values for content", 2, function() {
     var div = view.make('div', {id: 'test-div'}, 0);
     equal($(div).text(), '0');
 
@@ -41,7 +41,7 @@ $(document).ready(function() {
     equal($(div).text(), '');
   });
 
-  test("View: initialize", function() {
+  test("View: initialize", 1, function() {
     var View = Backbone.View.extend({
       initialize: function() {
         this.one = 1;
@@ -51,7 +51,7 @@ $(document).ready(function() {
     equal(view.one, 1);
   });
 
-  test("View: delegateEvents", function() {
+  test("View: delegateEvents", 6, function() {
     var counter = 0;
     var counter2 = 0;
     view.setElement(document.body);
@@ -71,7 +71,7 @@ $(document).ready(function() {
     equal(counter2, 3);
   });
 
-  test("View: delegateEvents allows functions for callbacks", function() {
+  test("View: delegateEvents allows functions for callbacks", 3, function() {
     view.counter = 0;
     view.setElement("#qunit-banner");
     var events = {"click": function() { this.counter++; }};
@@ -85,7 +85,7 @@ $(document).ready(function() {
     equal(view.counter, 3);
   });
 
-  test("View: undelegateEvents", function() {
+  test("View: undelegateEvents", 6, function() {
     var counter = 0;
     var counter2 = 0;
     view.setElement(document.body);
@@ -107,7 +107,7 @@ $(document).ready(function() {
     equal(counter2, 3);
   });
 
-  test("View: _ensureElement with DOM node el", function() {
+  test("View: _ensureElement with DOM node el", 1, function() {
     var ViewClass = Backbone.View.extend({
       el: document.body
     });
@@ -115,7 +115,7 @@ $(document).ready(function() {
     equal(view.el, document.body);
   });
 
-  test("View: _ensureElement with string el", function() {
+  test("View: _ensureElement with string el", 3, function() {
     var ViewClass = Backbone.View.extend({
       el: "body"
     });
@@ -135,13 +135,13 @@ $(document).ready(function() {
     ok(!view.el);
   });
 
-  test("View: with attributes", function() {
+  test("View: with attributes", 2, function() {
     var view = new Backbone.View({attributes : {'class': 'one', id: 'two'}});
     equal(view.el.className, 'one');
     equal(view.el.id, 'two');
   });
 
-  test("View: with attributes as a function", function() {
+  test("View: with attributes as a function", 1, function() {
     var viewClass = Backbone.View.extend({
       attributes: function() {
         return {'class': 'dynamic'};
@@ -150,7 +150,7 @@ $(document).ready(function() {
     equal((new viewClass).el.className, 'dynamic');
   });
 
-  test("View: multiple views per element", function() {
+  test("View: multiple views per element", 3, function() {
     var count = 0, ViewClass = Backbone.View.extend({
       el: $("body"),
       events: {
@@ -174,7 +174,7 @@ $(document).ready(function() {
     equal(5, count);
   });
 
-  test("View: custom events, with namespaces", function() {
+  test("View: custom events, with namespaces", 2, function() {
     var count = 0;
     var ViewClass = Backbone.View.extend({
       el: $('body'),
@@ -194,7 +194,7 @@ $(document).ready(function() {
     equal(count, 2);
   });
 
-  test("#1048 - setElement uses provided object.", function() {
+  test("#1048 - setElement uses provided object.", 2, function() {
     var $el = $('body');
     var view = new Backbone.View({el: $el});
     ok(view.$el === $el);
@@ -214,7 +214,7 @@ $(document).ready(function() {
     b.trigger('click');
   });
 
-  test("Clone attributes object", function() {
+  test("Clone attributes object", 2, function() {
     var View = Backbone.View.extend({attributes: {foo: 'bar'}});
     var v1 = new View({id: 'foo'});
     strictEqual(v1.el.id, 'foo');
@@ -222,7 +222,7 @@ $(document).ready(function() {
     ok(!v2.el.id);
   });
 
-  test("#1228 - tagName can be provided as a function", function() {
+  test("#1228 - tagName can be provided as a function", 1, function() {
     var View = Backbone.View.extend({tagName: function(){ return 'p'; }});
     ok(new View().$el.is('p'));
   });


### PR DESCRIPTION
As discussed with @braddunbar, this adds an `expected` argument to all tests. For one, this improves consistency in the test suite and establishes a guideline for declaring expectations in all future tests. Although this is only explicitly needed in a handful of individual tests, this can help to prevent future breakages or regressions in the number of assertions being run.

<del>There was 1 test that's currently unable to receive an `expected` argument set. When testing for nested model changes, this test alternates between 2 and 4 assertions. See: https://github.com/wookiehangover/backbone/blob/test_expected/test/model.js#L498

<del>I'd have like to fix this along with this patch, but wanted to get the pull req out there in order to have a few more eyes on it.

Thanks!
