### PR TITLE
Add Router.previous to retrieve/trigger previous route

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1002,6 +1002,12 @@
       return this;
     },
 
+    // Retrieve the previous fragment and save it into the history.
+    previous: function(options) {
+      Backbone.history.navigate(Backbone.history.previousFragment, options);
+      return this;
+    },
+
     // Bind all defined routes to `Backbone.history`. We have to reverse the
     // order of the routes here to support behavior where the most general
     // routes can be defined at the bottom of the route map.
@@ -1128,6 +1134,7 @@
 
       // Determine if we need to change the base url, for a pushState link
       // opened by a non-pushState browser.
+      this.previousFragment = '';
       this.fragment = fragment;
       var loc = this.location;
       var atRoot = loc.pathname.replace(/[^\/]$/, '$&/') === this.root;
@@ -1202,6 +1209,7 @@
       if (!options || options === true) options = {trigger: options};
       fragment = this.getFragment(fragment || '');
       if (this.fragment === fragment) return;
+      this.previousFragment = this.fragment;
       this.fragment = fragment;
       var url = this.root + fragment;
 

--- a/test/router.js
+++ b/test/router.js
@@ -198,6 +198,14 @@ $(document).ready(function() {
     Backbone.history.navigate('end_here', {replace: true});
   });
 
+  test("previous route via navigate", 2, function() {
+    router.navigate('search/denver/p30', {trigger: true});
+    router.navigate('search/manhattan/p20', {trigger: true});
+    router.previous({trigger: true});
+    equal(router.query, 'denver');
+    equal(router.page, '30');
+  });
+
   test("routes (splats)", 1, function() {
     location.replace('http://example.com#splat/long-list/of/splatted_99args/end');
     Backbone.history.checkUrl();


### PR DESCRIPTION
In many Backbone apps there is the need to retrieve and/or navigate to the previous route in Backbone's history (e.g., clicking a back button, closing a modal etc.). Instead of having to manually track the previous route, I suggest adding a `Router.previous` method to save the previous route back into the history and trigger if desired. Similar to `Router.navigate`, the `previous` method will proxy `Backbone.history.navigate`, passing the previous route fragment by default and accepting the same `options` object.
