### PR TITLE
updating documentation for Collection#reset method signature (fixes #1785)

### DIFF
--- a/index.html
+++ b/index.html
@@ -1819,7 +1819,7 @@ Accounts.fetch();
     </p>
 
     <p id="Collection-reset">
-      <b class="header">reset</b><code>collection.reset(models, [options])</code>
+      <b class="header">reset</b><code>collection.reset([models], [options])</code>
       <br />
       Adding and removing models one at a time is all well and good, but sometimes
       you have so many models to change that you'd rather just update the collection


### PR DESCRIPTION
Updating Collection#reset docs to reflect that the `models` argument is optional
