### PR TITLE
Add View#listening

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1306,6 +1306,7 @@
     this._ensureElement();
     this.initialize.apply(this, arguments);
     this.delegateEvents();
+    this._setupListening();
   };
 
   // Cached regex to split keys for `delegate`.
@@ -1406,6 +1407,24 @@
     // Backbone views attached to the same DOM element.
     undelegateEvents: function() {
       this.$el.unbind('.delegateEvents' + this.cid);
+    },
+
+    // Setup listeners from the declaratively specified objects by `listening`.
+    _setupListening: function() {
+      var listening;
+      if (!(listening = _.result(this, 'listening'))) return;
+      this.stopListening();
+      for (var prop in listening) {
+        var object = this[prop];
+        if (!object) throw new Error('Property "' + prop + '" does not exist');
+        var events = listening[prop];
+        for (var event in events) {
+          var method = events[event];
+          if (!_.isFunction(method)) method = this[events[event]];
+          if (!method) throw new Error('Method "' + events[event] + '" does not exist');
+          this.listenTo(object, event, method);
+        }
+      }
     },
 
     // Performs the initial configuration of a View with a set of options.

--- a/test/view.js
+++ b/test/view.js
@@ -363,4 +363,91 @@ $(document).ready(function() {
     equal(counter, 4);
   });
 
+  test("listening declaratively listens to objects", 2, function() {
+    var View = Backbone.View.extend({
+      listening: {
+        model: {'change': 'modelChange'},
+        eventable: {'custom': 'eventableCustom'}
+      },
+
+      initialize: function() {
+        this.eventable = _.extend({}, Backbone.Events);
+      },
+
+      modelChange: function() {
+        ok(true);
+      },
+
+      eventableCustom: function() {
+        ok(true);
+      }
+    });
+
+    var view = new View({model: new Backbone.Model});
+    view.model.trigger('change');
+    view.eventable.trigger('custom');
+  });
+
+  test("listening can be a function", 1, function() {
+    var View = Backbone.View.extend({
+      listening: function() {
+        return {model: {'change': 'modelChange'}};
+      },
+
+      modelChange: function() {
+        ok(true);
+      }
+    });
+
+    var view = new View({model: new Backbone.Model});
+    view.model.trigger('change');
+  });
+
+  test("listening binds the objects to the proper context", 1, function() {
+    var View = Backbone.View.extend({
+      listening: {
+        model: {'change': 'modelChange'}
+      },
+
+      initialize: function() {
+        this.context = this;
+      },
+
+      modelChange: function() {
+        ok(this.context && this.context === this);
+      }
+    });
+
+    var view = new View({model: new Backbone.Model});
+    view.model.trigger('change');
+  });
+
+  test("listening complains on undefined functions", 1, function() {
+    var View = Backbone.View.extend({
+      listening: {
+        model: {'change': 'modelChange'}
+      }
+    });
+
+    try {
+      var view = new View({model: new Backbone.Model});
+    } catch (e) {
+      equal('' + e, 'Error: Method "modelChange" does not exist');
+    }
+  });
+
+  test("listening complains on undefined properties", 1, function() {
+    var View = Backbone.View.extend({
+      listening: {
+        model: {'change': 'modelChange'}
+      }
+    });
+
+    try {
+      var view = new View();
+    } catch (e) {
+      equal('' + e, 'Error: Property "model" does not exist');
+    }
+  });
+
 });


### PR DESCRIPTION
Now that there are `Event#listenTo` and `Event#stopListening` I think that this is a great addition next to `View#events`. You can use `View#listening` to declaratively specify object listeners.

``` javascript
var View = Backbone.View.extend({
  listening: {
    model: {'change': 'modelChange'},
    eventable: {'custom': 'eventableCustom'}
  },

  initialize: function() {
    this.eventable = _.extend({}, Backbone.Events);
  },

  modelChange: function() { /* Do whatever... */ },
  eventableCustom: function() { /* Do whatever... */ }
}
```

And it will listen to both the passed `model` and the custom `eventable` object and with `stopListening` being called in `View#remove` the implementation is quite simple, as we don't have to unbind the events explicitly. I think that binding events is the most common thing to do in `initialize`, so this may strip-down them a bit.

Just throwing the idea out there, if you think that now something like this can live in master.
