### PR TITLE
Add `extend` to Backbone.History.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1467,7 +1467,7 @@
   };
 
   // Set up inheritance for the model, collection, router, and view.
-  Model.extend = Collection.extend = Router.extend = View.extend = extend;
+  Model.extend = Collection.extend = Router.extend = View.extend = History.extend = extend;
 
   // Throw an error when a URL is needed, and none is supplied.
   var urlError = function() {


### PR DESCRIPTION
Using `extend` on `Backbone.History` allows for [cleanly adding functionality such as a `"route-not-found"` event](https://github.com/documentcloud/backbone/issues/308#issuecomment-9482299).
