### PR TITLE
Remove dead code.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1138,7 +1138,7 @@
       fragment = this.getFragment(fragment || '');
       if (this.fragment === fragment) return;
       this.fragment = fragment;
-      var url = (fragment.indexOf(this.root) !== 0 ? this.root : '') + fragment;
+      var url = this.root + fragment;
 
       // If pushState is available, we use it to set the fragment as a real URL.
       if (this._hasPushState) {


### PR DESCRIPTION
Since the root will always contain a leading slash and
the fragment will never contain a leading slash, the
fragment will never start with the root.
