### PR TITLE
Checking that model.trigger is a function to make Backbone.sync more flexible

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1385,13 +1385,13 @@
     var success = options.success;
     options.success = function(resp, status, xhr) {
       if (success) success(resp, status, xhr);
-      model.trigger('sync', model, resp, options);
+      if (_.isFunction(model.trigger)) model.trigger('sync', model, resp, options);
     };
 
     var error = options.error;
     options.error = function(xhr, status, thrown) {
       if (error) error(model, xhr, options);
-      model.trigger('error', model, xhr, options);
+      if (_.isFunction(model.trigger)) model.trigger('error', model, xhr, options);
     };
 
     // Make the request, allowing the user to override any Ajax options.


### PR DESCRIPTION
Before the `success` & `error` handlers were consolidated into `Backbone.sync` - it was possible (albeit undocumented) functionality to use `Backbone.sync` standalone with a plain javascript object as the second argument - rather than a `Model` or `Collection`, as a convenient wrapper for  `$.ajax` calls:

```
 Backbone.sync('save', obj, {
     url : '/path/to/url',
     success : function () {
       // success
     },
     error : function () {
       // error         
     }
 });
```

While undocumented, I found it to be a nice feature to standardize an `$.ajax` wrapper to use stand-alone, in one-off cases where creating a model or collection seemed overkill. So I'm suggesting adding an `_.isFunction` check before the `trigger` call, so the `Backbone.sync` can continue to be used in this fashion.
