### PR TITLE
Fix namespace reference in the todos example app docs.

### DIFF
--- a/examples/todos/todos.js
+++ b/examples/todos/todos.js
@@ -45,7 +45,7 @@ $(function(){
     // Reference to this collection's model.
     model: Todo,
 
-    // Save all of the todo items under the `"todos"` namespace.
+    // Save all of the todo items under the `"todos-backbone"` namespace.
     localStorage: new Backbone.LocalStorage("todos-backbone"),
 
     // Filter down the list of all todo items that are finished.


### PR DESCRIPTION
Fix todos.js example namespace in the documentation.
