### PR TITLE
call ajax success and error callbacks on 'this', the jquery context object

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -335,7 +335,7 @@
       var success = options.success;
       options.success = function(resp, status, xhr) {
         if (!model.set(model.parse(resp, xhr), options)) return false;
-        if (success) success(model, resp, options);
+        if (success) success.call(this, model, resp, options);
         model.trigger('sync', model, resp, options);
       };
       options.error = Backbone.wrapError(options.error, model, options);
@@ -382,7 +382,7 @@
         var serverAttrs = model.parse(resp, xhr);
         if (options.wait) serverAttrs = _.extend(attrs || {}, serverAttrs);
         if (!model.set(serverAttrs, options)) return false;
-        if (success) success(model, resp, options);
+        if (success) success.call(this, model, resp, options);
         model.trigger('sync', model, resp, options);
       };
 
@@ -1405,7 +1405,7 @@
     return function(model, resp) {
       resp = model === originalModel ? resp : model;
       if (onError) {
-        onError(originalModel, resp, options);
+        onError.call(this, originalModel, resp, options);
       } else {
         originalModel.trigger('error', originalModel, resp, options);
       }


### PR DESCRIPTION
Allow access to the jQuery context object as 'this' inside of the ajax success and error callbacks instead of 'this' being the window object.

from http://api.jquery.com/jQuery.ajax
The this reference within all callbacks is the object in the context option passed to $.ajax in the settings; if context is not specified, this is a reference to the Ajax settings themselves.

simple test case  http://jsbin.com/atawow/4/edit
