### PR TITLE
Backbone.sync - remove params in favor of options

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1343,7 +1343,7 @@
     var type = methodMap[method];
 
     // JSON-request options & default options
-    options = _.extend({type: type, dataType: 'json'}, (options || {}));
+    options = _.extend({type: type, dataType: 'json'}, options);
 
     // Ensure that we have a URL.
     if (!options.url) {


### PR DESCRIPTION
Rather than using the `params` variable in `Backbone.sync`, all options for the ajax call can be added to the `options` argument.

This would be helpful in determining the type of action that was used to trigger the `error` or `success` event, as the `options` hash is passed as the last argument in the trigger - so `options.type` (or `options.data._method` if `emulateHTTP` is used) will now have the type of request associated with the sync along with other info about the request.
