### PR TITLE
Refactor `set` to avoid unnecessary `arguments` object creation

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -353,14 +353,15 @@
     // Set a hash of model attributes, and sync the model to the server.
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
-    save: function(attrs, options) {
-      var key, current, done;
+    save: function(key, val, options) {
+      var attrs, current, done;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
-      if (attrs != null && !_.isObject(attrs)) {
-        key = attrs;
-        (attrs = {})[key] = options;
-        options = arguments[2];
+      if (key == null || _.isObject(key)) {
+        attrs = key;
+        options = val;
+      } else if (key != null) {
+        (attrs = {})[key] = val;
       }
       options = options ? _.clone(options) : {};
 


### PR DESCRIPTION
`arguments` is slower and unnecessary in this case, so let's avoid it.
