### PR TITLE
Fix #1894, Collection#push should not sort.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -730,7 +730,7 @@
     // Add a model to the end of the collection.
     push: function(model, options) {
       model = this._prepareModel(model, options);
-      this.add(model, options);
+      this.add(model, _.extend({at: this.length}, options));
       return model;
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -828,4 +828,14 @@ $(document).ready(function() {
     strictEqual(c.length, 0);
   });
 
+  test("#1894 - Push should not trigger a sort", 0, function() {
+    var Collection = Backbone.Collection.extend({
+      comparator: 'id',
+      sort: function() {
+        ok(false);
+      }
+    });
+    new Collection().push({id: 1});
+  });
+
 });


### PR DESCRIPTION
Since `unshift` does not sort the collection, it only seems logical that `push` would follow suit.
