### PR TITLE
Stop Backbone throwing an error when an invalid model is added

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -543,7 +543,6 @@ $(document).ready(function() {
   });
 
   test("#861, adding models to a collection which do not pass validation", 2, function() {
-      var fired = null;
       var Model = Backbone.Model.extend({
         validate: function(attrs) {
           if (attrs.id == 3) return "id can't be 3";
@@ -554,27 +553,26 @@ $(document).ready(function() {
         model: Model
       });
 
-      var col = new Collection;
-      col.on("error", function() { fired = true; });
+      var collection = new Collection;
+      collection.on("error", function() { ok(true); });
 
-      col.add([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]);
-      equal(fired, true);
-      equal(col.length, 5);
+      collection.add([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]);
+      deepEqual(collection.pluck('id'), [1, 2, 4, 5, 6]);
   });
 
-  test("invalid models are discarded and only valid models are added to a collection", 5, function() {
-    var col = new Backbone.Collection();
-    col.on('test', function() { ok(true); });
-    col.model = Backbone.Model.extend({
+  test("Invalid models are discarded.", 5, function() {
+    var collection = new Backbone.Collection;
+    collection.on('test', function() { ok(true); });
+    collection.model = Backbone.Model.extend({
       validate: function(attrs){ if (!attrs.valid) return 'invalid'; }
     });
-    var model = new col.model({id: 1, valid: true});
-    col.add([model, {id: 2}]);;
+    var model = new collection.model({id: 1, valid: true});
+    collection.add([model, {id: 2}]);;
     model.trigger('test');
-    ok(col.getByCid(model.cid));
-    ok(col.get(1));
-    ok(!col.get(2));
-    equal(col.length, 1);
+    ok(collection.getByCid(model.cid));
+    ok(collection.get(1));
+    ok(!collection.get(2));
+    equal(collection.length, 1);
   });
 
   test("multiple copies of the same model", 3, function() {


### PR DESCRIPTION
Currently errors are thrown in the following places in Backbone:
- Syncing without defining a url
- Sorting a collection without a comparator
- Starting Backbone History twice
- Trying to delegate an event to a non existent method
- Adding an invalid model to a collection

The first four errors all relate to a bugs in a users code and should understandably be thrown. The last error however is the result of invalid data being sent to the application. This data may have come from a source outside the users control or there may be a bug in the users server code. Either way I think an error shouldn't be thrown when trying to add an invalid model to a collection. 

I was just bitten by this recently and I think this kind of error should trigger an error event rather than throwing an error. I had an application running smoothly for months, until some hidden server-side bug caused an empty model to be sent to the client along with about 100 valid models. The empty model prevented the other models being added. This pull request throws away invalid models and triggers an error event on the collection, rather than throwing an error and stopping the application.

If this pull request is not the answer, I think there still needs to be a better way of handling this.
In making the change I also removed a loop in Collection.add, - so this change should bring a small performance boost.

Similar issues:
https://github.com/documentcloud/backbone/pull/484
