### PR TITLE
Move sort after merge

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -619,7 +619,7 @@
       this.length += length;
       index = options.at != null ? options.at : this.models.length;
       splice.apply(this.models, [index, 0].concat(models));
-      if (this.comparator && options.at == null) this.sort({silent: true});
+      
 
       // Merge in duplicate models.
       if (options.merge) {
@@ -629,6 +629,7 @@
           }
         }
       }
+	  if (this.comparator && options.at == null) this.sort({silent: true});
 
       if (options.silent) return this;
       for (i = 0, length = this.models.length; i < length; i++) {


### PR DESCRIPTION
Following up on #1434
Moved the sort after the merge to keep the collection sorted if sort criteria is modified
