### PR TITLE
Bump underscore version to 1.3.3 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords"      : ["model", "view", "controller", "router", "server", "client", "browser"],
   "author"        : "Jeremy Ashkenas <jeremy@documentcloud.org>",
   "dependencies"  : {
-    "underscore"  : ">=1.3.1"
+    "underscore"  : ">=1.3.3"
   },
   "main"          : "backbone.js",
   "version"       : "0.9.2"


### PR DESCRIPTION
The changes that I made to `View#_configure` back in #1762, bumped the underscore version in the docs, but not in `package.json`. The latest change by @caseywebdev (#1784) reminded me to do that.
