### PR TITLE
Fix #1915 - `parse` ordering in `update`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -789,10 +789,10 @@
       var add = [], remove = [], modelMap = {};
       var idAttr = this.model.prototype.idAttribute;
       options = _.extend({add: true, merge: true, remove: true}, options);
+      if (options.parse) models = this.parse(models);
 
       // Allow a single model (or no argument) to be passed.
       if (!_.isArray(models)) models = models ? [models] : [];
-      if (options.parse) models = this.parse(models);
 
       // Proxy to `add` for this case, no need to iterate...
       if (options.add && !options.remove) return this.add(models, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -899,4 +899,15 @@ $(document).ready(function() {
     new Collection().add({id: 1}, {sort: false});
   });
 
+  test("#1915 - `parse` data in the right order in `update`", function() {
+    var collection = new (Backbone.Collection.extend({
+      parse: function (data) {
+        strictEqual(data.status, 'ok');
+        return data.data;
+      }
+    }));
+    var res = {status: 'ok', data:[{id: 1}]}
+    collection.update(res, {parse: true});
+  });
+
 });


### PR DESCRIPTION
We can't wrap `models` in an array before parsing it.
