### PR TITLE
Add functionality for passing success/error callback hash exclusively for Model.save().

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -348,7 +348,6 @@
       // Check if only success/error callbacks passed in for save call. Otherwise
       // Handle both `("key", value)` and `({key: value})` -style calls.
       if(_.isObject(key) && _.functions(key).length > 0){
-        console.log("Lookir")
         attrs = null;
         options = key;
       }


### PR DESCRIPTION
The save function is much like the other sync calls where it accepts a success/error callback hash however it requires at least a null for the the attributes field. I feel that setting the attributes before calling save is a common enough task that we should be able to pass just the callback hash just like we do with fetch and destroy. I also think it could help potential new users avoid a common pitfall (one I fell into myself) that being receiving no notification of success or error due to save() ignoring the callbacks silently.

New and old syntax both work

**Old:**

``` javascript
Model.save(null, {
  success: function(model, response){
    //success
  },
  error: function(model, response){
    //error
  }
}
```

**New:**

``` javascript
Model.save( {
  success: function(model, response){
    //success
  },
  error: function(model, response){
    //error
  }
}
```
