### PR TITLE
Create returns false on failed validation

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -798,7 +798,9 @@
         if (options.wait) collection.add(model, options);
         if (success) success(model, resp, options);
       };
-      model.save(null, options);
+      if(model.save(null, options) === false) {
+	return false; //"create" never returns false on failed validation.
+      }
       return model;
     },
 


### PR DESCRIPTION
When calling .create() on a model that fails to pass validation
still returns a model.  Now it returns false correctly
(according to documentation).
