### PR TITLE
Allow options.data to be set to null for no data.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1399,7 +1399,8 @@
     }
 
     // Ensure that we have the appropriate request data.
-    if (!options.data && model && (method === 'create' || method === 'update')) {
+    if (typeof options.data === 'undefined' && model &&
+        (method === 'create' || method === 'update')) {
       params.contentType = 'application/json';
       params.data = JSON.stringify(model.toJSON(options));
     }


### PR DESCRIPTION
When `options.data` is set to `null`, no request payload is sent to the server, even if the method is one of create and udpate.

Currently, there is provision to set `options.data` to override the default payload for create and update methods. But there is no way to tell Backbone not to send any payload. Because of the way `!options.data` is evaluated, even an empty string is considered as _data not set in options_.

**Reason**: There are end points out of my control which are to be run with a POST request but without a request body. Ex.: https://developers.google.com/google-apps/tasks/v1/reference/tasks/clear. That page states that no request body should be sent. But the request is a POST request.

I don't see this breaking any existing use cases, but I may be wrong. If there is a better way to do this or if its possible already, please let me know.

Thank you.
