### PR TITLE
Add an isolatedValidation option for the _validate method.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -533,7 +533,7 @@
     // been passed, call that instead of firing the general `"error"` event.
     _validate: function(attrs, options) {
       if (options.silent || !this.validate) return true;
-      attrs = _.extend({}, this.attributes, attrs);
+      if (!options.isolatedValidation) attrs = _.extend({}, this.attributes, attrs);
       var error = this.validate(attrs, options);
       if (!error) return true;
       if (options && options.error) {

--- a/test/model.js
+++ b/test/model.js
@@ -474,6 +474,23 @@ $(document).ready(function() {
     equal(lastError, "Can't change admin status.");
     equal(boundError, undefined);
   });
+  
+  test("Model: validate with isolatedValidation", 5, function() {
+    var lastError;
+    var model = new Backbone.Model();
+    model.on('error', function(model, error) {
+      lastError = error;
+    });
+    var result = model.set({a: 100});
+    equal(result, model);
+    equal(model.get('a'), 100);
+    equal(lastError, undefined);
+    model.validate = function(attrs) {
+     	equal(attrs.a, undefined);
+    };
+    result = model.set({admin: true}, {isolatedValidation: true});
+    equal(model.get('admin'), true);
+  });
 
   test("Model: defaults always extend attrs (#459)", 2, function() {
     var Defaulted = Backbone.Model.extend({


### PR DESCRIPTION
This pull request adds an isolatedValidation option to the _validate method, when this is set the _validate method does not merge the attrs attribute with the attributes currently set in the model. This feature has its uses in validation libraries such as [backbone.validation](http://thedersen.github.com/backbone.validation) that advocate using a callback method to update the DOM when an attribute validates. Without this flag DOM fields containing invalid data that has not been pushed to the model (which contains valid data) will be re-validated and updated to reflect a valid status despite containing a valid value.

For further details as to why this is useful see [backbone.validation issue 54](https://github.com/thedersen/backbone.validation/issues/54).

This change is otherwise rather benign for those who do not need it as it doesn't affect anything unless the user explicitly sets the flag. This is my first pull request to any github repository ever, so if I've botched any part of the code or process please let me know. :)

Thoughts?

Thank you.
