### PR TITLE
Use the actual contructor

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1423,7 +1423,7 @@
     if (protoProps && protoProps.hasOwnProperty('constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ parent.apply(this, arguments); };
+      child = function(){ parent.prototype.constructor.apply(this, arguments); };
     }
 
     // Inherit class (static) properties from parent.


### PR DESCRIPTION
Generally speaking parent == parent.prototype.constructor, however it is one of the joys of JavaScript to be able to change behavior my altering the prototypes, and this method of extending eliminates that, thus the proposal to fix it.
