### PR TITLE
"beforeRemove" event for View to be able to remove sub views

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1242,6 +1242,7 @@
     // Remove this view from the DOM. Note that the view isn't present in the
     // DOM by default, so calling this method may be a no-op.
     remove: function() {
+      this.trigger("beforeRemove");
       this.dispose();
       this.$el.remove();
       return this;


### PR DESCRIPTION
Glad to see new Backbone.VIew.dispose() method being called in Backbone.VIew.remove().
There is a problem with removing complex views. Suppose we have a view with a set of subviews. We should have an easy way to dispose and remove them before the parent view does to prevent memory leak.
I've added beforeRemove trigger that addresses this problem.

**Example:**

``` javascript
Backbone.View.extend({

        subView: null,

        initialize: function() {

            var class_subView = Backbone.View.extend();
            this.subViews = new class_subView();

            this.on("beforeRemove", this.beforeRemove, this);
        },


        beforeRemove: function() {
            subViews.remove();
        }

    });

```
