### PR TITLE
added test to show listenTo called on the same object

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -110,6 +110,12 @@ $(document).ready(function() {
     equal(true, calledWithoutContext);
   });
 
+  test("listenTo yourself", 1, function(){
+    var e = _.extend({}, Backbone.Events);
+    e.listenTo(e, "foo", function(){ ok(true); });
+    e.trigger("foo");
+  });
+
   test("trigger all for each event", 3, function() {
     var a, b, obj = { counter: 0 };
     _.extend(obj, Backbone.Events);


### PR DESCRIPTION
This doesn't fix any issues or add any features. It's just a unit test that shows a Backbone.Events object can `listenTo` itself and receive the event.

I'm tracking down an issue in Marionette and thought this might be the problem. This test shows that it works just fine, but I thought I would submit this to the project to prevent regression in the future.
