### PR TITLE
Allow empty routes

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -947,7 +947,7 @@
     _bindRoutes: function() {
       if (!this.routes) return;
       var route, routes = _.keys(this.routes);
-      while (route = routes.pop()) {
+      while (typeof (route = routes.pop()) !== 'undefined') {
         var name = this.routes[route];
         this.route(route, name, this[name]);
       }


### PR DESCRIPTION
As of 9b0e85213b5f579bea7b90238048f689afc4f62f loading route for empty fragment is no longer possible because "" is falsy. It used to be possible since issue #67. Added check for undefined.
