### PR TITLE
Fixes #1638 and #1604 - Account for order change in `add`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -635,8 +635,9 @@
       if (this.comparator && options.at == null) this.sort({silent: true});
 
       if (options.silent) return this;
-      for (i = 0, length = this.models.length; i < length; i++) {
-        if (!cids[(model = this.models[i]).cid]) continue;
+      var clone = this.models.slice();
+      for (i = 0, length = clone.length; i < length; i++) {
+        if (!cids[(model = clone[i]).cid]) continue;
         options.index = i;
         model.trigger('add', model, this, options);
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -668,4 +668,25 @@ $(document).ready(function() {
     collection.add({id: 1, x: 3}, {merge: true});
     deepEqual(collection.pluck('id'), [2, 1]);
   });
+
+  test("#1604 - Account for model removal during add.", 0, function() {
+    var collection = new Backbone.Collection([{}]);
+    collection.on('add', function() {
+      collection.at(0).destroy();
+    });
+    collection.add({}, {at: 0});
+  });
+
+  test("#1638 - sort on add triggers correctly.", function() {
+    var collection = new Backbone.Collection;
+    collection.comparator = function(model) { return model.get('x'); };
+    var added = [];
+    collection.on('add', function(model) {
+      model.set({x: 3});
+      collection.sort();
+      added.push(model.id);
+    });
+    collection.add([{id: 1, x: 1}, {id: 2, x: 2}]);
+    deepEqual(added, [1, 2]);
+  });
 });


### PR DESCRIPTION
Referencing `this.models` directly in the `add` event trigger loop seems to be causing issues. My solution is to clone the model list before iterating. Doesn't break any existing tests and fixes the two referenced cases (maybe more).
