### PR TITLE
Introduced destroy-method and attachable child-views; "outitialize" as opposite of initialize to unbind from custom events when view is destroyed.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1202,6 +1202,52 @@
       return this;
     },
 
+    // This is the opposite method of "initialize". This method can be used in child-classes to unbind from custom events
+    outitialize: function(){
+      // override in child-class.
+    },
+    
+    // Destroy this view and remove it from the DOM.
+    destroy: function() {
+      this.undelegateEvents();
+      this.model && this.model.off(null, null, this);
+      this.collection && this.collection.off(null, null, this);
+      this.outitialize && this.outitialize();
+      this.destroyChildViews();
+      this.remove();
+    },
+    
+    destroyChildViews: function() {
+      _.each(this._childViews, function(view){
+        view.destroy(); 
+      });
+    },
+
+    // Attach a child-view to this view, so it gets removed and detroyed, when the parent-view is destroyed. 
+    attachChildViews: function(childViews, options) {
+      options || (options = {});
+      childViews = _.isArray(childViews) ? childViews.slice() : [childViews];
+      this._childViews || (this._childViews = new Array());
+
+      _.each(childViews, _.bind(function(view){
+        if (_.indexOf(this._childViews, view) === -1) this._childViews.push(view);
+        if (options.render) view.render();
+      }, this));
+    },
+
+    // Detach a child-view from a this view. The child-view will not longer be destroyed when this view is destroyed. 
+    detachChildViews: function(childViews, options) {
+      options || (options = {});
+      childViews = _.isArray(childViews) ? childViews.slice() : [childViews];
+
+      _.each(childViews, _.bind(function(view){
+        this._childViews = _.without(this._childViews, view)
+        if (options.remove) view.remove();
+        if (options.destroy) view.destroy();
+      }, this));
+
+    },
+
     // For small amounts of DOM Elements, where a full-blown template isn't
     // needed, use **make** to manufacture elements, one at a time.
     //


### PR DESCRIPTION
The method attachChildViews can be used to attach views to a parent-view. When the parent-view gets disposed by calling myView.destroy() the child-views will get destroyed, too. 

The outitialize-method is the opposite of initialize and can be used to unbind views from events when the view is destroyed. (It's like a onDestroy-Method, but I like the name "outitialize" better for symmetrical reasons :-)

Any opinions on this commit? It's my first contribution on github. Please point me in the right direction in case I made any mistakes or broke any rules.

Thanks :-)

Tobias
