### PR TITLE
Be sure to return the value of `beforeSend`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1397,7 +1397,7 @@
       var beforeSend = options.beforeSend;
       options.beforeSend = function(xhr) {
         xhr.setRequestHeader('X-HTTP-Method-Override', type);
-        if (beforeSend) beforeSend.apply(this, arguments);
+        if (beforeSend) return beforeSend.apply(this, arguments);
       };
     }
 


### PR DESCRIPTION
We should return the result of `beforeSend`, checkout [the jQuery docs](http://api.jquery.com/jQuery.ajax/)...

> Returning false in the beforeSend function will cancel the request.
