### PR TITLE
When running in Node, Backbone is currently unable to load jQuery, Zepto, Ender

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -41,7 +41,6 @@
   if (!_ && (typeof require !== 'undefined')) _ = require('underscore');
 
   // For Backbone's purposes, jQuery, Zepto, or Ender owns the `$` variable.
-  console.log('backbone', Backbone);
   Backbone.$ = root.jQuery || root.Zepto || root.ender;
   if (!Backbone.$ && (typeof require !== 'undefined')) {
       ['jquery', 'zepto', 'ender'].some(function(engine) {


### PR DESCRIPTION
When running in Node, Backbone is currently unable to load any appropriate selector engine because of the way node manages global state. Global state is not provided by the `this` keyword, but rather through the `global` keyword. The proposed fix attempts to use the old root.jQuery method
first for the browser environment and then falls back to a similar loading strategy used for loading underscore in a Node environment. Appreciate any feedback on my approach for fixing this.
