### PR TITLE
Adding support regular expression in method 'where' of Collection.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -721,7 +721,11 @@
       if (_.isEmpty(attrs)) return [];
       return this.filter(function(model) {
         for (var key in attrs) {
-          if (attrs[key] !== model.get(key)) return false;
+          if (!(attrs[key] instanceof RegExp)) {
+            if (attrs[key] != model.get(key)) return false;
+          } else {
+            if (!attrs[key].test(model.get(key))) return false;
+          }
         }
         return true;
       });

--- a/test/collection.js
+++ b/test/collection.js
@@ -436,7 +436,7 @@ $(document).ready(function() {
     equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });
 
-  test("where", 6, function() {
+  test("where", 8, function() {
     var coll = new Backbone.Collection([
       {a: 1},
       {a: 1},
@@ -450,6 +450,8 @@ $(document).ready(function() {
     equal(coll.where({b: 1}).length, 0);
     equal(coll.where({b: 2}).length, 2);
     equal(coll.where({a: 1, b: 2}).length, 1);
+    equal(coll.where({b: /\d/}).length, 2);
+    equal(coll.where({a: /1/, b: 2}).length, 1);
   });
 
   test("Underscore methods", 13, function() {


### PR DESCRIPTION
For example, for select all models where 'id' attribute that begin from whole number:

Just write

``` JavaScript
collection.where({id: /^[\d]+/i});
```

instead

``` JavaScript
collection.filter(function(item) {
  return /^[\d]+/i.test(item.get('id'))
});
```
