### PR TITLE
Compliant CommonJS/NodeJS module

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1465,4 +1465,4 @@
     throw new Error('A "url" property or function must be specified');
   };
 
-}).call(this);
+}).call(new Function("return this")());


### PR DESCRIPTION
Currently Backbone cannot be used as CommonJS/NodeJS module on client-side (e.g. with help of bundlers like [Webmake](https://github.com/medikoo/modules-webmake)). It's caused by hardcoded assumption that `this` is `global`, where in NodeJS modules `this === exports`.

It's a bit weird as I see that Backbone tries to be CommonJS module (e.g. what's the reasoning behind require calls to `underscore` inside?)

The thing that would fix that is cross-environment and cross-mode (strict/non-strict) reference to global
