### PR TITLE
Fixed unscoped selection in ToDo example AppView.initialize

### DIFF
--- a/examples/todos/todos.js
+++ b/examples/todos/todos.js
@@ -181,7 +181,7 @@ $(function(){
       Todos.bind('all', this.render, this);
 
       this.footer = this.$('footer');
-      this.main = $('#main');
+      this.main = this.$('#main');
 
       Todos.fetch();
     },


### PR DESCRIPTION
The selection for this.main in the AppView initialize method was unscoped, which is bad practice, especially for the demo app. Anyone trying to learn from the demo app might be led to believe that unscoped selections inside views are a good idea.
