### PR TITLE
Fix #1403 - Trigger "sync" unconditionally.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -327,11 +327,8 @@
       var success = options.success;
       options.success = function(resp, status, xhr) {
         if (!model.set(model.parse(resp, xhr), options)) return false;
-        if (success) {
-          success(model, resp, options);
-        } else {
-          model.trigger('sync', model, resp, options);
-        }
+        if (success) success(model, resp, options);
+        model.trigger('sync', model, resp, options);
       };
       options.error = Backbone.wrapError(options.error, model, options);
       return (this.sync || Backbone.sync).call(this, 'read', this, options);
@@ -376,11 +373,8 @@
           serverAttrs = _.extend(attrs || {}, serverAttrs);
         }
         if (!model.set(serverAttrs, options)) return false;
-        if (success) {
-          success(model, resp, options);
-        } else {
-          model.trigger('sync', model, resp, options);
-        }
+        if (success) success(model, resp, options);
+        model.trigger('sync', model, resp, options);
       };
 
       // Finish configuring and sending the Ajax request.
@@ -410,11 +404,8 @@
 
       options.success = function(resp) {
         if (options.wait) triggerDestroy();
-        if (success) {
-          success(model, resp, options);
-        } else {
-          model.trigger('sync', model, resp, options);
-        }
+        if (success) success(model, resp, options);
+        model.trigger('sync', model, resp, options);
       };
 
       options.error = Backbone.wrapError(options.error, model, options);
@@ -766,11 +757,8 @@
       var success = options.success;
       options.success = function(resp, status, xhr) {
         collection[options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
-        if (success) {
-          success(collection, resp, options);
-        } else {
-          collection.trigger('sync', collection, resp, options);
-        }
+        if (success) success(collection, resp, options);
+        collection.trigger('sync', collection, resp, options);
       };
       options.error = Backbone.wrapError(options.error, collection, options);
       return (this.sync || Backbone.sync).call(this, 'read', this, options);
@@ -786,13 +774,9 @@
       if (!model) return false;
       if (!options.wait) coll.add(model, options);
       var success = options.success;
-      options.success = function(nextModel, resp, xhr) {
-        if (options.wait) coll.add(nextModel, options);
-        if (success) {
-          success(nextModel, resp, options);
-        } else {
-          nextModel.trigger('sync', model, resp, options);
-        }
+      options.success = function(model, resp, options) {
+        if (options.wait) coll.add(model, options);
+        if (success) success(model, resp, options);
       };
       model.save(null, options);
       return model;

--- a/test/collection.js
+++ b/test/collection.js
@@ -635,10 +635,17 @@ $(document).ready(function() {
     col.create(m, opts);
   });
 
-  test('#1412 - Trigger "sync" event for fetch also', 1, function() {
-    var collection = new Backbone.Collection;
+  test("#1412 - Trigger 'sync' event.", 2, function() {
+    var collection = new Backbone.Collection([], {
+      model: Backbone.Model.extend({
+        sync: function(method, model, options) {
+          options.success();
+        }
+      })
+    });
     collection.sync = function(method, model, options) { options.success(); };
     collection.on('sync', function() { ok(true); });
     collection.fetch();
+    collection.create({id: 1});
   });
 });

--- a/test/model.js
+++ b/test/model.js
@@ -831,10 +831,13 @@ $(document).ready(function() {
     model.destroy(opts);
   });
 
-  test('#1412 - Trigger "sync" event for fetch also', 1, function() {
-    var model = new Backbone.Model;
+  test("#1412 - Trigger 'sync' event.", 3, function() {
+    var model = new Backbone.Model({id: 1});
     model.sync = function(method, model, options) { options.success(); };
     model.on('sync', function() { ok(true); });
     model.fetch();
+    model.save();
+    model.destroy();
   });
+
 });


### PR DESCRIPTION
I'm of the opinion that events are most useful if they're triggered unconditionally.  This is why "change" events are so useful.  Handlers will always be notified of changes, regardless of other handlers or state.  I think the same is true of "sync" events.  Further, I think this is a much simpler and straightforward approach.
