### PR TITLE
Add a more meaningfull test for parsing by default.

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -701,4 +701,19 @@ $(document).ready(function() {
     collection.add([{id: 1, x: 1}, {id: 2, x: 2}]);
     deepEqual(added, [1, 2]);
   });
+
+  test("fetch parses models by default", 1, function() {
+    var model = {};
+    var Collection = Backbone.Collection.extend({
+      url: 'test',
+      model: Backbone.Model.extend({
+        parse: function(resp) {
+          strictEqual(resp, model);
+        }
+      })
+    });
+    new Collection().fetch();
+    this.ajaxSettings.success([model]);
+  });
+
 });


### PR DESCRIPTION
There is already [a test](https://github.com/documentcloud/backbone/blob/078bb39dba1ed7192b8f831dffe1767e2c9326f0/test/collection.js#L379) for providing the option but, in addition to being more clear, I think this one is more robust since it goes through `Backbone.sync` and ensures the option gets passed to `Collection#add`.
