### PR TITLE
added a note about Backbone.wrapError to the 0.9.9 changelog

### DIFF
--- a/index.html
+++ b/index.html
@@ -3875,6 +3875,11 @@ ActiveRecord::Base.include_root_in_json = false
         The natural complement to the <tt>"sync"</tt> event.
       </li>
       <li>
+        Removed <tt>Backbone.wrapError</tt> helper method, in favor of wrapping
+        optional error callbacks with a fallback error event within
+        <tt>Backbone.sync</tt>.
+      </li>
+      <li>
         Router URLs now support optional parts via parentheses, without having
         to use a regex.
       </li>


### PR DESCRIPTION
Looks like the removal of Backbone.wrapError didn't make it into the changelog. Closes #1966
