### PR TITLE
Use Array.slice() method for slicing arguments inside Events.trigger()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -132,11 +132,8 @@
       var event, calls, list, i, length, args, all, rest;
       if (!(calls = this._callbacks)) return this;
 
-      rest = [];
+      rest = [].slice.call(arguments, 1);
       events = events.split(eventSplitter);
-      for (i = 1, length = arguments.length; i < length; i++) {
-        rest[i - 1] = arguments[i];
-      }
 
       // For each event, walk through the list of callbacks twice, first to
       // trigger the event, then to trigger any `"all"` callbacks.


### PR DESCRIPTION
[].slice.call(arguments, 1) can be used for slicing an Array like object instead of a for loop. [This question](http://stackoverflow.com/questions/3978492/javascript-fastest-way-to-duplicate-an-array-slice-vs-for-loop) posted on Stackoverflow suggests that slice is faster than for loop.
