### PR TITLE
consistently handle `undefined` being passed to the model constr (#1545)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -183,11 +183,11 @@
   // is automatically generated and assigned for you.
   var Model = Backbone.Model = function(attributes, options) {
     var defaults;
-    attributes || (attributes = {});
+    var attrs = attributes || {};
     if (options && options.collection) this.collection = options.collection;
     if (options && options.parse) attributes = this.parse(attributes);
     if (defaults = _.result(this, 'defaults')) {
-      attributes = _.extend({}, defaults, attributes);
+      attrs = _.extend({}, defaults, attrs);
     }
     this.attributes = {};
     this._escapedAttributes = {};
@@ -195,7 +195,7 @@
     this.changed = {};
     this._silent = {};
     this._pending = {};
-    this.set(attributes, {silent: true});
+    this.set(attrs, {silent: true});
     // Reset change tracking.
     this.changed = {};
     this._silent = {};

--- a/test/model.js
+++ b/test/model.js
@@ -816,4 +816,15 @@ $(document).ready(function() {
     strictEqual(model.save(), false);
   });
 
+  test("#1545 - `undefined` can be passed to a model constructor without coersion", function() {
+    var Model = Backbone.Model.extend({
+      defaults: { one: 1 },
+      initialize : function(attrs, opts) {
+        equal(attrs, undefined);
+      }
+    });
+    var emptyattrs = new Model();
+    var undefinedattrs = new Model(undefined);
+  });
+
 });


### PR DESCRIPTION
This is a corrected rebase for #1550, providing a fix for #1545
