### PR TITLE
Added undelegateEvents to View::remove and created View::empty

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1313,6 +1313,15 @@
       this.stopListening();
       return this;
     },
+    
+    // Empties the view but leaves the container by removing any
+    // applicable Backbone.Events listeners and undelegating events.
+    empty: function() {
+      this.$el.empty();
+      this.undelegateEvents();
+      this.stopListening();
+      return this;
+    },
 
     // For small amounts of DOM Elements, where a full-blown template isn't
     // needed, use **make** to manufacture elements, one at a time.


### PR DESCRIPTION
Hi,
it would be useful to have View::remove to undelegateEvents also.

Also I created View::empty. It does the same as View::remove, but uses jQuery's empty(), useful for views that share the same container.
