### PR TITLE
using 'listenTo' instead of 'on' in todos example app

### DIFF
--- a/examples/todos/todos.js
+++ b/examples/todos/todos.js
@@ -100,8 +100,8 @@ $(function(){
     // a one-to-one correspondence between a **Todo** and a **TodoView** in this
     // app, we set a direct reference on the model for convenience.
     initialize: function() {
-      this.model.on('change', this.render, this);
-      this.model.on('destroy', this.remove, this);
+      this.listenTo(this.model, 'change', this.render);
+      this.listenTo(this.model, 'destroy', this.remove);
     },
 
     // Re-render the titles of the todo item.
@@ -174,9 +174,9 @@ $(function(){
       this.input = this.$("#new-todo");
       this.allCheckbox = this.$("#toggle-all")[0];
 
-      Todos.on('add', this.addOne, this);
-      Todos.on('reset', this.addAll, this);
-      Todos.on('all', this.render, this);
+      this.listenTo(Todos, 'add', this.addOne);
+      this.listenTo(Todos, 'reset', this.addAll);
+      this.listenTo(Todos, 'all', this.render);
 
       this.footer = this.$('footer');
       this.main = $('#main');


### PR DESCRIPTION
Since v0.9.9 is released, views in todos app should use `listenTo` to observe other Backbone objects.
