### PR TITLE
Document `route` event of Backbone.history

### DIFF
--- a/index.html
+++ b/index.html
@@ -821,6 +821,7 @@ view.stopListening(model);
       <li><b>"request"</b> (model, xhr, options) &mdash; when a model (or collection) has started a request to the server. </li>
       <li><b>"sync"</b> (model, resp, options) &mdash; when a model has been successfully synced with the server. </li>
       <li><b>"error"</b> (model, collection) &mdash; when a model's validation fails, or a <a href="#Model-save">save</a> call fails on the server. </li>
+      <li><b>"route"</b> (history) &mdash; when any route has been matched. </li>
       <li><b>"route:[name]"</b> (router) &mdash; when one of a router's routes has matched. </li>
       <li><b>"all"</b> &mdash; this special event fires for <i>any</i> triggered event, passing the event name as the first argument. </li>
     </ul>


### PR DESCRIPTION
`Router.route()` triggers both a specific route event on the router ("route:matchedRoute"), and a generic route on history ("route"),  document this in the events catalog.

[backbone.js#L996](https://github.com/documentcloud/backbone/blob/master/backbone.js#L996)
