### PR TITLE
Added 'include' allow for mixin functionality

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1442,8 +1442,28 @@
     return child;
   };
 
+  var include = function(props) {
+    var parent = this;
+
+    // Loop through each of the properties and add them to the prototype
+    // if they don't already exist on the object
+    _(props).each(function(value, key){
+      if( key === 'included' ||  parent.prototype[key] ) return;
+      parent.prototype[key] = value;
+    });
+
+    // Call the callback function to give the mixin the ability to modify
+    // the object that we're mixing into.
+    if( typeof props.included === 'function' ) {
+      props.included.call(this);
+    }
+  };
+
   // Set up inheritance for the model, collection, router, and view.
   Model.extend = Collection.extend = Router.extend = View.extend = extend;
+
+  // Set up mixin ability
+  Model.include = Collection.include = Router.include = View.include = include;
 
   // Throw an error when a URL is needed, and none is supplied.
   var urlError = function() {

--- a/test/collection.js
+++ b/test/collection.js
@@ -1,4 +1,4 @@
-$(document).ready(function() {
+ $(document).ready(function() {
 
   var a, b, c, d, e, col, otherCol;
 
@@ -668,4 +668,24 @@ $(document).ready(function() {
     collection.add({id: 1, x: 3}, {merge: true});
     deepEqual(collection.pluck('id'), [2, 1]);
   });
+
+  test("mixin properties from an object", function() {
+    var TestCollection = Backbone.Collection.extend();
+    var mixin = {
+      foo: true,
+      included: function(){
+        this.bar = true;
+        this.prototype.initialize = function(){
+          this.raz = true;
+        };
+      }
+    };
+    TestCollection.include(mixin);
+    equal(TestCollection.prototype.foo, true);
+    equal(TestCollection.bar, true);
+    equal(TestCollection.prototype.included, undefined);
+    var collection = new TestCollection();
+    equal(collection.raz, true);
+  });
+
 });


### PR DESCRIPTION
One ability that Backbone lacks on it's objects is the ability to easily mixin functionality. 'Plugins' and 'extensions' require us to either extend their version of Backbone objects or we need to mix the functionality in using obscure methods. 

These methods aren't necessarily bad, but they are often unclear and having a better interface for mixins on views, models and collections would make extending Backbone much easer.

I've added an `include` method that does just this. It mimics the functionality from Spine.js (which it borrowed from Ruby I'm assuming).

Example:

``` js
var MyView = Backbone.View.extend();
MyView.include(CompositeView);
MyView.include(EditableView);
MyView.include(DraggableView);

var MyModel = Backbone.Model.extend();
MyModel.include(Validation);

```

It allows for a very nice syntax in coffeescript also:

``` coffee
class MyView extends Backbone.View
  @include CompositeView
  @include EditableView
  @include DraggableView
```

This allows you to mix functionality into the prototype of objects easily. Obviously this can be done with a simple _.extend. But this gives it a consistent interface that extensions can use to augment the functionality of the standard Backbone objects. 

Firing the callback on the mixin allows for great separation of concerns. You can extend Backbone without needing to increase the size of the hierarchy.

``` coffee
SelectableView = 

  included: ->
    this.prototype.events['click'] = '_onSelectClick';
    this.prototype.initialize = -> @selected = false
    this.prototype.dispose = -> @unselect()

  select: ->
  unselect: ->
  isSelected: -> @selected
```

``` coffee
class TaskListItem extends Backbone.View
  @include SelectableView

task = new TaskListItem
task.isSelected() # false
task.select()
```

This is generic enough that I think it could be of use for most, if not all, Backbone applications. I've needed this functionality on every project so far.

Test included. I'd like to see what others think of this approach.
