### PR TITLE
Fix Backbone does not respect special constructors that does not return "this".

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1416,7 +1416,7 @@
     if (protoProps && protoProps.hasOwnProperty('constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ parent.apply(this, arguments); };
+      child = function(){ return parent.apply(this, arguments); };
     }
 
     // Inherit class (static) properties from parent.


### PR DESCRIPTION
When a constructor is not provided, inherits method creates a wrapper function which simply calls the parent constructor, without returning what it returns. On the contrary, JavaScript allows and honors non-this return values from constructors and this can actually be useful. This commit fixes that by adding a simple return statement inside the wrapper function.
