### PR TITLE
Collection#update to reduce waste

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -85,7 +85,7 @@
     // function. Passing `"all"` will bind the callback to all events fired.
     on: function(events, callback, context) {
       if (_.isObject(events)) {
-        for (key in events) {
+        for (var key in events) {
           this.on(key, events[key], callback);
         }
         return this;
@@ -108,7 +108,7 @@
     // Bind events to only be triggered a single time. After the first time
     // the callback is invoked, it will be removed.
     once: function(events, callback, context) {
-      once = true
+      once = true;
       this.on(events, callback, context);
       once = false;
       return this;
@@ -119,7 +119,7 @@
     // event. If `events` is null, removes all bound callbacks for all events.
     off: function(events, callback, context) {
       if (_.isObject(events)) {
-        for (key in events) {
+        for (var key in events) {
           this.off(key, events[key], callback);
         }
         return this;
@@ -204,6 +204,9 @@
   // Aliases for backwards compatibility.
   Events.bind   = Events.on;
   Events.unbind = Events.off;
+
+  // Supply a global event emitter on Backbone itself.
+  _.extend(Backbone, Events);
 
   // Backbone.Model
   // --------------
@@ -1008,7 +1011,7 @@
   var optionalParam = /\((.*?)\)/g;
   var namedParam    = /:\w+/g;
   var splatParam    = /\*\w+/g;
-  var escapeRegExp  = /[-{}[\]+?.,\\^$|#\s]/g;
+  var escapeRegExp  = /[\-{}\[\]+?.,\\\^$|#\s]/g;
 
   // Set up all inheritable **Backbone.Router** properties and methods.
   _.extend(Router.prototype, Events, {

--- a/test/events.js
+++ b/test/events.js
@@ -298,4 +298,8 @@ $(document).ready(function() {
     equal(obj.counter, 3);
   });
 
+  test("Backbone object inherits Events", function() {
+    ok(Backbone.on === Backbone.Events.on);
+  });
+
 });

--- a/test/router.js
+++ b/test/router.js
@@ -107,7 +107,7 @@ $(document).ready(function() {
     },
 
     optionalItem: function(arg){
-      this.arg = arg !== undefined ? arg : null;
+      this.arg = arg !== void 0 ? arg : null;
     },
 
     splat : function(args) {
@@ -139,7 +139,7 @@ $(document).ready(function() {
     location.replace('http://example.com#search/news');
     Backbone.history.checkUrl();
     equal(router.query, 'news');
-    equal(router.page, undefined);
+    equal(router.page, void 0);
     equal(lastRoute, 'search');
     equal(lastArgs[0], 'news');
   });
@@ -279,7 +279,7 @@ $(document).ready(function() {
     location.replace('http://example.com#search/fat');
     Backbone.history.checkUrl();
     equal(router.query, 'fat');
-    equal(router.page, undefined);
+    equal(router.page, void 0);
     equal(lastRoute, 'search');
   });
 


### PR DESCRIPTION
I created a PR a few days ago about this and (A) the PR became out of sync with my repo and (B) I feel I explained my rationale poorly which lead to its abrupt close. So I'm sorry for the poor re-issue etiquette, but I really think this should be at least discussed.

`reset` definitely has it's place as a quick way to completely wipe a collection and start over with new models. Often times though, I'd like to update a collection without obliterating my current models but rather firing off helpful `add`/`change`/`remove` events. This allows me to poll the server with `fetch` and effectively listen for these events without fear of having to recreate any models (wasteful). Here is an example:

``` js
var UsersView = Backbone.View.extend({
  delegateEvents: function () {
    Backbone.View.prototype.delegateEvents.apply(this, arguments);
    this.collection.on('add', this.addUser, this);
    this.pollInterval = setInterval(_.bind(this.poll, this), 10000);
  },

  undelegateEvents: function () {
    clearInterval(this.pollInterval);
    Backbone.View.prototype.delegateEvents.apply(this, arguments);
  },

  addUser: function (user) {
    var userView = new UserView({model: user});
    this.$el.append((userView).el);
  },

  poll: function () {
    // Ideally `update` is the default action, but that would be a
    // breaking change so the options object is used for now.
    this.collection.fetch({update: true});
  }
});

var UserView = Backbone.View.extend({
  initialize: function() {
    // Can be fine tuned thanks to `change:attr`, but in general...
    this.model.on('change', this.render, this);
    this.model.on('remove', this.remove, this);
  }
});

var users = new Backbone.Collection();
users.url = '/users';
var usersView = new UsersView({collection: users});
$('body').append(usersView.el);
usersView.poll();
```

This is not a complete example, but you can see what I'm getting at. The ability to rig a view (and subviews) this way makes for a clean, clear intent as to what should happen when an `add`/`change`/`remove` happens. The only alternative right now is a not-so-pretty `reset` dance that just doesn't use Backbone.Events to their potential.

Again, I apologize for the duplicate but I would really appreciate some input especially before the release is cut.
