### PR TITLE
Changes for a storage/unique model list implementation

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1445,7 +1445,8 @@
     if (protoProps && _.has(protoProps, 'constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ parent.apply(this, arguments); };
+      // Pass away the constructor return
+      child = function(){ return parent.apply(this, arguments); };
     }
 
     // Add static properties to the constructor function, if supplied.


### PR DESCRIPTION
Pass away the constructor return in the extend function,
this is needed storage/unique list implementation.
