### PR TITLE
isValid takes "options" param and passes through to validate

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -519,8 +519,9 @@
 
     // Check if the model is currently in a valid state. It's only possible to
     // get into an *invalid* state if you're using silent changes.
-    isValid: function() {
-      return !this.validate || !this.validate(this.attributes);
+    isValid: function(options) {
+      options || (options = {});
+      return !this.validate || !this.validate(this.attributes, options);
     },
 
     // Run validation against the next complete set of model attributes,


### PR DESCRIPTION
When checking whether or not a model isValid, it is sometimes necessary to check validation under a variety of contexts. Some validations may only be applicable in a certain context, and it's extremely useful to pass that context through in the options parameter.

All other validation workflows allow the passing of an options param. It seems like a logical extension to do the same thing for the isValid method.

Since the parameter is optional, no existing interfaces will break.
