### PR TITLE
Pass options through to toJSON

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1381,7 +1381,7 @@
     // Ensure that we have the appropriate request data.
     if (!options.data && model && (method === 'create' || method === 'update')) {
       params.contentType = 'application/json';
-      params.data = JSON.stringify(model);
+      params.data = JSON.stringify(model.toJSON(options));
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.


### PR DESCRIPTION
The toJSON() function on a model has an options parameter - which is quite useful if you need to override the default implementation with a custom one.

But the sync function isn't passing the options object through, so this commit fixes that.
