### PR TITLE
Simplify/robustify `update`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -824,23 +824,30 @@
     // Smartly update a collection with a change set of models, adding,
     // removing, and merging as necessary.
     update: function(models, options) {
-      var model, i, l, id, cid, existing;
+      var model, i, l, existing;
       var add = [], remove = [], modelMap = {};
       var idAttr = this.model.prototype.idAttribute;
       options = _.extend({add: true, merge: true, remove: true}, options);
 
+      // Allow a single model (or no argument) to be passed.
+      if (!_.isArray(models)) models = models ? [models] : [];
+
+      // Proxy to `add` for this case, no need to iterate...
+      if (options.add && !options.remove) return this.add(models, options);
+
       // Determine which models to add and merge, and which to remove.
       for (i = 0, l = models.length; i < l; i++) {
         model = models[i];
-        id = model.id || model.cid || model[idAttr];
-        modelMap[id] = true;
-        existing = this.get(id);
-        if (options.add || options.merge && existing) add.push(model);
+        existing = this.get(model.id || model.cid || model[idAttr]);
+        if (options.remove && existing) modelMap[existing.cid] = true;
+        if ((options.add && !existing) || (options.merge && existing)) {
+          add.push(model);
+        }
       }
       if (options.remove) {
         for (i = 0, l = this.models.length; i < l; i++) {
           model = this.models[i];
-          if (!modelMap[model.id] && !modelMap[model.cid]) remove.push(model);
+          if (!modelMap[model.cid]) remove.push(model);
         }
       }
 


### PR DESCRIPTION
Some reasoning:
- `add`/`remove`/`reset` can all take non-array arguments (or even single model arguments) without breaking, so I think that's a fair assumption for `update`.
- proxy to `add` in the case mentioned saves a duplicate iteration of `models`.
- `modelsMap` only needs to be assigned values when `options.remove` is true.
- `modelsMap` only needs to store the `cid`, as we are guaranteed in the proceeding loop to have models with `cid`s
- Since we're already iterating `models`, we can intelligently only add models to the `add` array based on the options, saving loop iterations in the `add` function.

The difference is SLOC is +2 (ignoring empty lines/comments), for what seems to me like some nice benefits. For your consideration...
