### PR TITLE
allow for chaining of router navigation

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -916,6 +916,7 @@
     // Simple proxy to `Backbone.history` to save a fragment into the history.
     navigate: function(fragment, options) {
       Backbone.history.navigate(fragment, options);
+      return this;
     },
 
     // Bind all defined routes to `Backbone.history`. We have to reverse the


### PR DESCRIPTION
To ensure that I'm triggering a specific route and running the method that I need, I often do:

```
myRouter.navigate('home');
myRouter.home();
```

It would be convenient to chain these.
