### PR TITLE
{merge: true} option for Collection::reset

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -504,6 +504,55 @@ $(document).ready(function() {
     });
   });
 
+  test("reset and merge", 24, function() {
+    var models = col.models.slice();
+
+    var removeCount = 0;
+    var addCount = 0;
+    var changeCount = 0;
+    var resetCount = 0;
+    col.on('remove', function() { removeCount += 1; });
+    col.on('add', function() { addCount += 1; });
+    col.on('change', function() { changeCount += 1; });
+    col.on('reset', function() { resetCount += 1; });
+
+    // Remove a, b, c, d
+    col.reset([], {merge: true});
+    equal(removeCount, 4); // +4
+    equal(addCount, 0);
+    equal(changeCount, 0);
+    equal(resetCount, 0);
+    equal(col.length, 0);
+    equal(col.last(), null);
+
+    // Add a, b, c, d
+    col.reset(models, {merge: true});
+    equal(removeCount, 4);
+    equal(addCount, 4); // +4
+    equal(changeCount, 0);
+    equal(resetCount, 0);
+    equal(col.length, 4);
+    equal(col.last(), d);
+
+    // Change a
+    col.reset({id: 3, label: 'aa'}, {merge: true});
+    equal(removeCount, 7); // +3
+    equal(addCount, 4);
+    equal(changeCount, 1); // +1
+    equal(resetCount, 0);
+    equal(col.length, 1);
+    equal(col.last(), a);
+
+    // Be quiet!
+    col.reset([], {merge: true, silent: true});
+    equal(removeCount, 7); // +0
+    equal(addCount, 4);
+    equal(changeCount, 1);
+    equal(resetCount, 0);
+    equal(col.length, 0);
+    equal(col.last(), null);
+  });
+
   test("trigger custom events on models", 1, function() {
     var fired = null;
     a.on("custom", function() { fired = true; });


### PR DESCRIPTION
A great addition to Backbone `>0.9.2` (actually `master`) is the `merge` option for `Collection::add` : 

``` javascript
Dog = Backbone.Model.extend({});
Dogs = Backbone.Collection.extend({model: Dog});

myDogs = new Dogs();
myDogs.add({id: 1, name: 'rex'}); // 'add'
myDogs.add({id: 1, name: 'Rex'}, {merge: true}); // 'change'
```
## 

This PR takes advantage on this new feature and applies it to `Collection::reset` in order to enable triggering individual `'add'`/`'change'`, `'remove'` events when `reset`ting a collection.

Let's have an example:

``` javascript
// As usual:
myDogs = new Dogs();
myDogs.reset([
  {id: 1, name: 'rex'},
  {id: 2, name: 'bill'}
]); // 'reset'

// And now with merge option:
myDogs.reset([
  {id: 1, name: 'Rex'},  // rex has changed to Rex => 'change'
                         // bill has gone => 'remove'
  {id: 3, name: 'Snowy'} // Snowy is coming => 'add'
], {merge: true});
```

NB : with `{merge: true}`, `'reset'` event is no longer triggered (like `'add'` isn't for `Collection::add` when merging).

If you want no event at all, just pass `{silent: true}` option.

This can be used in conjunction with `Collection::fetch` by passing `{merge: true}` option to it and stay compatible with the `{add: true}` option.
## 

It comes with 24 tests under ["reset and merge"](https://github.com/documentcloud/backbone/pull/1752/files#L1R507).

I'm quite new to Backbone so please review my implementation and tell me your opinion about it.

Cheers
