### PR TITLE
Add Model#dispose & Collection#dispose.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -429,6 +429,15 @@
       return xhr;
     },
 
+    // Clean up references to this model in order to prevent latent
+    // effects and memory leaks.
+    dispose: function() {
+      // Remove all event handlers on this module.
+      this.off();
+
+      return this;
+    },
+
     // Default URL for the model's representation on the server -- if you're
     // using Backbone's restful methods, override this to change the endpoint
     // that will be called.
@@ -823,6 +832,19 @@
       return _(this.models).chain();
     },
 
+    // Clean up references to this collection in order to prevent latent
+    // effects and memory leaks.
+    dispose: function() {
+      // Empty the list silently, but do not dispose all models since
+      // they might be referenced elsewhere.
+      this.reset([], silent: true);
+
+      // Remove all event handlers on this module.
+      this.off();
+
+      return this;
+    },
+
     // Reset all internal state. Called when the collection is reset.
     _reset: function(options) {
       this.length = 0;
@@ -1209,8 +1231,8 @@
     // memory leaks.
     dispose: function() {
       this.undelegateEvents();
-      if (this.model) this.model.off(null, null, this);
-      if (this.collection) this.collection.off(null, null, this);
+      if (this.model) this.model.dispose();
+      if (this.collection) this.collection.dispose();
       return this;
     },
 

--- a/index.html
+++ b/index.html
@@ -311,6 +311,7 @@
       <li>– <a href="#Model-changedAttributes">changedAttributes</a></li>
       <li>– <a href="#Model-previous">previous</a></li>
       <li>– <a href="#Model-previousAttributes">previousAttributes</a></li>
+      <li>– <a href="#Model-dispose">dispose</a></li>
     </ul>
 
     <a class="toc_title" href="#Collection">
@@ -344,6 +345,7 @@
       <li>– <a href="#Collection-fetch">fetch</a></li>
       <li>– <a href="#Collection-reset">reset</a></li>
       <li>– <a href="#Collection-create">create</a></li>
+      <li>– <a href="#Collection-dispose">dispose</a></li>
     </ul>
 
     <a class="toc_title" href="#Router">
@@ -1338,6 +1340,13 @@ bill.set({name : "Bill Jones"});
       an error occurs.
     </p>
 
+    <p id="Model-dispose">
+      <b class="header">dispose</b><code>model.dispose()</code>
+      <br />
+      Clean up any references to the model in order to prevent unwanted latent
+      effects and memory leaks.
+    </p>
+
     <h2 id="Collection">Backbone.Collection</h2>
 
     <p>
@@ -1844,6 +1853,13 @@ var othello = NYPL.create({
   author: "William Shakespeare"
 });
 </pre>
+
+    <p id="Collection-dispose">
+      <b class="header">dispose</b><code>collection.dispose()</code>
+      <br />
+      Clean up any references to the collection in order to prevent unwanted latent
+      effects and memory leaks.
+    </p>
 
     <h2 id="Router">Backbone.Router</h2>
 


### PR DESCRIPTION
A couple questions (that are [Chaplin](https://github.com/chaplinjs/chaplin) features), about making stuff more useful:
1. Should all disposable properties emit `dispose` event on disposal? Real-world use case:
   
   ``` javascript
   // Create edit form on top of the post view.
   editPost: function(event) {
     this.$('.post-text').remove();
     var editPostView = new EditPostFormView({
       model: this.model,
       container: this.$('.post-content')
     });
     // Re-render content of current post on successful disposal.
     editPostView.on('dispose', this.render);
   }
   ```
2. Should all disposable properties `delete` some default properties which Backbone sets to free more memory? For example, in Views:
   
   ```
   ['el', '$el', 'options', 'model', 'collection']
   ```
3. Should all disposable properties do `if (Object.freeze) Object.freeze(this);`? Reason: less bugs in browsers that developers use / debug most of the time == less bugs in apps.
