### PR TITLE
Add check for jsl in `Rakefile`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,6 +25,7 @@ end
 
 desc "run JavaScriptLint on the source"
 task :lint do
+  check 'jsl', 'JavaScript Lint', 'http://www.javascriptlint.com/'
   system "jsl -nofilelisting -nologo -conf docs/jsl.conf -process backbone.js"
 end
 


### PR DESCRIPTION
Hey all, just setting up dev, didn't have jsl, and `rake lint` silently fails. So I used the existing `check` function and added jsl info.

xoxo @ngauthier
