### PR TITLE
Make getValue public

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1450,7 +1450,7 @@
 
   // Helper function to get a value from a Backbone object as a property
   // or as a function.
-  var getValue = function(object, prop) {
+  var getValue = Backbone.getValue = function(object, prop) {
     if (!(object && object[prop])) return null;
     return _.isFunction(object[prop]) ? object[prop]() : object[prop];
   };


### PR DESCRIPTION
This function is needed when overriding some Backbone internals (e.g. .sync),
so it would be handy not to copy&paste it from Backbone sources. 
