### PR TITLE
Refactor events tests

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -302,4 +302,12 @@ $(document).ready(function() {
     ok(Backbone.on === Backbone.Events.on);
   });
 
+  asyncTest("once with asynchronous events", 1, function() {
+    var func = _.debounce(function() { ok(true); start(); }, 50);
+    var obj = _.extend({}, Backbone.Events).once('async', func);
+
+    obj.trigger('async');
+    obj.trigger('async');
+  });
+
 });


### PR DESCRIPTION
I had concerns that the `once` global flag would cause trouble with async events, so I wrote the `once with asynchronous events` test (which passed). While at it I ended up refactoring some methods for readability, but in the end I did go for the whole thing.
