### PR TITLE
Adding test for change event only firing if setting an object with a different value

### DIFF
--- a/test/model.js
+++ b/test/model.js
@@ -272,6 +272,21 @@ $(document).ready(function() {
     equal(model.get('name'), '');
   });
 
+  test("setting an object", 1, function() {
+    var model = new Backbone.Model({
+      custom: { foo: 1 }
+    });
+    model.on('change', function() {
+      ok(1);
+    });
+    model.set({
+      custom: { foo: 1 } // no change should be fired
+    });
+    model.set({
+      custom: { foo: 2 } // change event should be fired
+    });
+  });
+
   test("clear", 3, function() {
     var changed;
     var model = new Backbone.Model({id: 1, name : "Model"});


### PR DESCRIPTION
In 0.9.2. this test passes
In 0.9.9 this test fails.
In master this test passes, since `_.isEqual` is used again.

I certainly prefer that this test passes (`master`'s behavior), but I wanted to add a formal test so the behavior doesn't get reverted in the future (again).
