### PR TITLE
string comparator starts with '-' means descending order

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -763,7 +763,17 @@
         throw new Error('Cannot sort a set without a comparator');
       }
 
-      if (_.isString(this.comparator) || this.comparator.length === 1) {
+      if (_.isString(this.comparator)) {
+        var comparator;
+        var firstchar = this.comparator.charAt(0);
+        if (firstchar === '-' || firstchar === '\\') {
+          comparator = this.comparator.substr(1);
+        } else {
+          comparator = this.comparator;
+        }
+        this.models = this.sortBy(comparator, this);
+        if (firstchar === '-') this.models.reverse();
+      } else if (this.comparator.length === 1) {
         this.models = this.sortBy(this.comparator, this);
       } else {
         this.models.sort(_.bind(this.comparator, this));

--- a/test/collection.js
+++ b/test/collection.js
@@ -47,6 +47,24 @@ $(document).ready(function() {
     deepEqual(collection.pluck('id'), [1, 2, 3]);
   });
 
+  test("String comparator starts with '-'.", 1, function() {
+    var collection = new Backbone.Collection([
+      {id: 3},
+      {id: 1},
+      {id: 2}
+    ], {comparator: '-id'});
+    deepEqual(collection.pluck('id'), [3, 2, 1]);
+  });
+
+  test("String comparator for '-attr' in asc order needs backslash", 1, function() {
+    var collection = new Backbone.Collection([
+      {'-id': 3},
+      {'-id': 1},
+      {'-id': 2}
+    ], {comparator: '\\-id'});
+    deepEqual(collection.pluck('-id'), [1, 2, 3]);
+  });
+
   test("new and parse", 3, function() {
     var Collection = Backbone.Collection.extend({
       parse : function(data) {


### PR DESCRIPTION
Developers have to use `sortBy` -style or `sort` -style comparator function to sort collection in descending order. This PR allows comparator string start with '-' to easily achieve the purpose.

``` js
var collection = new Backbone.Collection([
  {id: 3},
  {id: 1},
  {id: 2}
], {comparator: '-id'});
collection.pluck('id'); // => [3, 2, 1]
```

Note that backward compatibility is broken a bit: attributes start with '-' need backslash escaping, but I think such names are really rare.

``` js
var collection = new Backbone.Collection([
  {'-id': 3},
  {'-id': 1},
  {'-id': 2}
], {comparator: '\\-id'});
collection.pluck('-id'); // => [1, 2, 3]
```
