### PR TITLE
Don't discard return value of default constructors. (with tests)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1416,7 +1416,7 @@
     if (protoProps && protoProps.hasOwnProperty('constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ parent.apply(this, arguments); };
+      child = function(){ return parent.apply(this, arguments); };
     }
 
     // Inherit class (static) properties from parent.

--- a/test/model.js
+++ b/test/model.js
@@ -59,6 +59,33 @@ $(document).ready(function() {
     equal(model.collection, collection);
   });
 
+  test("Model: overwritten constructors", 4, function () {
+    var saved;
+
+    var Unique = Backbone.Model.extend({
+        constructor: function (attrs, isDirect) {
+            if (isDirect)
+                return Backbone.Model.call(this, attrs);
+            return this.constructor.create(attrs);
+        }
+    }, {
+        create: function (attrs) {
+            saved = saved || new this(attrs, true);
+            return saved;
+        }
+    });
+
+    var Model = Unique.extend({});
+
+    var m1 = new Model();
+    var m2 = new Model();
+
+    strictEqual(m1, m2);
+    strictEqual(saved, m1);
+    ok(m1 instanceof Model);
+    ok(m2 instanceof Model);
+  });
+
   test("Model: initialize with attributes and options", 1, function() {
     var Model = Backbone.Model.extend({
       initialize: function(attributes, options) {


### PR DESCRIPTION
If you try to transform a Backbone class into an implicit factory
(i.e. a class that acts as a factory even when used with `new`) you
must have a reference to an object created by the default constructor.

This patch makes Backbone to not to discard return value of default
constructors. In addition to the scenario described above it also
makes both code paths consistent with each other.

This is a version of GH-1435 and GH-1429 (but with tests; not sure why
all other PRs didn't have tests) and an inverse of GH-1382.
