### PR TITLE
Optionally allow set() to accept an invalid value

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -276,7 +276,7 @@
       if (options.unset) for (attr in attrs) attrs[attr] = void 0;
 
       // Run validation.
-      if (!this._validate(attrs, options)) return false;
+      if (!this._validate(attrs, options) && !options.allowInvalid) return false;
 
       // Check for changes of `id`.
       if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];

--- a/test/model.js
+++ b/test/model.js
@@ -195,6 +195,25 @@ $(document).ready(function() {
     equal(a.id, undefined, "Unsetting the id should remove the id property.");
   });
 
+  test("Model: Disallow invalid value", function() {
+    var lastError, model = new Backbone.Model();
+    model.validate = function(attrs) {
+      return 'Invalid';
+    };
+
+    ok(model.set('field', 'value') === false, "An invalid value was allowed.");
+    ok(model.set('field', 'value', {allowInvalid: false}) === false, "An invalid value was allowed.");
+  });
+
+  test("Model: Allow invalid value", function() {
+    var lastError, model = new Backbone.Model();
+    model.validate = function(attrs) {
+      return 'Invalid';
+    };
+
+    ok(model.set('field', 'value', {allowInvalid: true}) === model, "An invalid value was not allowed.");
+  });
+
   test("Model: multiple unsets", function() {
     var i = 0;
     var counter = function(){ i++; };


### PR DESCRIPTION
This change allows us to choose of `Model.set()` should bail early when it receives an invalid value.

This is useful for more complex validation scenarios - Contrived example:

```
model.set('age', 5); // Valid
model.set('isAdult', true, {allowInvalid: true}); // Invalid - Adults must be 18 years or older
model.set('age', 18); // Valid again

console.log(model.get('isAdult')); // Outputs `true`, rather than `false`
```

Tests included.
