### PR TITLE
Enable IE8 to load a static page

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1071,18 +1071,20 @@
       // but we're currently in a browser that doesn't support it...
       if (this._wantsHashChange && this._wantsPushState && !this._hasPushState && !atRoot) {
         this.fragment = this.getFragment(null, true);
-        this.location.replace(this.root + this.location.search + '#' + this.fragment);
-        // Return immediately as browser will do redirect to new url
-        return true;
-
+        // Only change the current URL if we have a matching route.  Otherwise assume it's a normal page load.
+        if (!this.options.silent && this.loadUrl(this.fragment)) {
+            this.location.replace(this.root + this.location.search + '#' + this.fragment);
+            // Return immediately as browser will do redirect to new url
+            return true;
+        }
       // Or if we've started out with a hash-based route, but we're currently
       // in a browser where it could be `pushState`-based instead...
       } else if (this._wantsPushState && this._hasPushState && atRoot && loc.hash) {
         this.fragment = this.getHash().replace(routeStripper, '');
         this.history.replaceState({}, document.title, this.root + this.fragment);
+        if (!this.options.silent) return this.loadUrl();
       }
 
-      if (!this.options.silent) return this.loadUrl();
     },
 
     // Disable Backbone.history, perhaps temporarily. Not useful in a real app,


### PR DESCRIPTION
Previously if you went to:
http://domain.com/some/page

IE8 with pushState would rewrite the URL to:
http://domain.com/#some/page

That's usually good if there is a route for 'some/page', however if there is no route, IE8 tries to load the root URL (/) and then do nothing else.

This would mean that some/page would load, then get cleared off, leading to a strange and bad user experience.

With this change, backbone only changes the current page on history start if there is a matching route.  

Push state enabled browsers are untouched in operation.
