### PR TITLE
Allowing events to be passed in view's options

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1204,7 +1204,7 @@
   var delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
   // List of view options to be merged as properties.
-  var viewOptions = ['model', 'collection', 'el', 'id', 'attributes', 'className', 'tagName'];
+  var viewOptions = ['model', 'collection', 'el', 'id', 'attributes', 'className', 'tagName', 'events'];
 
   // Set up all inheritable **Backbone.View** properties and methods.
   _.extend(View.prototype, Events, {

--- a/test/view.js
+++ b/test/view.js
@@ -331,4 +331,28 @@ $(document).ready(function() {
     ok(view.$el.is('p:has(a)'));
   });
 
+  test("events passed in options", 2, function() {
+    var counter = 0;
+
+    var View = Backbone.View.extend({
+      el: '<p><a id="test"></a></p>',
+      increment: function() {
+        counter++;
+      }
+    });
+    
+    var view = new View({events:{'click #test':'increment'}});
+    var view2 = new View({events:function(){
+      return {'click #test':'increment'};
+    }});
+    
+    view.$('#test').trigger('click');
+    view2.$('#test').trigger('click');
+    equal(counter, 2);
+    
+    view.$('#test').trigger('click');
+    view2.$('#test').trigger('click');
+    equal(counter, 4);
+  });
+
 });


### PR DESCRIPTION
Allows the user to pass a view's `events` object when creating a new view, rather than requiring the events always be pre-defined with `Backbone.View.extend`

Includes a test of the new functionality.
