### PR TITLE
Validation method renaming.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -280,7 +280,7 @@
       if (unset) for (attr in attrs) attrs[attr] = void 0;
 
       // Run validation.
-      if (!this._validate(attrs, options)) return false;
+      if (!this.validate(attrs, options)) return false;
 
       // Check for changes of `id`.
       if (this.idAttribute in attrs) this.id = attrs[this.idAttribute];
@@ -367,7 +367,7 @@
 
       // If we're "wait"-ing to set changed attributes, validate early.
       if (options.wait) {
-        if (!this._validate(attrs, options)) return false;
+        if (!this.validate(attrs, options)) return false;
         current = _.clone(this.attributes);
       }
 
@@ -378,7 +378,7 @@
       }
 
       // Do not persist invalid models.
-      if (!attrs && !this._validate(null, options)) return false;
+      if (!attrs && !this.validate(null, options)) return false;
 
       // After a successful server-side save, the client is (optionally)
       // updated with the server-side state.
@@ -538,16 +538,16 @@
     // Check if the model is currently in a valid state. It's only possible to
     // get into an *invalid* state if you're using silent changes.
     isValid: function(options) {
-      return !this.validate || !this.validate(this.attributes, options);
+      return !this.validator || !this.validator(this.attributes, options);
     },
 
     // Run validation against the next complete set of model attributes,
     // returning `true` if all is well. If a specific `error` callback has
     // been passed, call that instead of firing the general `"error"` event.
-    _validate: function(attrs, options) {
-      if (options && options.silent || !this.validate) return true;
+    validate: function(attrs, options) {
+      if (options && options.silent || !this.validator) return true;
       attrs = _.extend({}, this.attributes, attrs);
-      var error = this.validate(attrs, options);
+      var error = this.validator(attrs, options);
       if (!error) return true;
       if (options && options.error) options.error(this, error, options);
       this.trigger('error', this, error, options);
@@ -837,7 +837,7 @@
       options || (options = {});
       options.collection = this;
       var model = new this.model(attrs, options);
-      if (!model._validate(model.attributes, options)) return false;
+      if (!model.validate(model.attributes, options)) return false;
       return model;
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -394,7 +394,7 @@ $(document).ready(function() {
 
   test("create enforces validation", 1, function() {
     var ValidatingModel = Backbone.Model.extend({
-      validate: function(attrs) {
+      validator: function(attrs) {
         return "fail";
       }
     });
@@ -407,7 +407,7 @@ $(document).ready(function() {
 
   test("a failing create runs the error callback", 1, function() {
     var ValidatingModel = Backbone.Model.extend({
-      validate: function(attrs) {
+      validator: function(attrs) {
         return "fail";
       }
     });
@@ -545,7 +545,7 @@ $(document).ready(function() {
   test("#861, adding models to a collection which do not pass validation", 1, function() {
     raises(function() {
       var Model = Backbone.Model.extend({
-        validate: function(attrs) {
+        validator: function(attrs) {
           if (attrs.id == 3) return "id can't be 3";
         }
       });
@@ -566,7 +566,7 @@ $(document).ready(function() {
     var col = new Backbone.Collection();
     col.on('test', function() { ok(false); });
     col.model = Backbone.Model.extend({
-      validate: function(attrs){ if (!attrs.valid) return 'invalid'; }
+      validator: function(attrs){ if (!attrs.valid) return 'invalid'; }
     });
     var model = new col.model({id: 1, valid: true});
     raises(function() { col.add([model, {id: 2}]); });

--- a/test/model.js
+++ b/test/model.js
@@ -183,12 +183,12 @@ $(document).ready(function() {
     ok(a.get('foo') == 2, "Foo should NOT have changed, still 2");
     ok(changeCount == 1, "Change count should NOT have incremented.");
 
-    a.validate = function(attrs) {
+    a.validator = function(attrs) {
       equal(attrs.foo, void 0, "don't ignore values when unsetting");
     };
     a.unset('foo');
     equal(a.get('foo'), void 0, "Foo should have changed");
-    delete a.validate;
+    delete a.validator;
     ok(changeCount == 2, "Change count should have incremented for unset.");
 
     a.unset('id');
@@ -332,7 +332,7 @@ $(document).ready(function() {
 
   test("validate after save", 1, function() {
     var lastError, model = new Backbone.Model();
-    model.validate = function(attrs) {
+    model.validator = function(attrs) {
       if (attrs.admin) return "Can't change admin status.";
     };
     model.sync = function(method, model, options) {
@@ -347,7 +347,7 @@ $(document).ready(function() {
 
   test("isValid", 5, function() {
     var model = new Backbone.Model({valid: true});
-    model.validate = function(attrs) {
+    model.validator = function(attrs) {
       if (!attrs.valid) return "invalid";
     };
     equal(model.isValid(), true);
@@ -399,7 +399,7 @@ $(document).ready(function() {
   test("validate", 7, function() {
     var lastError;
     var model = new Backbone.Model();
-    model.validate = function(attrs) {
+    model.validator = function(attrs) {
       if (attrs.admin != this.get('admin')) return "Can't change admin status.";
     };
     model.on('error', function(model, error) {
@@ -420,7 +420,7 @@ $(document).ready(function() {
   test("validate on unset and clear", 6, function() {
     var error;
     var model = new Backbone.Model({name: "One"});
-    model.validate = function(attrs) {
+    model.validator = function(attrs) {
       if (!attrs.name) {
         error = true;
         return "No thanks.";
@@ -434,7 +434,7 @@ $(document).ready(function() {
     equal(model.get('name'), 'Two');
     model.clear();
     equal(model.get('name'), 'Two');
-    delete model.validate;
+    delete model.validator;
     model.clear();
     equal(model.get('name'), undefined);
   });
@@ -442,7 +442,7 @@ $(document).ready(function() {
   test("validate with error callback", 8, function() {
     var lastError, boundError;
     var model = new Backbone.Model();
-    model.validate = function(attrs) {
+    model.validator = function(attrs) {
       if (attrs.admin) return "Can't change admin status.";
     };
     var callback = function(model, error) {
@@ -636,7 +636,7 @@ $(document).ready(function() {
   test("save with wait validates attributes", 1, function() {
     var model = new Backbone.Model();
     model.url = '/test';
-    model.validate = function() { ok(true); };
+    model.validator = function() { ok(true); };
     model.save({x: 1}, {wait: true});
   });
 
@@ -770,7 +770,7 @@ $(document).ready(function() {
 
   test("#1179 - isValid returns true in the absence of validate.", 1, function() {
     var model = new Backbone.Model();
-    model.validate = null;
+    model.validator = null;
     ok(model.isValid());
   });
 
@@ -822,7 +822,7 @@ $(document).ready(function() {
 
   test("#1433 - Save: An invalid model cannot be persisted.", 1, function() {
     var model = new Backbone.Model;
-    model.validate = function(){ return 'invalid'; };
+    model.validator = function(){ return 'invalid'; };
     model.sync = function(){ ok(false); };
     strictEqual(model.save(), false);
   });
@@ -831,7 +831,7 @@ $(document).ready(function() {
     var Model = Backbone.Model.extend({
       url: '/test/',
       sync: function(method, model, options){ options.success(); },
-      validate: function(){ return 'invalid'; }
+      validator: function(){ return 'invalid'; }
     });
     var model = new Model({id: 1});
     model.on('error', function(){ ok(true); });


### PR DESCRIPTION
Renamed the unimplemented method `validate` to `validator` and renamed `_validate` to `validate`. This has a couple of benefits:
- The name "validator" is more in line with what it actually is.
- The name "validator" is more in line with the other methods like `comparator` and the iterators in underscore.js.
- Makes is possible to actually call the validate method and get results.
- Makes is possible to validate data in context of the model without setting it.

I've also updated and run all the tests related to this change. Everything passes.
