### PR TITLE
Sort operation done before merge

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -618,10 +618,13 @@
       splice.apply(this.models, [index, 0].concat(models));
       
 
-      // Merge in duplicate models.
-      if (options.merge) {
+      // Merge in or replace duplicate models.
+      if (options.merge || options.replace ) {
         for (i = 0, length = dups.length; i < length; i++) {
           if (model = this._byId[dups[i].id]) {
+            if( options.replace ){
+                model.clear();
+            }
             model.set(dups[i], options);
           }
         }


### PR DESCRIPTION
If merge update one of the sort criterias, the collection is incorrectly sorted.So I just moved the sort after the merge operation
