### PR TITLE
Check if model/collection support .off when disposing of the view

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1234,8 +1234,8 @@
     // memory leaks.
     dispose: function() {
       this.undelegateEvents();
-      if (this.model) this.model.off(null, null, this);
-      if (this.collection) this.collection.off(null, null, this);
+      if (this.model && this.model.off) this.model.off(null, null, this);
+      if (this.collection && this.collection.off) this.collection.off(null, null, this);
       return this;
     },
 

--- a/test/view.js
+++ b/test/view.js
@@ -286,11 +286,11 @@ $(document).ready(function() {
   test("dispose", 0, function() {
     var View = Backbone.View.extend({
       events: {
-        click: function() { ok(false); }
+        click: function() { fail(); }
       },
       initialize: function() {
-        this.model.on('all x', function(){ ok(false); }, this);
-        this.collection.on('all x', function(){ ok(false); }, this);
+        this.model.on('all x', function(){ fail(); }, this);
+        this.collection.on('all x', function(){ fail(); }, this);
       }
     });
 
@@ -303,6 +303,11 @@ $(document).ready(function() {
     view.model.trigger('x');
     view.collection.trigger('x');
     view.$el.click();
+  });
+
+  test("dispose with non Backbone objects", 0, function() {
+    var view = new Backbone.View({model: {}, collection: {}});
+    view.dispose();
   });
 
   test("view#remove calls dispose.", 1, function() {


### PR DESCRIPTION
I often start with models/collections which are plain objects who don't have `.off` method.   And the current backbone master breaks some of my code. I don't think is necessary to force all model/collection objects who the Backbone.View accept to be from Backbone.Model/Collection.
