### PR TITLE
Improve the Backbone inheritance chain

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,5 +8,5 @@
     "underscore"  : ">=1.3.3"
   },
   "main"          : "backbone.js",
-  "version"       : "0.9.2"
+  "version"       : "0.9.2-inheritance"
 }


### PR DESCRIPTION
The Backbone extends method was implemented last, rather than first, so none of the Backbone classes actually inherited their functionality with it.

Instead, Backbone was using the _.extend method to handle inheritance (which is also encapsulated inside the new Backbone.Class.extend method.

All of the Backbone classes were extending Events, but Events itself was just a POJO.  Adding the extend method to Backbone.Class, and starting the inheritance chain there, and extending it for Events,

Backbone now eats its own dog food.

In addition, Backbone now has a generic Backbone.Class method that can be extended to make other generic classes.  Something I've found myself hacking out in other ways, even though Backbone already had the capability, but wasn't exposing it.

The original Backbone.Events.\* methods should be deprecated in future releases so that developers are encouraged to use the new prototype methods.

All tests pass.
