### PR TITLE
Fix #1961- pass options to initial set call

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -241,7 +241,7 @@
     if (options && options.collection) this.collection = options.collection;
     if (options && options.parse) attrs = this.parse(attrs, options);
     if (defaults = _.result(this, 'defaults')) _.defaults(attrs, defaults);
-    this.set(attrs, {silent: true});
+    this.set(attrs, _.extend({}, options, {silent: true}));
     this._currentAttributes = _.clone(this.attributes);
     this._previousAttributes = _.clone(this.attributes);
     this.initialize.apply(this, arguments);

--- a/test/model.js
+++ b/test/model.js
@@ -949,4 +949,17 @@ $(document).ready(function() {
     equal(model.changedAttributes(), false);
   });
 
+  test("#1961 - pass along options.error to the creating set if present", function () {
+    var Model = Backbone.Model.extend({
+      validate: function (model) {
+        return "Error";
+      }
+    });
+    var model = new Model({a:1}, {
+      error: function (model, message) {
+        equal(message, "Error");
+      }
+    });
+  });
+
 });


### PR DESCRIPTION
So an error function, when specified, can handle failed model validations. Test included.
