### PR TITLE
routeStripper now properly escapes routes

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -988,8 +988,8 @@
     }
   };
 
-  // Cached regex for cleaning leading hashes and slashes.
-  var routeStripper = /^[#\/]|\s+$/;
+  // Cached regex for cleaning a leading hash and/or slash or /#/ .
+  var routeStripper = /^#\/?|\/(#\/?)?|\s+$/;
 
   // Cached regex for stripping leading and trailing slashes.
   var rootStripper = /^\/+|\/+$/g;

--- a/test/router.js
+++ b/test/router.js
@@ -292,7 +292,7 @@ $(document).ready(function() {
     strictEqual(fragment, location.pathname.replace(/^\//, ''));
   });
 
-  test("#1206 - Strip leading slash before location.assign.", 1, function() {
+  test("#1206 - Strip leading slash before location.assign.", 5, function() {
     Backbone.history.stop();
     location.replace('http://example.com/root/');
     Backbone.history = _.extend(new Backbone.History, {location: location});
@@ -300,7 +300,32 @@ $(document).ready(function() {
     location.assign = function(pathname) {
       strictEqual(pathname, '/root/fragment');
     };
+
     Backbone.history.navigate('/fragment');
+
+    Backbone.history.stop();
+    location.replace('http://example.com/root/');
+    Backbone.history.start({hashChange: false, root: '/root/'});
+
+    Backbone.history.navigate('#fragment');
+
+    Backbone.history.stop();
+    location.replace('http://example.com/root/');
+    Backbone.history.start({hashChange: false, root: '/root/'});
+
+    Backbone.history.navigate('/#fragment');
+
+    Backbone.history.stop();
+    location.replace('http://example.com/root/');
+    Backbone.history.start({hashChange: false, root: '/root/'});
+
+    Backbone.history.navigate('#/fragment');
+
+    Backbone.history.stop();
+    location.replace('http://example.com/root/');
+    Backbone.history.start({hashChange: false, root: '/root/'});
+
+    Backbone.history.navigate('/#/fragment');
   });
 
   test("#1387 - Root fragment without trailing slash.", 1, function() {


### PR DESCRIPTION
The comment on line 991 of backbone.js was "cleaning leading hashes and slashes" when the regex clearly only took care of a single hash or a single slash.

I asked on irc and knowtheory helped a bit with the intention of the function, but wasn't able to tell me the original intention of the code.

The comment and matching code were objectively incorrect, and I made some assumptions about what the correct behavior should be.

It boils down to "which of the following routes are valid and identical?"

I decided that 
- #route
- /route
- #/route
- /#route
- /#/route

are all identical and that anything else should not be stripped.
