### PR TITLE
Ensure defaults are passed to Backbone.Model.initialize.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -179,7 +179,7 @@
   // Create a new model, with defined attributes. A client id (`cid`)
   // is automatically generated and assigned for you.
   var Model = Backbone.Model = function(attributes, options) {
-    var defaults;
+    var defaults, args, i, length;
     attributes || (attributes = {});
     if (options && options.collection) this.collection = options.collection;
     if (options && options.parse) attributes = this.parse(attributes);
@@ -198,7 +198,15 @@
     this._silent = {};
     this._pending = {};
     this._previousAttributes = _.clone(this.attributes);
-    this.initialize.apply(this, arguments);
+
+    // Ensure that the modified version of attributes is passed to initialize.
+    // Since we're only copying the tail of `arguments`, a loop is much faster
+    // than Array#slice.
+    args = [attributes, options];
+    for (i = 2, length = arguments.length; i < length; i++) {
+      args[i] = arguments[i];
+    }
+    this.initialize.apply(this, args);
   };
 
   // Attach all inheritable methods to the Model prototype.

--- a/test/model.js
+++ b/test/model.js
@@ -479,7 +479,7 @@ $(document).ready(function() {
     var Defaulted = Backbone.Model.extend({
       defaults: {one: 1},
       initialize : function(attrs, opts) {
-        equal(this.attributes.one, 1);
+        equal(attrs.one, 1);
       }
     });
     var providedattrs = new Defaulted({});


### PR DESCRIPTION
Without this fix, if you create a model via `new MyModel()`, then the defaults specified in `MyModel` aren't passed to the `initialize` method.  This is perfectly illustrated by the test I've modified ("Model: defaults always extend attrs (#459)"): without my fix, it's necessary to use `this.attributes` inside `initialize` rather than `attrs` to get the assertion to pass for the `new Defaulted()` case.  This therefore makes the `initialize` API much more consistent.

Two other comments about this fix:
1.  I would have used `Array.prototype.slice` and `concat` to generate `args`, but I noticed that this was explicitly avoided in `Backbone.Events.trigger`, so I copied that pattern even though it's more code.
2.  I did not also include this fix in `Backbone.Collection`, `Backbone.View`, or `Backbone.Router`, because they do not appear to modify their arguments before calling `initialize`.  However, it might be a good idea to also include this fix in those constructors to be more future-proof.  I can add that to this pull request if you would like.

FYI, this bug was introduced in commit 4316b04ffa75257e9eec9fe46b3c48535b659936.
