### PR TITLE
Add validate flag to trigger validation of models, default to true on save

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -241,7 +241,7 @@
     if (options && options.collection) this.collection = options.collection;
     if (options && options.parse) attrs = this.parse(attrs, options);
     if (defaults = _.result(this, 'defaults')) _.defaults(attrs, defaults);
-    this.set(attrs, {silent: true});
+    this.set(attrs, _.extend({silent: true}, options));
     this._currentAttributes = _.clone(this.attributes);
     this._previousAttributes = _.clone(this.attributes);
     this.initialize.apply(this, arguments);
@@ -373,7 +373,7 @@
       } else if (key != null) {
         (attrs = {})[key] = val;
       }
-      options = options ? _.clone(options) : {};
+      options = _.extend({validate: true}, options);
 
       // If we're "wait"-ing to set changed attributes, validate early.
       if (options.wait) {
@@ -568,11 +568,17 @@
       return _.clone(this._previousAttributes);
     },
 
+    // Check if the model is currently in a valid state. It's only possible to
+    // get into an *invalid* state if you're using silent changes.
+    isValid: function(options) {
+      return !this.validate || !this.validate(this.attributes, options);
+    },
+
     // Run validation against the next complete set of model attributes,
     // returning `true` if all is well. Otherwise, fire a general
     // `"error"` event and call the error callback, if specified.
     _validate: function(attrs, options) {
-      if (!this.validate) return true;
+      if (!options || !options.validate || !this.validate) return true;
       attrs = _.extend({}, this.attributes, attrs);
       var error = this.validate(attrs, options);
       if (!error) return true;

--- a/test/collection.js
+++ b/test/collection.js
@@ -417,7 +417,7 @@ $(document).ready(function() {
     equal(model.collection, collection);
   });
 
-  test("create enforces validation", 1, function() {
+  test("create with validate:true enforces validation", 1, function() {
     var ValidatingModel = Backbone.Model.extend({
       validate: function(attrs) {
         return "fail";
@@ -427,7 +427,7 @@ $(document).ready(function() {
       model: ValidatingModel
     });
     var col = new ValidatingCollection();
-    equal(col.create({"foo":"bar"}), false);
+    equal(col.create({"foo":"bar"}, {validate:true}), false);
   });
 
   test("a failing create runs the error callback", 1, function() {
@@ -567,7 +567,7 @@ $(document).ready(function() {
     equal(col.length, 0);
   });
 
-  test("#861, adding models to a collection which do not pass validation", function() {
+  test("#861, adding models to a collection which do not pass validation, with validate:true", function() {
       var Model = Backbone.Model.extend({
         validate: function(attrs) {
           if (attrs.id == 3) return "id can't be 3";
@@ -581,18 +581,18 @@ $(document).ready(function() {
       var collection = new Collection;
       collection.on("error", function() { ok(true); });
 
-      collection.add([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}]);
+      collection.add([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}], {validate:true});
       deepEqual(collection.pluck('id'), [1, 2, 4, 5, 6]);
   });
 
-  test("Invalid models are discarded.", 5, function() {
+  test("Invalid models are discarded with validate:true.", 5, function() {
     var collection = new Backbone.Collection;
     collection.on('test', function() { ok(true); });
     collection.model = Backbone.Model.extend({
       validate: function(attrs){ if (!attrs.valid) return 'invalid'; }
     });
     var model = new collection.model({id: 1, valid: true});
-    collection.add([model, {id: 2}]);
+    collection.add([model, {id: 2}], {validate:true});
     model.trigger('test');
     ok(collection.get(model.cid));
     ok(collection.get(1));


### PR DESCRIPTION
From the discussion in #1961 - there are several valid use cases of wanting to create invalid models, including creating a partial model to eventually fetch, and updating attributes individually, as with a form.

Making the `validate` functionality mirror that of an active record object might be the be best approach. With this, models can be modified with invalid attributes, but by default can not be persisted when they're invalid.

This pull request adds the `isValid` method/tests back, as well as adds an extra flag, `{validate:true}` or `{validate:false}`. The flag will default to `true` on save, and `false` everywhere else (`new Model`, `set`, `unset`, `clear`). 

`silent:true` is still used strictly for event notification, rather than being mixed in with validation.

The `options` are also passed along from the Model's constructor to `set`, so an error function can be specified to catch instances where `{validate:true}` is set as an option on the constructor.
