### PR TITLE
Added fallback on model.get()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -236,8 +236,8 @@
     },
 
     // Get the value of an attribute.
-    get: function(attr) {
-      return this.attributes[attr];
+    get: function(attr, fallback) {
+      return ((this.attributes[attr] != null) || (_.isUndefined(fallback))) ? this.attributes[attr] : fallback;
     },
 
     // Get the HTML-escaped value of an attribute.

--- a/index.html
+++ b/index.html
@@ -828,10 +828,14 @@ new Book({
     </p>
 
     <p id="Model-get">
-      <b class="header">get</b><code>model.get(attribute)</code>
+      <b class="header">get</b><code>model.get(attribute, [fallback])</code>
       <br />
       Get the current value of an attribute from the model. For example:
       <tt>note.get("title")</tt>
+      <br />
+      <br />
+      Pass a fallback so when the return of the property is either undefined or null
+      <tt>note.get("readCount", "1")</tt>
     </p>
 
     <p id="Model-set">

--- a/test/model.js
+++ b/test/model.js
@@ -816,4 +816,29 @@ $(document).ready(function() {
     strictEqual(model.save(), false);
   });
 
+  test("Test fallback on model get", 8, function() {
+    var model = new Backbone.Model()
+    model.set({
+      x: 1234,
+      y: undefined,
+      j: null,
+      a: 'String'
+    });
+
+    strictEqual(model.get('x'), 1234);
+    strictEqual(model.get('x', 'fallback'), 1234);
+
+    strictEqual(model.get('y'), undefined);
+    strictEqual(model.get('y', 'fallback'), 'fallback');
+
+    strictEqual(model.get('j'), null);
+    strictEqual(model.get('j', 'hello'), 'hello');
+
+    strictEqual(model.get('a', 'Boo'), 'String');
+
+    strictEqual(model.get('hello', 'world'), 'world');
+
+
+  });
+
 });


### PR DESCRIPTION
Allows for a view, template etc to define a fallback if the attribute
is null or undefined … nice to have it other then undefined in the
rendered templates
