### PR TITLE
Allow view.el to be provided as a function.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1320,7 +1320,7 @@
         if (this.className) attrs['class'] = _.result(this, 'className');
         this.setElement(this.make(_.result(this, 'tagName'), attrs), false);
       } else {
-        this.setElement(this.el, false);
+        this.setElement(_.result(this, 'el'), false);
       }
     }
 

--- a/test/view.js
+++ b/test/view.js
@@ -312,4 +312,15 @@ $(document).ready(function() {
     view.remove();
   });
 
+  test("Provide function for el.", 1, function() {
+    var View = Backbone.View.extend({
+      el: function() {
+        return "<p><a></a></p>";
+      }
+    });
+
+    var view = new View;
+    ok(view.$el.is('p:has(a)'));
+  });
+
 });


### PR DESCRIPTION
I find this to be a rather elegant way to include the view element in a template (a much requested feature).

``` js
var View = Backbone.View.extend({
  el: _.template("<a class='…'><%- this.model.get('name') %></a>")
});
```
