### PR TITLE
Add selector context to View.$

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1213,7 +1213,10 @@
 
     // jQuery delegate for element lookup, scoped to DOM elements within the
     // current view. This should be prefered to global lookups where possible.
-    $: function(selector) {
+    $: function(selector, context) {
+      if (typeof context !== 'undefined') {
+        return this.$el.find(context).find(selector);
+      }
       return this.$el.find(selector);
     },
 

--- a/test/view.js
+++ b/test/view.js
@@ -20,10 +20,11 @@ $(document).ready(function() {
     equal(view.options.className, 'test-view');
   });
 
-  test("jQuery", 1, function() {
+  test("jQuery", 2, function() {
     var view = new Backbone.View;
     view.setElement('<p><a><b>test</b></a></p>');
     strictEqual(view.$('a b').html(), 'test');
+    strictEqual(view.$('b', 'a').html(), 'test');
   });
 
   test("make", 3, function() {


### PR DESCRIPTION
jQuery'`$` accepts a [selector context](http://api.jquery.com/jquery/#selector-context) (implemented internally with [$.find](http://api.jquery.com/find/)).

This tiny patch makes Backbone's `View.$` behave similarly (one surprise less), and does not increase the number of failed tests on the Ender and Zepto suites, so I think it's innocent enough.

Anyway, HTH. :)
