### PR TITLE
fixing #1964 - change event should be fired if a change occurs

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -479,13 +479,16 @@
       // Generate the changes to be triggered on the model.
       var triggers = this._computeChanges(true);
 
-      this._pending = !!triggers.length;
+      var pending = this._pending = !!triggers.length;
 
       for (var i = triggers.length - 2; i >= 0; i -= 2) {
         this.trigger('change:' + triggers[i], this, triggers[i + 1], options);
       }
 
       if (changing) return this;
+
+      // Ensure the original `change` event is fired regardless of interim changes
+      if (pending) this._pending = true;
 
       // Trigger a `change` while there have been changes.
       while (this._pending) {

--- a/test/model.js
+++ b/test/model.js
@@ -949,4 +949,15 @@ $(document).ready(function() {
     equal(model.changedAttributes(), false);
   });
 
+  test("#1964 - final `change` event is always fired, regardless of interim changes", 1, function () {
+    var model = new Backbone.Model();
+    model.on('change:property', function() {
+      model.set('property', 'bar');
+    });
+    model.on('change', function() {
+      ok(true);
+    });
+    model.set('property', 'foo');
+  });
+
 });


### PR DESCRIPTION
Fixes #1964 - there should be a "change" event triggered (if there were changes to the model) regardless of the changes made to the model during the nested change listeners.
