### PR TITLE
Implement once with minimal change to other Events methods.

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -227,7 +227,7 @@ $(document).ready(function() {
   test("once", 2, function() {
     // Same as the previous test, but we use once rather than having to explicitly unbind
     var obj = { counterA: 0, counterB: 0 };
-    _.extend(obj,Backbone.Events);
+    _.extend(obj, Backbone.Events);
     var incrA = function(){ obj.counterA += 1; obj.trigger('event'); };
     var incrB = function(){ obj.counterB += 1 };
     obj.once('event', incrA);
@@ -308,6 +308,23 @@ $(document).ready(function() {
 
     obj.trigger('async');
     obj.trigger('async');
+  });
+
+  test("Off during iteration with once.", 2, function() {
+    var obj = _.extend({}, Backbone.Events);
+    var f = function(){ this.off('event', f); };
+    obj.on('event', f);
+    obj.once('event', function(){});
+    obj.on('event', function(){ ok(true); });
+
+    obj.trigger('event');
+    obj.trigger('event');
+  });
+
+  test("once with multiple events.", 2, function() {
+    var obj = _.extend({}, Backbone.Events);
+    obj.once('x y', function() { ok(true); });
+    obj.trigger('x y');
   });
 
 });


### PR DESCRIPTION
This version is a bit larger, but I think the cost in bytes is more than offset by minimizing change to the other methods.  `on` and `trigger` are unchanged, and `off` provides one small concession for removing handlers with a callback reference.
