### PR TITLE
Fixing issue in patch not sending data

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1446,7 +1446,7 @@
     }
 
     // Ensure that we have the appropriate request data.
-    if (options.data == null && model && (method === 'create' || method === 'update')) {
+    if (options.data == null && model && (method === 'create' || method === 'update' || method === 'patch')) {
       params.contentType = 'application/json';
       params.data = JSON.stringify(options.attrs || model.toJSON(options));
     }
@@ -1459,7 +1459,7 @@
 
     // For older servers, emulate HTTP by mimicking the HTTP method with `_method`
     // And an `X-HTTP-Method-Override` header.
-    if (options.emulateHTTP && (type === 'PUT' || type === 'DELETE')) {
+    if (options.emulateHTTP && (type === 'PUT' || type === 'DELETE' || type === 'PATCH')) {
       params.type = 'POST';
       if (options.emulateJSON) params.data._method = type;
       var beforeSend = options.beforeSend;

--- a/test/model.js
+++ b/test/model.js
@@ -400,6 +400,7 @@ $(document).ready(function() {
     equal(_.size(this.syncArgs.options.attrs), 2);
     equal(this.syncArgs.options.attrs.d, 4);
     equal(this.syncArgs.options.attrs.a, undefined);
+    equal(this.ajaxSettings.data, "{\"b\":2,\"d\":4}");
   });
 
   test("save in positional style", 1, function() {


### PR DESCRIPTION
Fixes the issue found by @philfreo [here](https://github.com/documentcloud/backbone/issues/618#issuecomment-11313449), the check for: 

``` javascript
(method === 'create' || method === 'update')
```

is preventing any patch data from being sent to the ajax call. Test included.
