### PR TITLE
Proposed fix for #1477

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -780,6 +780,7 @@
     // any `add` or `remove` events. Fires `reset` when finished.
     reset: function(models, options) {
       if (options && options.parse) models = this.parse(models);
+      if (this.validate && !this.validate(models)) return false;
       for (var i = 0, l = this.models.length; i < l; i++) {
         this._removeReference(this.models[i]);
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -769,4 +769,17 @@ $(document).ready(function() {
     equal(c.at(0).get('name'), 'test');
   });
 
+  test("#1477 - custom validate called on collection if present", 1, function() {
+    var Collection = Backbone.Collection.extend({
+      validate: function (models) {
+        if (models.length < 3) return false;
+      }
+    });
+    var collection = new Collection([
+      {id: 1},
+      {id: 2}
+    ]);
+    equal(collection.length, 0);
+  });
+
 });


### PR DESCRIPTION
As pointed out in #1477, the forced `silent:true` in the Collection's `.reset` prevents any model validation calls from being triggered. in the majority of cases it can be safely assumed that any data used to create/reset a collection is already filtered, and the model's validate doesn't have to be called on every model going in.

However - there could be instances where this isn't the case, and removing `{silent:true}` isn't the answer because that would trigger `add` for every model going in. So this pull request adds a check for a `validate` function on the collection - which would serve as the appropriate place for a validation check on the incoming model data to take place (after it is parsed, but before anything else).

Tests included.
