### PR TITLE
Fix gh-1201 - Simple TravisCI support.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 raw
 *.sw?
 .DS_Store
+node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: node_js
+node_js:
+  - 0.8

--- a/package.json
+++ b/package.json
@@ -7,6 +7,12 @@
   "dependencies"  : {
     "underscore"  : ">=1.3.3"
   },
+  "devDependencies": {
+    "phantomjs": "0.2.2"
+  },
+  "scripts": {
+    "test": "phantomjs test/vendor/runner.js test/index.html"
+  },
   "main"          : "backbone.js",
   "version"       : "0.9.2"
 }

--- a/test/vendor/runner.js
+++ b/test/vendor/runner.js
@@ -1,0 +1,98 @@
+/*
+ * Qt+WebKit powered headless test runner using Phantomjs
+ *
+ * Phantomjs installation: http://code.google.com/p/phantomjs/wiki/BuildInstructions
+ *
+ * Run with:
+ *  phantomjs runner.js [url-of-your-qunit-testsuite]
+ *
+ * E.g.
+ *      phantomjs runner.js http://localhost/qunit/test
+ */
+
+/*jshint latedef:false */
+/*global phantom:true require:true console:true */
+var url = phantom.args[0],
+	page = require('webpage').create();
+
+// Route "console.log()" calls from within the Page context to the main Phantom context (i.e. current "this")
+page.onConsoleMessage = function(msg) {
+	console.log(msg);
+};
+
+page.onInitialized = function() {
+	page.evaluate(addLogging);
+};
+page.open(url, function(status){
+	if (status !== "success") {
+		console.log("Unable to access network: " + status);
+		phantom.exit(1);
+	} else {
+		// page.evaluate(addLogging);
+		var interval = setInterval(function() {
+			if (finished()) {
+				clearInterval(interval);
+				onfinishedTests();
+			}
+		}, 500);
+	}
+});
+
+function finished() {
+	return page.evaluate(function(){
+		return !!window.qunitDone;
+	});
+}
+
+function onfinishedTests() {
+	var output = page.evaluate(function() {
+			return JSON.stringify(window.qunitDone);
+	});
+	phantom.exit(JSON.parse(output).failed > 0 ? 1 : 0);
+}
+
+function addLogging() {
+	window.document.addEventListener( "DOMContentLoaded", function() {
+		var current_test_assertions = [];
+
+		QUnit.testDone(function(result) {
+			var i,
+				name = result.module + ': ' + result.name;
+
+			if (result.failed) {
+				console.log('Assertion Failed: ' + name);
+
+				for (i = 0; i < current_test_assertions.length; i++) {
+					console.log('    ' + current_test_assertions[i]);
+				}
+			}
+
+			current_test_assertions = [];
+		});
+
+		QUnit.log(function(details) {
+			var response;
+
+			if (details.result) {
+				return;
+			}
+
+			response = details.message || '';
+
+			if (typeof details.expected !== 'undefined') {
+				if (response) {
+					response += ', ';
+				}
+
+				response += 'expected: ' + details.expected + ', but was: ' + details.actual;
+			}
+
+			current_test_assertions.push('Failed assertion: ' + response);
+		});
+
+		QUnit.done(function(result){
+			console.log('Took ' + result.runtime +  'ms to run ' + result.total + ' tests. ' + result.passed + ' passed, ' + result.failed + ' failed.');
+			window.qunitDone = result;
+		});
+	}, false );
+}


### PR DESCRIPTION
Used the QUnit [runner](https://github.com/jquery/qunit/blob/master/addons/phantomjs/runner.js) script to run tests via phantomjs.  The phantomjs dependency is not strictly necessary to run on travis but it allows you to run tests locally via `npm install && npm test`, which I think is nice.
