### PR TITLE
Adding validateAll feature to Backbone.Model during set or save

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -536,7 +536,6 @@
     // been passed, call that instead of firing the general `"error"` event.
     _validate: function(attrs, options) {
       if (options.silent || !this.validate) return true;
-      attrs = _.extend({}, this.attributes, attrs);
       if (options.validateAll !== false) attrs = _.extend({}, this.attributes, attrs);
       var error = this.validate(attrs, options);
       if (!error) return true;


### PR DESCRIPTION
This commit creates a new `validateAll` option that can be passed when saving or setting one or multiple model properties.  A sample use case for this option is **form validation**.

Often during form validation, a developer will not want all model properties to be validated at the same time.  Instead, a developer might want to only validate model properties that are currently being set.

**The default Model set/save behavior is exactly the same with this addition**, and is purely opt-in.  Thanks!
