### PR TITLE
Fix broken reference to underscore js in todos example

### DIFF
--- a/examples/todos/index.html
+++ b/examples/todos/index.html
@@ -42,7 +42,7 @@
 
   <script src="../../test/vendor/json2.js"></script>
   <script src="../../test/vendor/jquery-1.7.1.js"></script>
-  <script src="../../test/vendor/underscore-1.3.1.js"></script>
+  <script src="../../test/vendor/underscore.js"></script>
   <script src="../../backbone.js"></script>
   <script src="../backbone-localstorage.js"></script>
   <script src="todos.js"></script>


### PR DESCRIPTION
Todos index.html was incorrectly referencing a specific version of underscore that was not included in the project.
