### PR TITLE
History.start shouldn't convert to fragment if silent

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1056,7 +1056,7 @@
 
       // If we've started off with a route from a `pushState`-enabled browser,
       // but we're currently in a browser that doesn't support it...
-      if (this._wantsHashChange && this._wantsPushState && !this._hasPushState && !atRoot) {
+      if (this._wantsHashChange && this._wantsPushState && !this._hasPushState && !atRoot && !this.options.silent) {
         this.fragment = this.getFragment(null, true);
         this.location.replace(this.options.root + this.location.search + '#' + this.fragment);
         // Return immediately as browser will do redirect to new url


### PR DESCRIPTION
History.start({silent: true, pushState: true}) in non-pushState browsers should probably not cause a redirect, since the {silent: true} implies I do not want backbone to act on the initial route.

Is there any reason why this might not be the case?
