### PR TITLE
Pass `options.attributes` through during save

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -364,6 +364,7 @@
         (attrs = {})[key] = val;
       }
       options = options ? _.clone(options) : {};
+      options.attributes = attrs;
 
       // If we're "wait"-ing to set changed attributes, validate early.
       if (options.wait) {


### PR DESCRIPTION
This is helpful for custom `Backbone.sync` methods. Knowing which attributes are being saved (or defaulting to all) is awesome for doing partial updates on records (or documents).
