### PR TITLE
Fragments should be handled encoded.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1013,7 +1013,7 @@
           fragment = this.getHash();
         }
       }
-      return decodeURIComponent(fragment.replace(routeStripper, ''));
+      return fragment.replace(routeStripper, '');
     },
 
     // Start the hash change handling, returning `true` if the current URL matches

--- a/test/router.js
+++ b/test/router.js
@@ -251,12 +251,12 @@ $(document).ready(function() {
     if (!Backbone.history.iframe) ok(true);
   });
 
-  test("route callback gets passed decoded values", 3, function() {
+  test("#967 - Route callback gets passed encoded values.", 3, function() {
     var route = 'has%2Fslash/complex-has%23hash/has%20space';
     Backbone.history.navigate(route, {trigger: true});
-    equal(router.first, 'has/slash');
-    equal(router.part, 'has#hash');
-    equal(router.rest, 'has space');
+    strictEqual(router.first, 'has%2Fslash');
+    strictEqual(router.part, 'has%23hash');
+    strictEqual(router.rest, 'has%20space');
   });
 
   test("correctly handles URLs with % (#868)", 3, function() {


### PR DESCRIPTION
For the reasons enumerated in #967, url fragments should always be handled in their encoded form.  Decoding them makes for impossible comparisons.  For instance, decoding the fragment `"search/foo%2Fbar"` using `decodeURIComponent` yields `"search/foo/bar"`, which cannot be meaningfully compared to another fragment because it's not clear which slash should be re-encoded.

This means that fragments should always be encoded before being passed to `History#navigate`.  If they aren't, there is no way to compare them to the current fragment.

Also, routes should always get encoded values and decoding should be handled by the user so that `"search/foo%2Fbar/2"` yields the arguments `"foo%2Fbar"` and `"2"` instead of `"foo"` and `"bar"`.

``` js
var Router = Backbone.Router.extend({

  routes: {
    'search/:query/:page': 'search'
  },

  search: function(query, page) {
    query = decodeURIComponent(query);
  }

});
```
