### PR TITLE
Call 'beforeSend' function set with $.ajaxSetup when Backbone.emulateHTT...

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1396,8 +1396,8 @@
         if (Backbone.emulateJSON) params.data._method = type;
         params.type = 'POST';
         var beforeSend = Backbone.$.ajaxSettings.beforeSend;
-        params.beforeSend = function(xhr, settings) {
-          beforeSend && beforeSend(xhr, settings);
+        params.beforeSend = function(xhr) {
+          beforeSend && beforeSend.apply(this, arguments);
           xhr.setRequestHeader('X-HTTP-Method-Override', type);
         };
       }


### PR DESCRIPTION
...P is set to true.

Previously if we set:

```
Backbone.emulateHTTP = true;
```

and 'beforeSend' on $.ajax via:

```
$.ajaxSetup({
  beforeSend: function (xhr) {
    xhr.setRequestHeader('X-CSRFToken', $.cookie('csrftoken'));
  }
});
```

Then 'beforeSend' won't be called on xhr requests.
