### PR TITLE
Bump Underscore to 1.4.3 in package.json and index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -569,7 +569,7 @@
 
     <p>
       Backbone's only hard dependency is either
-      <a href="http://underscorejs.org/">Underscore.js</a> <small>( > 1.3.3)</small> or
+      <a href="http://underscorejs.org/">Underscore.js</a> <small>( > 1.4.3)</small> or
       <a href="http://lodash.com">Lo-Dash</a>.
       For RESTful persistence, history support via <a href="#Router">Backbone.Router</a>
       and DOM manipulation with <a href="#View">Backbone.View</a>, include

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords"      : ["model", "view", "controller", "router", "server", "client", "browser"],
   "author"        : "Jeremy Ashkenas <jeremy@documentcloud.org>",
   "dependencies"  : {
-    "underscore"  : ">=1.3.3"
+    "underscore"  : ">=1.4.3"
   },
   "devDependencies": {
     "phantomjs": "0.2.2"


### PR DESCRIPTION
Since [a5299f8](https://github.com/documentcloud/backbone/commit/a5299f8058b71b9f770d82b8e120709df2822289) Underscore `1.4.*` is required, just declare that in `package.json` and `index.html`, so it doesn't slip by later on.
