### PR TITLE
Add custom "fetch" events on Models and Collections

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -336,6 +336,10 @@
         model.trigger('sync', model, resp, options);
       };
       options.error = Backbone.wrapError(options.error, model, options);
+      
+      // Trigger "fetch" events
+      this.trigger('fetch',this,options);
+      
       return this.sync('read', this, options);
     },
 
@@ -780,6 +784,10 @@
         collection.trigger('sync', collection, resp, options);
       };
       options.error = Backbone.wrapError(options.error, collection, options);
+      
+      // Trigger "fetch" events
+      this.trigger('fetch',this,options);
+      
       return this.sync('read', this, options);
     },
 


### PR DESCRIPTION
...found this pretty useful to add "generic" loader views on any collections/models.

Simple example, a generic loader that can be quickly binded to any collection, and will do the job.

``` javascript
var Loader = Backbone.View.extend({

    tagName:'img',
    attributes:{
        src:'loader.gif'
    },

    initialize:function() {
        _.bindAll(this,'hide','show')
        this.collection.on('reset',this.hide);
        this.collection.on('fetch',this.show);
    },

    hide:function() {
        $(this.el).hide();
    },
    show:function() {
        $(this.el).show();
    }

})
```
