### PR TITLE
Array support for conditions in `where`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -725,7 +725,11 @@
       if (_.isEmpty(attrs)) return [];
       return this.filter(function(model) {
         for (var key in attrs) {
-          if (attrs[key] !== model.get(key)) return false;
+          if (_.isArray(attrs[key])) {
+            if (!_.include(attrs[key], model.get(key))) return false;
+          } else {
+            if (attrs[key] !== model.get(key)) return false;
+          }
         }
         return true;
       });

--- a/test/collection.js
+++ b/test/collection.js
@@ -416,20 +416,23 @@ $(document).ready(function() {
     equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });
 
-  test("Collection: where", 6, function() {
+  test("Collection: where", 8, function() {
     var coll = new Backbone.Collection([
       {a: 1},
       {a: 1},
       {a: 1, b: 2},
       {a: 2, b: 2},
-      {a: 3}
+      {a: 3},
+      {a: 4, b: 2}
     ]);
     equal(coll.where({a: 1}).length, 3);
     equal(coll.where({a: 2}).length, 1);
     equal(coll.where({a: 3}).length, 1);
     equal(coll.where({b: 1}).length, 0);
-    equal(coll.where({b: 2}).length, 2);
+    equal(coll.where({b: 2}).length, 3);
     equal(coll.where({a: 1, b: 2}).length, 1);
+    equal(coll.where({a: [2, 3]}).length, 2);
+    equal(coll.where({a: [1, 2], b: 2}).length, 2);
   });
 
   test("Collection: Underscore methods", 13, function() {


### PR DESCRIPTION
You be able to use array in `where` conditions:

``` javascript
  collection = new Backbone.Collection([
    {a: 1, b: 2},
    {a: 2, b: 2},
    {a: 3},
    {a: 4, b: 2}
  ]);

  collection.where({a: [2, 3]});
  // => [{a: 2, b: 2}, {a: 3}]

  collection.where({a: [3, 4], b: 2});
  // => [{a: 4, b: 2}]
```

I'll add examples to documentation if all OK with this new feature.
