### PR TITLE
Trigger "error" unconditionally.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -536,11 +536,8 @@
       attrs = _.extend({}, this.attributes, attrs);
       var error = this.validate(attrs, options);
       if (!error) return true;
-      if (options && options.error) {
-        options.error(this, error, options);
-      } else {
-        this.trigger('error', this, error, options);
-      }
+      if (options && options.error) options.error(this, error, options);
+      this.trigger('error', this, error, options);
       return false;
     }
 

--- a/test/model.js
+++ b/test/model.js
@@ -472,7 +472,7 @@ $(document).ready(function() {
     equal(result, false);
     equal(model.get('a'), 100);
     equal(lastError, "Can't change admin status.");
-    equal(boundError, undefined);
+    equal(boundError, true);
   });
 
   test("Model: defaults always extend attrs (#459)", 2, function() {


### PR DESCRIPTION
Errors should be triggered even when an error callback is passed to a `sync` method, or onwards to the `_validate` method. This has already been done for sync events (discussed in #1405) and I think it would be consistent to do this for errors too.
