### PR TITLE
Only sort when a model is changed or added

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -638,7 +638,8 @@
       options || (options = {});
       var i, args, length, model, attrs, existing, needsSort;
       var at = options.at;
-      var sort = options.sort == null ? true : options.sort;
+      var sort = (options.sort == null ? true : options.sort) &&
+                  this.comparator && at == null;
       models = _.isArray(models) ? models.slice() : [models];
 
       // Turn bare objects into model references, and prevent invalid models
@@ -657,7 +658,7 @@
         if (existing = this.get(model)) {
           if (options.merge) {
             existing.set(attrs != model ? attrs : model.attributes, options);
-            needsSort = sort;
+            if (sort && !needsSort && existing.hasChanged()) needsSort = true;
           }
           models.splice(i, 1);
           continue;
@@ -678,7 +679,6 @@
       splice.apply(this.models, args);
 
       // Silently sort the collection if appropriate.
-      needsSort = needsSort && this.comparator && at == null;
       if (needsSort) this.sort({silent: true});
 
       if (options.silent) return this;

--- a/test/collection.js
+++ b/test/collection.js
@@ -959,8 +959,9 @@ $(document).ready(function() {
       comparator: 'id'
     }))([{id: 1}, {id: 2}, {id: 3}]);
     collection.on('sort', function () { ok(true); });
-    collection.add({id: 4}); // trigger
-    collection.add({id: 1}, {merge: true}); // trigger
+    collection.add({id: 4}); // trigger, new model
+    collection.add({id: 1, a: 1}, {merge: true}); // trigger, changed model
+    collection.add({id: 1, a: 1}, {merge: true}); // don't trigger
     collection.add({id: 1}); // don't trigger
     collection.add({id: 5}, {silent: true}); // don't trigger
   });


### PR DESCRIPTION
This will keep useless sorts at bay. Polling is a perfect example. Sometimes you get the same data back two requests in a row and there is no sense in sorting so don't bother.
