### PR TITLE
Events should allow proxying

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -124,6 +124,18 @@
       return this;
     },
 
+    proxy: function(events, target) {
+      var proxy = _.bind(target.trigger, target, events);
+      this.on(events, proxy);
+      return this;
+    },
+
+    proxyAll: function(target) {
+      var proxy = _.bind(target.trigger, target);
+      this.on("all", proxy);
+      return this;
+    },
+
     // Trigger one or many events, firing all bound callbacks. Callbacks are
     // passed the same arguments as `trigger` is, apart from the event name
     // (unless you're listening on `"all"`, which will cause your callback to


### PR DESCRIPTION
## Proxying Events

In Composite Views, I tend to find myself proxying events from the contained views to their containers.
Adding proxying capabilities to the Events Module seems like a fairly intuitive answer.
## Commit Message
- A.proxy("foo", B) << Proxies the "foo" event of object A to B
- A.proxyAll(B) << Proxies all events of object A to B

In both cases, B will trigger the events that were dispatched by A.
