### PR TITLE
Ensure that, on a collection, fetch calls update if only {add: true} option is passed, instead of calling reset.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -859,7 +859,7 @@
       var collection = this;
       var success = options.success;
       options.success = function(resp, status, xhr) {
-        var method = options.update ? 'update' : 'reset';
+        var method = (options.update || options.add) ? 'update' : 'reset';
         collection[method](resp, options);
         if (success) success(collection, resp, options);
       };

--- a/test/collection.js
+++ b/test/collection.js
@@ -407,6 +407,19 @@ $(document).ready(function() {
     equal(counter, 1);
   });
 
+  test("ensure fetch calls 'update' if only {add: true} option is passed", 1, function() {
+    var collection = new Backbone.Collection;
+    var counter = 0;
+    collection.update = function(models) {
+      counter++;
+      return this;
+    };
+    collection.url = '/test';
+    collection.fetch({add: true});
+    this.syncArgs.options.success([]);
+    equal(counter, 1);
+  });
+
   test("create", 4, function() {
     var collection = new Backbone.Collection;
     collection.url = '/test';


### PR DESCRIPTION
Ensure that, on a collection, `fetch` calls `update` if only `{add: true}` option is passed, instead of calling reset.
Calling `reset` in this case looks incorrect.
