### PR TITLE
Optimize `add`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -636,18 +636,17 @@
     // firing the `add` event for every new model.
     add: function(models, options) {
       options || (options = {});
-      var i, args, length, model, attrs, existing, needsSort;
+      var i, l, args, length, model, attrs, existing, needsSort, add = [];
       var at = options.at;
       var sort = options.sort == null ? true : options.sort;
       models = _.isArray(models) ? models.slice() : [models];
 
       // Turn bare objects into model references, and prevent invalid models
       // from being added.
-      for (i = models.length - 1; i >= 0; i--) {
+      for (i = 0, l = models.length; i < l; i++) {
         attrs = models[i];
         if(!(model = this._prepareModel(attrs, options))) {
           this.trigger('invalid', this, attrs, options);
-          models.splice(i, 1);
           continue;
         }
         models[i] = model;
@@ -659,9 +658,11 @@
             existing.set(attrs != model ? attrs : model.attributes, options);
             needsSort = sort;
           }
-          models.splice(i, 1);
           continue;
         }
+
+        // This is a new model, push it to the `add` list.
+        add.push(model);
 
         // Listen to added models' events, and index models for lookup by
         // `id` and by `cid`.
@@ -671,11 +672,15 @@
       }
 
       // See if sorting is needed, update `length` and splice in new models.
-      if (models.length) needsSort = sort;
-      this.length += models.length;
-      args = [at != null ? at : this.models.length, 0];
-      push.apply(args, models);
-      splice.apply(this.models, args);
+      if (add.length) {
+        needsSort = sort;
+        this.length += add.length;
+        if (at != null) {
+          splice.apply(this.models, [at, 0].concat(add));
+        } else {
+          push.apply(this.models, add);
+        }
+      }
 
       // Silently sort the collection if appropriate.
       needsSort = needsSort && this.comparator && at == null;
@@ -684,8 +689,8 @@
       if (options.silent) return this;
 
       // Trigger `add` events.
-      while (model = models.shift()) {
-        model.trigger('add', model, this, options);
+      for (i = 0, l = add.length; i < l; i++) {
+        (model = add[i]).trigger('add', model, this, options);
       }
 
       // Trigger `sort` if the collection was sorted.


### PR DESCRIPTION
As we learned from refactoring events, `push` is faster than `splice`. Also see [this jdalton perf](http://jsperf.com/splice-vs-push/2). Here is a comparison between the patch and master: http://jsperf.com/bb-add-perf

The difference is small due to all of the other overhead in `add`, but I would say significant for a function that can potentially handle very large arrays.
