### PR TITLE
Allow HTTP verbs to be specified for sync

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1352,7 +1352,7 @@
   // Useful when interfacing with server-side languages like **PHP** that make
   // it difficult to read the body of `PUT` requests.
   Backbone.sync = function(method, model, options) {
-    var type = methodMap[method];
+    var type = methodMap[method] || method;
 
     // Default options, unless specified.
     options || (options = {});


### PR DESCRIPTION
While the CRUD->REST mapping can be useful conceptually, it's not entirely accurate.  Because POST is not idempotent, but PUT is, there are times a create or an update could be either.

This change allows HTTP verbs to be directly passed to sync, ignoring the mapping.

A possible alternative (which could also be used in conjunction with this change), would be to add 'get', 'put', 'post', and 'delete' to the methodMap.
