### PR TITLE
Added `sort` as `set` option

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -848,6 +848,10 @@
     _onModelEvent: function(event, model, collection, options) {
       if ((event === 'add' || event === 'remove') && collection !== this) return;
       if (event === 'destroy') this.remove(model, options);
+      // `collection` is the `options` object for the `change` event
+      if (event === 'change' && collection && collection.sort) {
+        if (this.comparator) this.sort();
+      }
       if (model && event === 'change:' + model.idAttribute) {
         delete this._byId[model.previous(model.idAttribute)];
         if (model.id != null) this._byId[model.id] = model;

--- a/test/collection.js
+++ b/test/collection.js
@@ -668,4 +668,16 @@ $(document).ready(function() {
     collection.add({id: 1, x: 3}, {merge: true});
     deepEqual(collection.pluck('id'), [2, 1]);
   });
+
+  test("#1587 - set sort option.", function() {
+    var collection = new Backbone.Collection([
+      {x: 1},
+      {x: 2}
+    ]);
+    collection.comparator = function(model){ return model.get('x'); };
+    collection.at(0).set({x: 3});
+    equal(collection.at(0).get('x'), 3);
+    collection.at(0).set({x: 4}, {sort: true});
+    equal(collection.at(0).get('x'), 2);
+  });
 });


### PR DESCRIPTION
Now calling `model.set({attr: 'val'}, {sort: true});` will cause collections containing `model` to be re-sorted if 'attr' was changed and the collection has a comparator.
