### PR TITLE
New Model extension point: idFromAttributes 

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -276,7 +276,7 @@
       if (!this._validate(attrs, options)) return false;
 
       // Check for changes of `id`.
-      if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];
+      this.id = this.idFromAttributes(attrs);
 
       var changes = options.changes = {};
       var now = this.attributes;
@@ -310,6 +310,15 @@
       // Fire the `"change"` events.
       if (!options.silent) this.change(options);
       return this;
+    },
+
+    // **idFromIdAttributes** extracts an id from attrs based on this.idAttribute.
+    // The default implementation uses this.idAttribute as the lookup key in attrs
+    // and returns the value if it exists, otherwise returns the current this.id value.
+    idFromAttributes: function(attrs) {
+        if (this.idAttribute in attrs) 
+            return attrs[this.idAttribute];
+        return this.id;
     },
 
     // Remove an attribute from the model, firing `"change"` unless you choose


### PR DESCRIPTION
There have been several issues raised previously (#598, #1215, #1232) to add support for nested ids in models.  The previously-proposed solutions all baked in support in `Backbone.Model.set` for specific nesting schemes, and all were rejected with a a note that this type of functionality should be included as a plugin or extension.

The issue with `Backbone.Model.set` today is that it doesn't allow for easy extension to change this behavior - extensions have to completely replace `set` to change this behavior, which is fragile.  This pull request adds a new `idFromAttributes` method to `Backbone.Model`, with the default behavior identical to the existing attribute-to-id mapping behavior.  But this enables extension to easily replace `Backbone.Model.idFromAttributes` as needed without affecting other `set` behavior.
