### PR TITLE
Use Model#attributes instead of Model#get

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -725,7 +725,7 @@
       if (_.isEmpty(attrs)) return [];
       return this.filter(function(model) {
         for (var key in attrs) {
-          if (attrs[key] !== model.get(key)) return false;
+          if (attrs[key] !== model.attributes[key]) return false;
         }
         return true;
       });
@@ -885,7 +885,7 @@
   _.each(attributeMethods, function(method) {
     Collection.prototype[method] = function(value, context) {
       var iterator = _.isFunction(value) ? value : function(model) {
-        return model.get(value);
+        return model.attributes[value];
       };
       return _[method](this.models, iterator, context);
     };


### PR DESCRIPTION
While there are some pretty good usages of `Model#get` (like the implementation of `Collection#pluck`), its there just for symmetry with set and I don't think it will change (it hasn't been touched for two years).

We can avoid the function overhead when model attribute access is needed internally. I have replaced `model.get` with `model.attributes` in the implementation of `Collection#where` and the underscore delegation of the `Collection` `attributeMethods` (`groupBy`, `countBy`, `sortBy`).

Its not a big speedup, but its not a complex change also.
