### PR TITLE
Add component.json for Bower support

### DIFF
--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name"          : "backbone",
   "version"       : "0.9.2",
-	"main"          : "backbone.js",
+  "main"          : "backbone.js",
   "dependencies"  : {
     "underscore"  : ">=1.3.3"
   }


### PR DESCRIPTION
Since [Bower](http://twitter.github.com/bower/) v5 does not use `package.json` for dependency management, the bower community needs you to add a `component.json` file to your repo.

See twitter/bower#172

Thanks for merging this !
