### PR TITLE
Allow model attribute name to be used as collection sort comparator value

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -741,10 +741,10 @@
       options || (options = {});
       if (!this.comparator) throw new Error('Cannot sort a set without a comparator');
       if (typeof this.comparator === "string"){
-        var compstr = this.comparator, attrName = compstr.replace(/^\+|\-/,"");
-        this.comparator = function(o1,o2){
-          return (o2.get(attrName) > o1.get(attrName) ? -1 : 1)*(compstr[0] === "-" ? -1 : 1);
-        }
+        var attrName = this.comparator;
+        this.comparator = function(o){
+          return o.get(attrName);
+        };
       }
       var boundComparator = _.bind(this.comparator, this);
       if (this.comparator.length === 1) {

--- a/index.html
+++ b/index.html
@@ -1609,15 +1609,13 @@ var book = Library.get(110);
       </li>
       <li>
         Finally the comparator can also be a <b>string</b> containing the name of the model
-        attribute we wish to sort by. If you wish the sort to be descending, prepend the
-        comparator string with a <tt>-</tt> character. The collection will automatically 
-        resort itself whenever a model changes the attribute.
+        attribute we wish to sort by.
       </li>
     </ul>
 
     <p>
       Note how even though all of the chapters in this example are added backwards,
-      they come out in the proper order thanks to the comparator sortBy function:
+      they come out in the proper order thanks to the comparator:
     </p>
 
 <pre class="runnable">
@@ -1652,16 +1650,11 @@ chapters.add(new Chapter({page: 1, title: "The Beginning"}));
 
 alert(chapters.pluck('title'));
 
-chapters.comparator = "-page"; // '-' prefix will make sort descending
-chapters.sort();
-
-alert(chapters.pluck('title'));
 </pre>    
 
     <p class="warning">
       Collections with a comparator will not automatically re-sort if you
-      later change model attributes (except for when the comparator was
-      set as a string value with an attribute name), so you may wish to call
+      later change model attributes, so you may wish to call
       <tt>sort</tt> after changing model attributes that would affect the order.
     </p>
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -31,7 +31,7 @@ $(document).ready(function() {
 
   });
 
-  test("Collection: new and sort", 13, function() {
+  test("Collection: new and sort", 9, function() {
     equal(col.first(), a, "a should be first");
     equal(col.last(), d, "d should be last");
     col.comparator = function(a, b) {
@@ -46,15 +46,7 @@ $(document).ready(function() {
     equal(col.last(), a, "a should be last");
     equal(col.length, 4);
     // tests with string comparator
-    col.comparator = "+label"; // prefix "+" means ascending sort
-    col.sort();
-    equal(col.first(), a, "a should be first");
-    equal(col.last(), d, "d should be last");
-    col.comparator = "-label"; // prefix "-" means descending sort
-    col.sort();
-    equal(col.first(), d, "d should be first");
-    equal(col.last(), a, "a should be last");
-    col.comparator = "label"; // no prefix defaults to ascending
+    col.comparator = "label";
     col.sort();
     equal(col.first(), a, "a should be first");
     equal(col.last(), d, "d should be last");


### PR DESCRIPTION
This update edits `Collection::sort` to work with a model attribute name as comparator. The goal was to facilitates the common use case where we just want to sort by the values of a certain attribute without doing any processing of the values. When before we had to do this:

``` javascript
// old way
myCollection.comparator = function(model){
  return model.get("someprop");
}
```

...we can now instead simply do this:

``` javascript
// new way
myCollection.comparator = "someprop";
```

And mostly because it was so easy to implement in the same go, the attribute name can be prefixed with "-" to make the sort descending. So, when before we would have to do this:

``` javascript
// old way
myCollection.comparator = function(o1,o2){
  return o1.get("someprop") > o2.get("someprop") ? -1 : 1;
}
```

...this will now suffice: 

``` javascript
// new way
myCollection.comparator = "-someprop";
```

No existing code will break, as all current usage expects `comparator` to be a function. The new code checks if it is a string (meaning new propname syntax) or a function and acts accordingly.
