### PR TITLE
Backbone.Events.onMany - Only trigger callback once all child events have triggered at least once.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -64,23 +64,22 @@
   // Regular expression used to split event strings
   var eventSplitter = /\s+/;
 
-  // Handles the processing that onMany requires as 
-  // each of the many events is triggered.
+  // Handles the processing that onMany requires as each of the many events 
+  // is triggered.
   var triggerMany = function(name, node) {
     node.states[name] = true;
 
     // Work out what matches we have
-    var total = 0, matched = 0;
-    if (!node.triggered) {
+    var shouldRun = node.triggered || function() {
       for (var key in node.states) {
-        total++;
-        if (node.states[key])
-          matched++;
+        if (!node.states[key])
+          return false;
       }
-    }
+      return true;
+    }();
 
     // Detect if we should trigger things
-    if (total === matched) {
+    if (shouldRun) {
       node.callback();
       node.triggered = true;
     }
@@ -100,7 +99,7 @@
     // Allows for multiple events to be registered and the callback only to be 
     // triggered at least once all the events have been executed at least once. 
     // This is useful when needing to wait for multiple events to occur before 
-    // you wan to execute the callback.
+    // you want to execute the callback.
     onMany: function() {
       var args = arguments,
           callback = args[args.length - 1],


### PR DESCRIPTION
This feature allows for multiple events to be registered along with a single callback. The callback only is triggered once all the events have been executed at least once. This is useful when needing to wait for multiple events to occur before you want to execute the callback.

I'm not sure if this is a feature you want in core, but its been very useful for me as my work is usually based on a composition of multiple events. 

I don't have any tests for this, but I wanted to get your feedback before spending more time with this. Let me know what you think.

Note usage would look like the following:

``` javascript
var obj = {};
_.extend(obj,Backbone.Events);

obj.onMany('event1', 'event2', function() {
    alert('You will only see this once both "event1" and "event2" have been triggered');
});

obj.tigger('event1');   //Will NOT cause alert to be shown 
obj.tigger('event2');   //Will cause alert to be shown 
```

Cheers
Anthony 
