### PR TITLE
Trigger lifetime view events on Backbone.View

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1155,13 +1155,19 @@
 
   // Creating a Backbone.View creates its initial element outside of the DOM,
   // if an existing element is not provided...
+  // Firing `"configure"` and firing `"initialize"` events on **Backbone.View** object
   var View = Backbone.View = function(options) {
     this.cid = _.uniqueId('view');
     this._configure(options || {});
+    View.trigger('configure', this, this.options);
     this._ensureElement();
     this.initialize.apply(this, arguments);
+    View.trigger('initialize', this);
     this.delegateEvents();
   };
+
+  // Backbone.View should be able to receive events
+  _.extend(View, Events);
 
   // Cached regex to split keys for `delegate`.
   var delegateEventSplitter = /^(\S+)\s*(.*)$/;
@@ -1201,8 +1207,10 @@
 
     // Remove this view from the DOM. Note that the view isn't present in the
     // DOM by default, so calling this method may be a no-op.
+    // Firing `"remove"` event on **Backbone.View** object
     remove: function() {
       this.$el.remove();
+      View.trigger('remove', this, this.el);
       return this;
     },
 
@@ -1219,12 +1227,13 @@
     },
 
     // Change the view's element (`this.el` property), including event
-    // re-delegation.
+    // re-delegation. Firing `"change:element"` event on **Backbone.View** object
     setElement: function(element, delegate) {
       if (this.$el) this.undelegateEvents();
       this.$el = element instanceof Backbone.$ ? element : Backbone.$(element);
       this.el = this.$el[0];
       if (delegate !== false) this.delegateEvents();
+      View.trigger('change:element', this, this.el);
       return this;
     },
 

--- a/test/view.js
+++ b/test/view.js
@@ -226,4 +226,34 @@ $(document).ready(function() {
     var View = Backbone.View.extend({tagName: function(){ return 'p'; }});
     ok(new View().$el.is('p'));
   });
+
+  test("triggering lifetime events", 6, function() {
+    Backbone.View.on('configure', function(targetView, options) {
+      ok(targetView instanceof Backbone.View);
+      equal(options.option, 'value');
+    });
+
+    Backbone.View.on('initialize', function(targetView) {
+      ok(targetView instanceof Backbone.View);
+    });
+
+    var view = new Backbone.View({option: 'value'});
+
+    var element = document.createElement('div');
+
+    Backbone.View.on('change:element', function(targetView, newElement) {
+      equal(targetView, view);
+      equal(newElement, element);
+    });
+
+    view.setElement(element);
+
+    Backbone.View.on('remove', function(targetView) {
+      equal(targetView, view);
+    });
+
+    view.remove();
+
+    Backbone.View.off()
+  });
 });


### PR DESCRIPTION
I'm working on several `Backbone.View` extensions, currently. Some of them, I have [open-sourced](https://github.com/RStankov), some I may open-source in the future. 

Currently if I want to have some behavior when view is removed, for example, I have three feasible options:
- store the current `Backbone.View.prototype.remove`, replace it with my method, then call it from there to keep the remove behavior.
- `MyCustomVIew` extends `Backbone.View` and just replace the whole `Backbone.View` with `MyCustomView`
-  `MyCustomVIew` extends `Backbone.View` and when someone wants to use it, just extends `MyCustomVIew` instead of `Backbone.View`

The last way, is nice if you don't have external Views, or you are not providing a external extensions. Because several people may want to have more than one extension in the same view. For example I want to have both `Backbone.ViewWithSubviews``and`Backbone.ViewWithOtherExtentions``` at the same time.

I think most of the plugins need to be able to run before `Backbone.View#initialize` and `Backbone.View#remove`.
I was playing with possible plugin solutions, but I couldn't figure out an nice api for them.
So in the end, I just add lifetime events triggered directly to `Backbone.View`.

For example:

``` coffee
view = new CustomView()       # triggers 'configure', 'initialize' on the Backbone.View object itself
view.setElement(otherElement) # triggers 'change:element' on the Backbone.View object itself
view.remove()                 # triggers 'remove' on the Backbone.View object itself

# so an user can
Backbone.View.on 'remove', (view) -> console.log "#{view.cid} was removed"
```

At least with my prototypes this worked perfectly and will give a lot more options for extending `Backbone.View`.

Here are some minor examples:

My [Backbone.BindTo](https://github.com/RStankov/backbone-bind-to) can be rewritten to be just:

``` coffee

Backbone.View.on 'configure', (view) ->
  # this out of scope function for binding events
  bindTo view, view.bindToModel, view.model if view.model
  bindTo view, view.bindToCollection, view.collection if view.collection

Backbone.View.on 'remove', (view) ->
  # this out of scope function for unbinding events
  unbindFrom view, view.bindToModel, view.model if view.view
  unbindFrom view, view.bindToCollection, view.collection if view.collection

```

_my current implementation replace `Backbone.View` with my view `Backbone.BindTo.View`_

An other nice example is, having `optionNames` for a view:

``` coffee
Backbone.View.on 'configure', (view, options) ->
  for value, name in view.optionNames
    view[name] = options[name] || value
    delete options[name]

# this will enable, replacing this:
class MyView extends Backbone.View
  initialize: (options) ->
    @offset = options.offset || 1
    @size   = options.size || 2


# with that:
class MyView extends Backbone.View
  defaultOptions:
    offset: 1,
    size: 2

```

Creating a plugin for sub-views (there are a lot of those) not to be like this:

``` coffee
Backbone.ViewWithSubviews extends Backbone.View
  addSubView: (view) ->
    @subViews ?= []
    @subViews.push view

  remove:
    _.invoke @subViews, 'remove'
    super

Backbone.View = Backbone.ViewWithSubviews

# and just be
Backbone.View::addSubView: (view) ->
  addSubView: (view) ->
    @subViews ?= []
    @subViews.push view

Backbone.View.on 'remove', (view) ->
  _.invoke view.subViews, 'remove'
```

I was also wondering if is needed to trigger normal view events for `change:element` and `remove`. If you want I can add those events to.
