### PR TITLE
Correcting upgrade guide for collection.fetch({add: true})

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,7 +646,7 @@
         server, where models are added or removed, and updated attributes are merged
         as appropriate. If you were previously using <br />
         <tt>collection.fetch({add: true})</tt>,
-        use <tt>{update: true}</tt> now instead.
+        use <tt>{update: true, remove: false}</tt> now instead.
       </li>
       <li>
         Backbone events now support <a href="#Events-once"</a>once</a>.


### PR DESCRIPTION
The upgrade guide says:

> If you were previously using `collection.fetch({add: true})`, use `{update: true}` now instead.

But having just upgraded myself, I think this isn't really the same thing. The `add` option in `Collection#fetch` used to just add (never remove) newly fetched models to the collection. Use case: think infinity scroll. To get that behavior with `Collection#update` you need to pass the non-default `{ remove: false }` option.
