### PR TITLE
Don't unnecessarily call _prepareModel in unshift

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -689,7 +689,6 @@
 
     // Add a model to the beginning of the collection.
     unshift: function(model, options) {
-      model = this._prepareModel(model, options);
       this.add(model, _.extend({at: 0}, options));
       return model;
     },


### PR DESCRIPTION
Collection.unshift calls _prepareModel before calling add (which again calls _prepareModel right away).

This pull request removes the unnecessary _prepareModel call in unshift.
