### PR TITLE
Use _.pick to simplify View#_configure

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1313,10 +1313,7 @@
     // attached directly to the view.
     _configure: function(options) {
       if (this.options) options = _.extend({}, this.options, options);
-      for (var i = 0, l = viewOptions.length; i < l; i++) {
-        var attr = viewOptions[i];
-        if (options[attr]) this[attr] = options[attr];
-      }
+      _.extend(this, _.pick(options, viewOptions));
       this.options = options;
     },
 

--- a/index.html
+++ b/index.html
@@ -556,7 +556,7 @@
 
     <p>
       Backbone's only hard dependency is either
-      <a href="http://underscorejs.org/">Underscore.js</a> <small>( > 1.3.1)</small> or
+      <a href="http://underscorejs.org/">Underscore.js</a> <small>( > 1.3.3)</small> or
       <a href="http://lodash.com">Lo-Dash</a>.
       For RESTful persistence, history support via <a href="#Router">Backbone.Router</a>
       and DOM manipulation with <a href="#View">Backbone.View</a>, include

--- a/test/view.js
+++ b/test/view.js
@@ -7,17 +7,20 @@ $(document).ready(function() {
     setup: function() {
       view = new Backbone.View({
         id        : 'test-view',
-        className : 'test-view'
+        className : 'test-view',
+        other     : 'non-special-option'
       });
     }
 
   });
 
-  test("constructor", 4, function() {
+  test("constructor", 6, function() {
     equal(view.el.id, 'test-view');
     equal(view.el.className, 'test-view');
+    equal(view.el.other, void 0);
     equal(view.options.id, 'test-view');
     equal(view.options.className, 'test-view');
+    equal(view.options.other, 'non-special-option');
   });
 
   test("jQuery", 1, function() {


### PR DESCRIPTION
`_.pick` is available in Underscore since 1.3.3, so bumped the docs to reflect that too. Also added 2 more assertions to the `View#constructor` test to verify that the non special options go to the `options` property and not the instance itself.
