### PR TITLE
adding detach, for alternate view removal

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1194,10 +1194,17 @@
       return this;
     },
 
-    // Remove this view from the DOM. Note that the view isn't present in the
-    // DOM by default, so calling this method may be a no-op.
+    // Remove this view from the DOM. Note that calling remove will also
+    // remove all jQuery bindings, including any delegated events.
     remove: function() {
       this.$el.remove();
+      return this;
+    },
+
+    // Remove this view from the DOM, keeping jQuery bindings. Note that the view 
+    // isn't present in the DOM by default, so calling this method may be a no-op.
+    detach: function() {
+      this.$el.detach();
       return this;
     },
 


### PR DESCRIPTION
Prompted by this question:
http://stackoverflow.com/questions/11073877/delegateevents-in-backbone-js/11074013#11074013

It can be confusing that just by calling `.remove()`, all bound events are lost from the view element, even when the cached `$el` still exists on the view, appearing to indicate that it should contains all previously bound events. jQuery (1.4+) provides `.detach()` for these cases where you may want to temporarily remove the view without losing bindings on the element.

If anything, it would be helpful to include in the documentation that calling `remove` will remove all delegated events as well.

An alternate approach could be to change `.remove()` to be `.remove([bool])`, where a true value indicates that jQuery data is to be maintained and calla `.detach` rather than `.remove`

---

Edit: just checked and there doesn't appear to be an equivalent zepto method to `.detach`, so the `.remove([bool])` might be a better option
