### PR TITLE
Remove a conditional that prevents (re)navigating to the current fragment

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1113,7 +1113,6 @@
       if (!History.started) return false;
       if (!options || options === true) options = {trigger: options};
       var frag = (fragment || '').replace(routeStripper, '');
-      if (this.fragment === frag) return;
       this.fragment = frag;
       var url = (frag.indexOf(this.options.root) !== 0 ? this.options.root : '') + frag;
 


### PR DESCRIPTION
I'm writing an application that has a logged-in and logged-out state. If a logged-out user accesses the application using a link that contains a hash fragment (http://host/app#fragment), an authentication form is displayed and I do not populate any of the application's model collections. Once the user authenticates, I would like to be able to trigger the navigation event again, with `router.navigate(document.location.hash)`. But the router currently prevents navigating to the current location. Is this an optimization, or is there a reason to prevent such behavior?
