### PR TITLE
Changed _.isEqual and _.has to native methods

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -288,7 +288,7 @@
         val = attrs[attr];
 
         // If the new and current value differ, record the change.
-        if ((now[attr] !== val) || (options.unset && now.hasOwnProperty(attr))) {
+        if ((now[attr] !== val) || (options.unset && _.has(now, attr))) {
           delete escaped[attr];
           (options.silent ? this._silent : changes)[attr] = true;
         }
@@ -298,7 +298,7 @@
 
         // If the new and previous value differ, record the change.  If not,
         // then remove changes for this attribute.
-        if ((prev[attr] !== val) || (now.hasOwnProperty(attr) !== prev.hasOwnProperty(attr))) {
+        if ((prev[attr] !== val) || !_.has(now, attr)) {
           this.changed[attr] = val;
           if (!options.silent) this._pending[attr] = true;
         } else {

--- a/test/model.js
+++ b/test/model.js
@@ -301,7 +301,6 @@ $(document).ready(function() {
     equal(model.hasChanged('name'), true);
     model.change();
     equal(model.get('name'), 'Rob');
-
   });
 
   test("Model: changedAttributes", 3, function() {
@@ -567,9 +566,15 @@ $(document).ready(function() {
   });
 
   test("unset fires change for undefined attributes", 1, function() {
-    var model = new Backbone.Model({x: undefined});
+    var model = new Backbone.Model({x: undefined, hasOwnProperty: true});
     model.on('change:x', function(){ ok(true); });
     model.unset('x');
+  });
+
+  test('set with hasOwnProperty', 1, function() {
+    var model = new Backbone.Model({name : 'Model', hasOwnProperty: true});
+    model.set({name: 'Model'})
+    equal(model.get('name'), 'Model');
   });
 
   test("set: undefined values", 1, function() {


### PR DESCRIPTION
~50% speed improvement for `set` method. Just changed `_.has` to `hasOwnProperty` and `_.isEqual` to `===`

Before:
![Before](http://chart.apis.google.com/chart?chtt=%u2714%20Backbone%20Test%20Suite%7COps/sec%20%28Chrome%2021.0.1180.57%20on%20Intel%20Mac%20OS%20X%2010_8_0%29&chts=000000,10&cht=bhg&chd=t:43274,37664,39479&chds=0,43274&chxt=x&chxl=0:|0|43.3K&chsp=0,1&chm=tModel%3A%20set%20Math.random%28%29%2843.3K%29,000000,0,0,10|tModel%3A%20set%20rand%28%29%20with%20an%20event%2837.7K%29,000000,0,1,10|tModel%3A%20set%20rand%28%29%20with%20an%20attribute%20observer%2839.5K%29,000000,0,2,10&chbh=15,0,5&chs=250x130)
After:
![After](http://chart.apis.google.com/chart?chtt=%u2714%20Backbone%20Test%20Suite%7COps/sec%20%28Chrome%2021.0.1180.57%20on%20Intel%20Mac%20OS%20X%2010_8_0%29&chts=000000,10&cht=bhg&chd=t:67983,44257,46678&chds=0,67983&chxt=x&chxl=0:|0|68K&chsp=0,1&chm=tModel%3A%20set%20Math.random%28%29%2868K%29,000000,0,0,10|tModel%3A%20set%20rand%28%29%20with%20an%20event%2844.3K%29,000000,0,1,10|tModel%3A%20set%20rand%28%29%20with%20an%20attribute%20observer%2846.7K%29,000000,0,2,10&chbh=15,0,5&chs=250x130)
