### PR TITLE
Fix #1943 - use _.isEqual to check model change

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -548,7 +548,7 @@
         // Check if the attribute has been modified since the last change,
         // and update `this.changed` accordingly. If we're inside of a `change`
         // call, also add a trigger to the list.
-        if (current[key] !== val) {
+        if (!_.isEqual(current[key], val)) {
           this.changed[key] = val;
           if (!loud) continue;
           triggers.push(key, val);

--- a/test/model.js
+++ b/test/model.js
@@ -314,7 +314,6 @@ $(document).ready(function() {
     equal(model.hasChanged('name'), true);
     model.change();
     equal(model.get('name'), 'Rob');
-
   });
 
   test("changedAttributes", 3, function() {
@@ -946,6 +945,12 @@ $(document).ready(function() {
     model.set({a:'a'}, {silent:true});
     model.change();
     deepEqual(changes, ['a']);
+  });
+
+  test("#1943 change calculations should use _.isEqual", function() {
+    var model = new Backbone.Model({a: {key: 'value'}});
+    model.set('a', {key:'value'}, {silent:true});
+    equal(model.changedAttributes(), false);
   });
 
 });


### PR DESCRIPTION
Looks like this was an oversight when I reworked the set/change internals - includes a test of this functionality.
