### PR TITLE
Improve getting of models with non-default ids

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -735,7 +735,8 @@
     get: function(obj) {
       if (obj == null) return void 0;
       var idAttr = this.model.prototype.idAttribute;
-      return this._byId[obj[idAttr] != null ? obj[idAttr] : obj] || this._byCid[obj.cid || obj];
+      return this._byId[obj[idAttr] != null ? obj[idAttr] : obj.id != null ? obj.id : obj]
+             || this._byCid[obj.cid || obj];
     },
 
     // Get the model at the given index.

--- a/test/collection.js
+++ b/test/collection.js
@@ -62,14 +62,15 @@ $(document).ready(function() {
     strictEqual(collection.last().get('a'), 4);
   });
 
-  test("get", 4, function() {
+  test("get", 5, function() {
     equal(col.get(0), d);
     equal(col.get(2), b);
     equal(col.get({id: 1}), c);
+    equal(col.get(c.clone()), c);
     equal(col.get(col.first().cid), col.first());
   });
 
-  test("get with non-default ids", 3, function() {
+  test("get with non-default ids", 4, function() {
     var col = new Backbone.Collection();
     var MongoModel = Backbone.Model.extend({
       idAttribute: '_id'
@@ -84,6 +85,7 @@ $(document).ready(function() {
     col2 = new Col2();
     col2.push(model);
     equal(col2.get({_id: 101}), model);
+    equal(col2.get(model.clone()), model);
   });
 
   test("update index when id changes", 3, function() {


### PR DESCRIPTION
Just as you can get a model from a collection using default ids by passing `.get()` an object i.e. `col.get({id: 1})`, I've added the ability to do the same when using non-default ids i.e. `col.get({_id: 1})` (If the collection prototype has the correct `model` set).

What do you think?
