### PR TITLE
Collection url can be implied from Model's `urlRoot`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -823,6 +823,13 @@
       return _(this.models).chain();
     },
 
+    // Default URL for the collection's representation on the server -- if
+    // you're using Backbone's restful methods, override this to change the
+    // endpoint that will be called.
+    url: function() {
+      return getValue(this.model.prototype, 'urlRoot') || urlError();
+    },
+
     // Reset all internal state. Called when the collection is reset.
     _reset: function(options) {
       this.length = 0;

--- a/test/collection.js
+++ b/test/collection.js
@@ -689,4 +689,20 @@ $(document).ready(function() {
     collection.add({id: 1, x: 3}, {merge: true});
     deepEqual(collection.pluck('id'), [2, 1]);
   });
+
+  test("url can be implied from Model's `urlRoot`", function() {
+    var Model = Backbone.Model.extend();
+    var Collection = Backbone.Collection.extend({
+      model: Model
+    });
+    collection = new Collection;
+    raises(function() {
+      collection.url();
+    }, "raises exception when urlRoot doesn't exist");
+    Model.prototype.urlRoot = '/models';
+    ok(collection.url() === '/models', 'returns `urlRoot` when it does exist');
+    Model.prototype.urlRoot = function() { return '/models'; }
+    ok(collection.url() === '/models', 'also works for `urlRoot` functions');
+  });
+
 });


### PR DESCRIPTION
This saves the pain of duplicating the `urlRoot` on the Model and Collection...

Before:

``` coffee
class Model extends Backbone.Model
  urlRoot: '/models'
class Collection extends Backbone.Collection
  model: Model
  url: '/models'
```

After:

``` coffee
class Model extends Backbone.Model
  urlRoot: '/models'
class Collection extends Backbone.Collection
  model: Model
```

Because there's only so many times I can write the same thing before going crazy :+1:
