### PR TITLE
Input model passed to Backbone.Model#set shouldn't be cleared.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -275,7 +275,7 @@
       // Extract attributes and options.
       var silent = options && options.silent;
       var unset = options && options.unset;
-      if (attrs instanceof Model) attrs = attrs.attributes;
+      if (attrs instanceof Model) attrs = _.clone(attrs.attributes);
       if (unset) for (attr in attrs) attrs[attr] = void 0;
 
       // Run validation.


### PR DESCRIPTION
Previously:
  var foo = new Backbone.Model({p: 1});
  var bar = new Backbone.Model({p: 2});
  bar.set(foo, {unset: true});
  console.info(foo.get('p'));
  console.info(bar.get('p'));

Displayed

> undefined
> undefined

Expected behaviour would be:

> 1
> undefined

Input model was even reset directly through 'attributes' property.
