### PR TITLE
Fix #1584 - Create default Backbone.history.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -913,7 +913,6 @@
     //     });
     //
     route: function(route, name, callback) {
-      Backbone.history || (Backbone.history = new History);
       if (!_.isRegExp(route)) route = this._routeToRegExp(route);
       if (!callback) callback = this[name];
       Backbone.history.route(route, _.bind(function(fragment) {
@@ -1162,6 +1161,9 @@
     }
 
   });
+
+  // Create the default Backbone.history.
+  Backbone.history = new History;
 
   // Backbone.View
   // -------------


### PR DESCRIPTION
There may be a perfectly good reason to create `Backbone.history` lazily, but I couldn't find one in the issues since it was included with the [first draft of controllers and history](https://github.com/documentcloud/backbone/commit/bdee3a2512ba9a3f32a7b49fbf24883a6369613e#L0R591).  It seems to me that this doesn't significantly change any functionality and it prevents the error described in #1584 (which I agree is surprising when it's first encountered).
