### PR TITLE
name the constructor functions

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -181,7 +181,7 @@
 
   // Create a new model, with defined attributes. A client id (`cid`)
   // is automatically generated and assigned for you.
-  var Model = Backbone.Model = function(attributes, options) {
+  var Model = Backbone.Model = function BackboneModel(attributes, options) {
     var defaults;
     var attrs = attributes || {};
     this.cid = _.uniqueId('c');
@@ -582,7 +582,7 @@
   // Provides a standard collection class for our sets of models, ordered
   // or unordered. If a `comparator` is specified, the Collection will maintain
   // its models in sort order, as they're added and removed.
-  var Collection = Backbone.Collection = function(models, options) {
+  var Collection = Backbone.Collection = function BackboneCollection(models, options) {
     options || (options = {});
     if (options.model) this.model = options.model;
     if (options.comparator !== void 0) this.comparator = options.comparator;
@@ -920,7 +920,7 @@
 
   // Routers map faux-URLs to actions, and fire events when routes are
   // matched. Creating a new one sets its `routes` hash, if not set statically.
-  var Router = Backbone.Router = function(options) {
+  var Router = Backbone.Router = function BackboneRouter(options) {
     options || (options = {});
     if (options.routes) this.routes = options.routes;
     this._bindRoutes();
@@ -999,7 +999,7 @@
 
   // Handles cross-browser history management, based on URL fragments. If the
   // browser does not support `onhashchange`, falls back to polling.
-  var History = Backbone.History = function() {
+  var History = Backbone.History = function BackboneHistory() {
     this.handlers = [];
     _.bindAll(this, 'checkUrl');
 
@@ -1214,7 +1214,7 @@
 
   // Creating a Backbone.View creates its initial element outside of the DOM,
   // if an existing element is not provided...
-  var View = Backbone.View = function(options) {
+  var View = Backbone.View = function BackboneView(options) {
     this.cid = _.uniqueId('view');
     this._configure(options || {});
     this._ensureElement();


### PR DESCRIPTION
I've named the constructor functions, so that a tracing library I wrote can inspect the Backbone classes and get the name of the classes by doing <class>.prototype.constructor.name.
