### PR TITLE
default constructor should return parent value

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1499,7 +1499,7 @@
     if (protoProps && _.has(protoProps, 'constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ parent.apply(this, arguments); };
+      child = function(){ return parent.apply(this, arguments); };
     }
 
     // Add static properties to the constructor function, if supplied.


### PR DESCRIPTION
I came across this issue with a class that caches instances when
they are firste created. Subsequent calls to the constructor will
return the cached instance if available. This relies on a feature
of JavaScript described here:

http://bclary.com/2004/11/07/#a-13.2.2

Note Step 7 in the reference document. By not returning the value
from the default constructor, subclasses of Backbone classes that
rely on this feature will break.
