### PR TITLE
Add Lo-Dash reference to index.html.

### DIFF
--- a/index.html
+++ b/index.html
@@ -555,8 +555,9 @@
     </table>
 
     <p>
-      Backbone's only hard dependency is
-      <a href="http://underscorejs.org/">Underscore.js</a> <small>( > 1.3.1)</small>.
+      Backbone's only hard dependency is either
+      <a href="http://underscorejs.org/">Underscore.js</a> <small>( > 1.3.1)</small> or
+      <a href="http://lodash.com">Lo-Dash</a>.
       For RESTful persistence, history support via <a href="#Router">Backbone.Router</a>
       and DOM manipulation with <a href="#View">Backbone.View</a>, include
       <a href="https://github.com/douglascrockford/JSON-js">json2.js</a>, and either


### PR DESCRIPTION
At the moment `index.html` lists Underscore as the only hard dependency, but that is no longer the case. Lo-Dash is developed with Backbone compatibility in mind and is used by Backbone boilerplates from @gfranko, [Backbone-Require-Boilerplate](https://github.com/gfranko/Backbone-Require-Boilerplate), and @tbranyen, [Backbone Boilerplate](https://github.com/tbranyen/backbone-boilerplate).

Lo-Dash has custom build options for Backbone, template precompiler options, AMD and build optimizer support, and is tested against Backbone's unit tests.

Because Lo-Dash is developed as a drop-in replacement for Underscore it aligns more closely with the expected API.

_(unlike Backbone's secondary optional dependency, zepto, and its `.remove` method which doesn't destroy element event data like jQuery and can contribute to single page memory leaks)_
