### PR TITLE
Collection.fetch() documentation update.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1777,8 +1777,12 @@ var Tweets = Backbone.Collection.extend({
       resetting the collection when they arrive. The <b>options</b> hash takes
       <tt>success</tt> and <tt>error</tt>
       callbacks which will be passed <tt>(collection, response)</tt> as arguments.
-      When the model data returns from the server, the collection will
-      <a href="#Collection-reset">reset</a>.
+    </p>
+    <p>
+      When the model data returns from the server, the collection will invoke the
+      <a href="#Collection-reset">reset</a> on success, which in turn will trigger
+      the <tt>"reset"</tt> event. Pass <tt>{silent: true}</tt> to suppress it.
+    </p>
       Delegates to <a href="#Sync">Backbone.sync</a>
       under the covers for custom persistence strategies and returns a
       <a href="http://api.jquery.com/jQuery.ajax/#jqXHR">jqXHR</a>.
@@ -1816,12 +1820,6 @@ Accounts.fetch();
       intended for lazily-loading models for interfaces that are not needed
       immediately: for example, documents with collections of notes that may be
       toggled open and closed.
-    </p>
-
-    <p>
-      <b>fetch</b> will call <b>reset</b> on success, which in turn will trigger
-      the <tt>"reset"</tt> event. Pass <tt>{silent: true}</tt> to suppress the
-      <tt>"reset"</tt> event.
     </p>
 
     <p id="Collection-reset">


### PR DESCRIPTION
Added the part about 'reset' even and slicencing it. It was something I was trying to find in docs.

Some whitespaces removed at the end of strings.
