### PR TITLE
Hand over return value from parent constructor

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1416,7 +1416,7 @@
     if (protoProps && protoProps.hasOwnProperty('constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ parent.apply(this, arguments); };
+      child = function(){ return parent.apply(this, arguments); };
     }
 
     // Inherit class (static) properties from parent.


### PR DESCRIPTION
The return value from the parent constructor must be returned by the childs constructor. The current implementation suffers from the following bug:

``` javascript
var GenericModelFactory = Backbone.Model.extend({
    constructor: function(attributes,options) {
        //do some stuff here, may return different objects
        return new CustomModel(/*...*/);
    }
});
var SpecialModelFactory = GenericModelFactory.extend();

var modelA = new GenericModelFactory(/*...*/); //correctly returns an instance of CustomModel
var modelB = new SpecialModelFactory(/*...*/); //doesn't return an instance of CustomModel
```

I agree that it is not great employing constructors as factories. Anyway, this construct allows using a Collection containing different models and their dynamic creation.

Thanks!
