### PR TITLE
Backbone.Router.initialize should be called *before* route callbacks are...

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -888,8 +888,8 @@
   var Router = Backbone.Router = function(options) {
     options || (options = {});
     if (options.routes) this.routes = options.routes;
-    this._bindRoutes();
     this.initialize.apply(this, arguments);
+    this._bindRoutes();
   };
 
   // Cached regular expressions for matching named param parts and splatted


### PR DESCRIPTION
... fired, otherwise you get "used" router which is being initialized.
