### PR TITLE
Add Collection#update to better use collection events

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -776,6 +776,27 @@
       return _.invoke(this.models, 'get', attr);
     },
 
+    // Update a collection with models, removing, adding, and merging as
+    // necessary.
+    update: function(models, options) {
+      var i, model, existing, removed = this.models.slice();
+      models = models ? _.isArray(models) ? models.slice() : [models] : [];
+      for (i = models.length - 1; i >= 0; i--) {
+        if(!(model = this._prepareModel(models[i], options))) {
+          this.trigger("error", this, models[i], options);
+          models.splice(i, 1);
+          continue;
+        }
+        if ((existing = this._byId[model.id]) ||
+            (existing = this._byCid[model.cid])) {
+          removed.splice(_.indexOf(removed, existing), 1);
+        }
+      }
+      if (models.length) this.add(models, _.extend({merge:true}, options));
+      if (removed.length) this.remove(removed, options);
+      return this;
+    },
+
     // When you have more items than you want to add or remove individually,
     // you can reset the entire set with a new list of models, without firing
     // any `add` or `remove` events. Fires `reset` when finished.
@@ -798,7 +819,8 @@
       var collection = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {
-        collection[options.add ? 'add' : 'reset'](collection.parse(resp, xhr), options);
+        var action = options.add ? 'add' : options.update ? 'update' : 'reset'
+        collection[action](collection.parse(resp, xhr), options);
         if (success) success(collection, resp, options);
       };
       return this.sync('read', this, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -715,4 +715,29 @@ $(document).ready(function() {
     this.ajaxSettings.success([model]);
   });
 
+  test("update", 5, function() {
+    var m1 = new Backbone.Model;
+    var m2 = new Backbone.Model({id: 2});
+    var m3 = new Backbone.Model;
+    var c = new Backbone.Collection([m1, m2]);
+
+    // Test add/change/remove events
+    c.on('add', function(model) {
+      strictEqual(model, m3);
+    });
+    c.on('change', function(model) {
+      strictEqual(model, m2);
+    });
+    c.on('remove', function(model) {
+      strictEqual(model, m1);
+    });
+    c.update([{id: 2, a: 1}, m3]);
+
+    // Test removing models by passing an empty array
+    c.off('remove').on('remove', function(model) {
+      ok(model === m2 || model === m3);
+    });
+    c.update([]);
+  });
+
 });


### PR DESCRIPTION
Here's the use case. I have a collection of users that varies in size and attributes over time. I want to periodically poll the server and receive updates so I can render my views accordingly. With the current `reset`, I can wipe my view clean and re-render pretty easily, but I can't reuse my existing DOM (easily with events).

With `update`, I can poll my server and listen for `add`/`change`/`remove` on the collection. This is much nicer as now I have the power to do specific tasks on these events rather than some bulk task on `reset`.

Regarding `fetch`, `Model#fetch` doesn't set `attributes` to `{}` and then fill them with the response, and `Collection#fetch` shouldn't do that for its models (by that I mean completely emptying the set and refilling). This patch is non-breaking, `update` can be used instead of `reset` by passing `{update: true}`. However, I really think the default action for `Collection#fetch` should be `update`, and a new major/minor version would be the time to introduce it.

In short, I want to know after fetching what was added, changed, and removed in the process and reset just can't offer that.
