### PR TITLE
Fix a few typos in documentation, and note that Rails >= 3.1 doesn't namespace to_json

### DIFF
--- a/index.html
+++ b/index.html
@@ -2140,7 +2140,7 @@ end
     <p id="Sync-emulateHTTP">
       <b class="header">emulateHTTP</b><code>Backbone.emulateHTTP = true</code>
       <br />
-      If you want to work with a legacy web server that doesn't support Backbones's
+      If you want to work with a legacy web server that doesn't support Backbone's
       default REST/HTTP approach, you may choose to turn on <tt>Backbone.emulateHTTP</tt>.
       Setting this option will fake <tt>PUT</tt> and <tt>DELETE</tt> requests with
       a HTTP <tt>POST</tt>, setting the <tt>X-HTTP-Method-Override</tt> header


### PR DESCRIPTION
Aside from the typo changes, I added comments specifying that only Rails versions prior to 3.1 default namespacing for a model's `to_json` method.

E.g. For a new project in Rails 3.0.15 with no changes to config:

```
λ rails console
Loading development environment (Rails 3.0.15)
irb(main):001:0> puts Entry.first.to_json
{"entry":{"created_at":"2012-06-23T07:42:42Z","id":1,"name":"bob","updated_at":"2012-06-23T07:42:42Z"}}
```

On Rails 3.1:

```
λ rails console
Loading development environment (Rails 3.1.0)
irb(main):009:0> puts Entry.first.to_json
{"created_at":"2012-06-23T07:47:29Z","id":1,"name":"bob","updated_at":"2012-06-23T07:47:29Z"}
```
