### PR TITLE
Fix case where model.save(model, {wait:true}) does not correctly merge 'serverAttrs' with the 'model.attributes' 

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -380,7 +380,7 @@
       options.success = function(resp, status, xhr) {
         done = true;
         var serverAttrs = model.parse(resp, xhr);
-        if (options.wait) serverAttrs = _.extend(attrs || {}, serverAttrs);
+        if (options.wait) serverAttrs = _.extend((attrs instanceof Model) ? attrs.attributes : attrs, serverAttrs);
         if (!model.set(serverAttrs, options)) return false;
         if (success) success(model, resp, options);
         model.trigger('sync', model, resp, options);

--- a/test/model.js
+++ b/test/model.js
@@ -626,6 +626,34 @@ $(document).ready(function() {
     equal(changed, 1);
   });
 
+  test("`save` with `wait` correctly merges 'attrs' and 'serverAttrs' hashes", 5, function() {
+    var changed = 0;
+    var model = new Backbone.Model({x: 1, y: 2});
+    model.parse = function (resp, xhr) { return {x: 2, y: 2}; } // simulate server response w/ modified attribute
+    model.on('change:x', function() { changed++; });
+    model.save({x: 1, y: 2}, {wait: true});
+    deepEqual(JSON.parse(ajaxParams.data), {x: 1, y: 2});
+    equal(model.get('x'), 1); // 'x' shouldn't be changed to 2 until after success()
+    equal(changed, 0);
+    lastRequest.options.success({});
+    equal(model.get('x'), 2);
+    equal(changed, 1);
+  });
+
+  test("`save` with `wait` correctly merges 'attrs' Model and 'serverAttrs' hash", 5, function() {
+    var changed = 0;
+    var model = new Backbone.Model({x: 1, y: 2});
+    model.parse = function (resp, xhr) { return {x: 2, y: 2}; }  // simulate server response w/ modified attribute
+    model.on('change:x', function() { changed++; });
+    model.save(model, {wait: true});
+    deepEqual(JSON.parse(ajaxParams.data), {x: 1, y: 2});
+    equal(model.get('x'), 1); // 'x' shouldn't be changed to 2 until after success()
+    equal(changed, 0);
+    lastRequest.options.success({});
+    equal(model.get('x'), 2);
+    equal(changed, 1);
+  });
+
   test("a failed `save` with `wait` doesn't leave attributes behind", 1, function() {
     var model = new Backbone.Model;
     model.save({x: 1}, {wait: true});


### PR DESCRIPTION
I've run into an issue where, when saving a model object with {wait:true}, attributes from the server are not correctly merged with the existing client-side model attributes. The root issue seems to be that Model.save()'s success function uses _.extend( attrs || {}, serverAttrs), not paying attention to the possibility that 'attrs' may not be a simple hash, but may instead be a Model object. If it is a Model object, then the serverAttrs are merged as top-level properties instead of into the model's 'attributes' hash, where they belong:

``` javascript
options.success = function(resp, status, xhr) {
        done = true;
        var serverAttrs = model.parse(resp, xhr);
        if (options.wait) serverAttrs = _.extend(attrs || {}, serverAttrs);
        if (!model.set(serverAttrs, options)) return false;
    ...
```

In the Model.set() function the code then does this:

``` javascript
if (attrs instanceof Model) attrs = attrs.attributes;
```

which results in the loss of the top-level attributes we just merged from the 'serverAttrs' hash.

I propose that save()'s success function be changed to detect whether attrs is a Model object and extract the attributes this way:

``` javascript
if (options.wait) serverAttrs = _.extend((attrs instanceof Model) ? attrs.attributes : attrs, serverAttrs);
```

Please advise if I'm missing something here. I suspect that the server modifying attributes in this manner is just not a common scenario, though it does seem valid.
