### PR TITLE
Fix #1478 - Attribute changes to original value should be silent.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -192,12 +192,12 @@
     this._escapedAttributes = {};
     this.cid = _.uniqueId('c');
     this.changed = {};
-    this._silent = {};
+    this._changes = {};
     this._pending = {};
     this.set(attributes, {silent: true});
     // Reset change tracking.
     this.changed = {};
-    this._silent = {};
+    this._changes = {};
     this._pending = {};
     this._previousAttributes = _.clone(this.attributes);
     this.initialize.apply(this, arguments);
@@ -209,9 +209,9 @@
     // A hash of attributes whose current and previous value differ.
     changed: null,
 
-    // A hash of attributes that have silently changed since the last time
-    // `change` was called.  Will become pending attributes on the next call.
-    _silent: null,
+    // A hash of attributes that have changed since the last time `change` was
+    // called.
+    _changes: null,
 
     // A hash of attributes that have changed since the last `'change'` event
     // began.
@@ -256,23 +256,22 @@
 
     // Set a hash of model attributes on the object, firing `"change"` unless
     // you choose to silence it.
-    set: function(key, value, options) {
-      var attrs, attr, val;
+    set: function(attrs, options) {
+      var attr, key, val;
+      if (attrs == null) return this;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
-      if (_.isObject(key) || key == null) {
-        attrs = key;
-        options = value;
-      } else {
-        attrs = {};
-        attrs[key] = value;
+      if (!_.isObject(attrs)) {
+        key = attrs;
+        (attrs = {})[key] = options;
+        options = arguments[2];
       }
 
       // Extract attributes and options.
-      options || (options = {});
-      if (!attrs) return this;
+      var silent = options && options.silent;
+      var unset = options && options.unset;
       if (attrs instanceof Model) attrs = attrs.attributes;
-      if (options.unset) for (attr in attrs) attrs[attr] = void 0;
+      if (unset) for (attr in attrs) attrs[attr] = void 0;
 
       // Run validation.
       if (!this._validate(attrs, options)) return false;
@@ -280,7 +279,6 @@
       // Check for changes of `id`.
       if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];
 
-      var changes = options.changes = {};
       var now = this.attributes;
       var escaped = this._escapedAttributes;
       var prev = this._previousAttributes || {};
@@ -290,27 +288,28 @@
         val = attrs[attr];
 
         // If the new and current value differ, record the change.
-        if (!_.isEqual(now[attr], val) || (options.unset && _.has(now, attr))) {
+        if (!_.isEqual(now[attr], val) || (unset && _.has(now, attr))) {
           delete escaped[attr];
-          (options.silent ? this._silent : changes)[attr] = true;
+          this._changes[attr] = true;
         }
 
         // Update or delete the current value.
-        options.unset ? delete now[attr] : now[attr] = val;
+        unset ? delete now[attr] : now[attr] = val;
 
         // If the new and previous value differ, record the change.  If not,
         // then remove changes for this attribute.
         if (!_.isEqual(prev[attr], val) || (_.has(now, attr) !== _.has(prev, attr))) {
           this.changed[attr] = val;
-          if (!options.silent) this._pending[attr] = true;
+          if (!silent) this._pending[attr] = true;
         } else {
           delete this.changed[attr];
           delete this._pending[attr];
+          if (!silent) delete this._changes[attr];
         }
       }
 
       // Fire the `"change"` events.
-      if (!options.silent) this.change(options);
+      if (!silent) this.change(options);
       return this;
     },
 
@@ -345,16 +344,14 @@
     // Set a hash of model attributes, and sync the model to the server.
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
-    save: function(key, value, options) {
-      var attrs, current, done;
+    save: function(attrs, options) {
+      var key, current, done;
 
-      // Handle both `("key", value)` and `({key: value})` -style calls.
-      if (_.isObject(key) || key == null) {
-        attrs = key;
-        options = value;
-      } else {
-        attrs = {};
-        attrs[key] = value;
+      // Handle both `"key", value` and `{key: value}` -style arguments.
+      if (attrs != null && !_.isObject(attrs)) {
+        key = attrs;
+        (attrs = {})[key] = options;
+        options = arguments[2];
       }
       options = options ? _.clone(options) : {};
 
@@ -454,16 +451,15 @@
     // a `"change:attribute"` event for each changed attribute.
     // Calling this will cause all objects observing the model to update.
     change: function(options) {
-      options || (options = {});
       var changing = this._changing;
       this._changing = true;
 
       // Silent changes become pending changes.
-      for (var attr in this._silent) this._pending[attr] = true;
+      for (var attr in this._changes) this._pending[attr] = true;
 
-      // Silent changes are triggered.
-      var changes = _.extend({}, options.changes, this._silent);
-      this._silent = {};
+      // Trigger 'change:attr' for any new or silent changes.
+      var changes = this._changes;
+      this._changes = {};
       for (var attr in changes) {
         this.trigger('change:' + attr, this, this.get(attr), options);
       }
@@ -475,7 +471,7 @@
         this.trigger('change', this, options);
         // Pending and silent changes still remain.
         for (var attr in this.changed) {
-          if (this._pending[attr] || this._silent[attr]) continue;
+          if (this._pending[attr] || this._changes[attr]) continue;
           delete this.changed[attr];
         }
         this._previousAttributes = _.clone(this.attributes);
@@ -531,7 +527,7 @@
     // returning `true` if all is well. If a specific `error` callback has
     // been passed, call that instead of firing the general `"error"` event.
     _validate: function(attrs, options) {
-      if (options.silent || !this.validate) return true;
+      if (options && options.silent || !this.validate) return true;
       attrs = _.extend({}, this.attributes, attrs);
       var error = this.validate(attrs, options);
       if (!error) return true;

--- a/test/model.js
+++ b/test/model.js
@@ -741,8 +741,9 @@ $(document).ready(function() {
     });
     model.set({b: 0});
     deepEqual(changes, [0, 1, 1]);
+    changes = [];
     model.change();
-    deepEqual(changes, [0, 1, 1, 2, 1]);
+    deepEqual(changes, [2, 1]);
   });
 
   test("nested set multiple times", 1, function() {
@@ -814,6 +815,13 @@ $(document).ready(function() {
     model.validate = function(){ return 'invalid'; };
     model.sync = function(){ ok(false); };
     strictEqual(model.save(), false);
+  });
+
+  test("#1478 - Set to original value.", 0, function() {
+    var model = new Backbone.Model({x: 1});
+    model.on('change change:x', function(){ ok(false); });
+    model.set({x: 2}, {silent: true});
+    model.set({x: 1});
   });
 
 });


### PR DESCRIPTION
- Rename `_silent` as `_changes`.
- Use `_changes` for both silent and immediate changes.  This has the fortunate
  property of removing the `changes` option to `change`.
- Do not default `options` to `{}` where not necessary.
- Most importantly, delete attrs from `_changes` unless `{silent: true}`.
- Use single branch for argument normalization.
