### PR TITLE
Fix typo in .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,5 @@ test/
 Rakefile
 docs/
 raw/
-examples/examples/
+examples/
 index.html


### PR DESCRIPTION
Pulled down `/examples` on my last `npm update`, this was the culprit.
