### PR TITLE
removed redundant extend

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1304,7 +1304,6 @@
   // The self-propagating extend function that Backbone classes use.
   var extend = function(protoProps, classProps) {
     var child = inherits(this, protoProps, classProps);
-    child.extend = this.extend;
     return child;
   };
 


### PR DESCRIPTION
Inside the Backbone `extend` function:

``` javascript
child.extend = this.extend;
```

replicates functionality from the Backbone `inherits` function which calls:

``` javascript
_.extend(child, parent);
```

Is this intentional? If so, could you please explain why it is necessary?
