### PR TITLE
Fix for #1407 consistent 'parse' on collection constructor & reset

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -588,10 +588,7 @@
     if (options.comparator !== void 0) this.comparator = options.comparator;
     this._reset();
     this.initialize.apply(this, arguments);
-    if (models) {
-      if (options.parse) models = this.parse(models);
-      this.reset(models, {silent: true, parse: options.parse});
-    }
+    if (models) this.reset(models, _.extend({silent: true}, options));
   };
 
   // Define the Collection's inheritable methods.
@@ -780,6 +777,7 @@
     // you can reset the entire set with a new list of models, without firing
     // any `add` or `remove` events. Fires `reset` when finished.
     reset: function(models, options) {
+      if (options && options.parse) models = this.parse(models);
       for (var i = 0, l = this.models.length; i < l; i++) {
         this._removeReference(this.models[i]);
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -715,4 +715,47 @@ $(document).ready(function() {
     this.ajaxSettings.success([model]);
   });
 
+  test("#1407 parse option on constructor parses collection and models", 2, function() {
+    var model = {
+      namespace : [{id: 1}, {id:2}]
+    };
+    var Collection = Backbone.Collection.extend({
+      model: Backbone.Model.extend({
+        parse: function(model) {
+          model.name = 'test';
+          return model;
+        }
+      }),
+      parse: function(model) {
+        return model.namespace;
+      }
+    });
+    var c = new Collection(model, {parse:true});
+
+    equal(c.length, 2);
+    equal(c.at(0).get('name'), 'test');
+  });
+
+  test("#1407 parse option on reset parses collection and models", 2, function() {
+    var model = {
+      namespace : [{id: 1}, {id:2}]
+    };
+    var Collection = Backbone.Collection.extend({
+      model: Backbone.Model.extend({
+        parse: function(model) {
+          model.name = 'test';
+          return model;
+        }
+      }),
+      parse: function(model) {
+        return model.namespace;
+      }
+    });
+    var c = new Collection();
+        c.reset(model, {parse:true});
+
+    equal(c.length, 2);
+    equal(c.at(0).get('name'), 'test');
+  });
+
 });


### PR DESCRIPTION
Addressing part of the issue brought up in #1407 - this allows `{parse:true}` to be used when creating a new `Backbone.Collection`, or calling `Collection#reset` on a collection, mirroring the way the `{parse:true}` is used in the model. It doesn't call parse on `.add` directly, as this is similar to a `set` in a model, where parse is not used - and parse is already called on `.add` when fetch is used.

Tests included.
