### PR TITLE
Add clone() now clones with constructor options

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -507,8 +507,9 @@
     },
 
     // Create a new model with identical attributes to this one.
-    clone: function() {
-      return new this.constructor(this.attributes);
+    clone: function(options) {
+      options = _.extend({collection: this.collection}, options || {});
+      return new this.constructor(this.attributes, options);
     },
 
     // A model is new if it has never been saved to the server, and lacks an id.
@@ -917,8 +918,10 @@
     },
 
     // Create a new collection with an identical list of models as this one.
-    clone: function() {
-      return new this.constructor(this.models);
+    clone: function(options) {
+      options = _.extend({comparator: this.comparator, model: this.model},
+                         options || {});
+      return new this.constructor(this.models, options);
     },
 
     // Proxy to _'s chain. Can't be proxied the same way the rest of the

--- a/test/collection.js
+++ b/test/collection.js
@@ -857,4 +857,19 @@ $(document).ready(function() {
     new Collection().add({id: 1}, {sort: false});
   });
 
+  test("clone", 6, function() {
+    var Model = Backbone.Model.extend({});
+    var col = new Backbone.Collection([{id: 1}], {comparator: 'id', model: Model});
+    var otherCol = col.clone();
+    deepEqual(otherCol.models, col.models);
+    equal(otherCol.model, Model);
+    equal(otherCol.comparator, 'id');
+
+    var ModelB = Backbone.Model.extend({});
+    otherCol = col.clone({comparator: 'name', model: ModelB});
+    deepEqual(otherCol.models, col.models);
+    equal(otherCol.model, ModelB);
+    equal(otherCol.comparator, 'name');
+  });
+
 });

--- a/test/model.js
+++ b/test/model.js
@@ -99,7 +99,7 @@ $(document).ready(function() {
     equal(model.url(), '/nested/1/collection/2');
   });
 
-  test("clone", 10, function() {
+  test("clone", 14, function() {
     var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
     var b = a.clone();
     equal(a.get('foo'), 1);
@@ -117,6 +117,17 @@ $(document).ready(function() {
     bar.set(foo.clone(), {unset: true});
     equal(foo.get('p'), 1);
     equal(bar.get('p'), undefined);
+
+    var parse = function (resp) {return resp;};
+    var baz = new Backbone.Model({p: 3}, {collection: collection});
+    var c = baz.clone();
+    equal(c.get('p'), 3);
+    equal(c.collection, collection);
+
+    var col = new klass();
+    var d = baz.clone({collection: col});
+    equal(d.get('p'), 3);
+    equal(d.collection, col);
   });
 
   test("isNew", 6, function() {


### PR DESCRIPTION
Cloning a collection now doesn't clone the `model` and `comparator` attributes now. I think it's reasonable for users calling `clone()` to expect the returned new collection has the same attributes as the one it was cloned from.

Cloning a model now also clones the reference to the `collection` for the same reason.

If for some reason `comparator` and `collection` shouldn't be cloned, `model` should be cloned regardless I think. It would be surprising that the newly created collection can't vivify models if you add a bunch of object hashes.
