### PR TITLE
Add failing test case for different `idAttribute` fields

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -824,4 +824,13 @@ $(document).ready(function() {
     strictEqual(c.length, 0);
   });
 
+  test("`update` with non-normal id", function() {
+    var Collection = Backbone.Collection.extend({
+      model: Backbone.Model.extend({idAttribute: '_id'})
+    });
+    var collection = new Collection({_id: 1});
+    collection.update([{_id: 1, a: 1}], {add: false});
+    equal(collection.first().get('a'), 1);
+  });
+
 });


### PR DESCRIPTION
The failing test had to be in `get` or here, so here it is. [This is how I handled it](https://github.com/documentcloud/backbone/blob/d6d264bebd17d5d9f578c8c2df9060ae8a705c4e/backbone.js#L826-L830) in my `update`.
