### PR TITLE
Fixes issue 1527 related to event exceptions

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -151,7 +151,9 @@
         // Execute event callbacks.
         if (list) {
           for (i = 0, length = list.length; i < length; i += 2) {
-            list[i].apply(list[i + 1] || this, rest);
+            try {
+              list[i].apply(list[i + 1] || this, rest);
+            } catch(e){}
           }
         }
 
@@ -159,7 +161,9 @@
         if (all) {
           args = [event].concat(rest);
           for (i = 0, length = all.length; i < length; i += 2) {
-            all[i].apply(all[i + 1] || this, args);
+            try {
+              all[i].apply(all[i + 1] || this, args);
+            } catch(e){}
           }
         }
       }

--- a/test/events.js
+++ b/test/events.js
@@ -192,4 +192,17 @@ $(document).ready(function() {
     obj.trigger('event');
   });
 
+  test("#1527 - exceptions thrown by a listener allows other listeners to be called", 4, function(){
+    var obj = _.extend({}, Backbone.Events);
+    obj.on('event', function(){ ok(true, 'event 1 throwing exception'); throw 'BOOM!' }, obj);
+    obj.on('all', function(){ ok(true, 'event "all" 1 throwing exception'); throw 'BOOM!' }, obj);
+    obj.on('event', function(){ ok(true, 'event 2 still executed'); }, obj);
+    obj.on('all', function(){ ok(true, 'event "all" 2 still executed'); }, obj);
+    try{
+      obj.trigger('event');
+    }catch(e){
+        ok(false, 'trigger threw an exception');
+    }
+  });
+
 });


### PR DESCRIPTION
adds try catch blocks around the event triggers to avoid exceptions being thrown from preventing other events from being called as well as from interrupting the caller. Unit tests included.
