### PR TITLE
Use typeof in `sort`, http://jsperf.com/isstring-vs-typeof-string/2

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -736,16 +736,17 @@
     // normal circumstances, as the set will maintain sort order as each item
     // is added.
     sort: function(options) {
-      if (!this.comparator) {
+      var comparator = this.comparator;
+      if (!comparator) {
         throw new Error('Cannot sort a set without a comparator');
       }
       options || (options = {});
 
       // Run sort based on type of `comparator`.
-      if (_.isString(this.comparator) || this.comparator.length === 1) {
-        this.models = this.sortBy(this.comparator, this);
+      if (typeof comparator === 'string' || comparator.length === 1) {
+        this.models = this.sortBy(comparator, this);
       } else {
-        this.models.sort(_.bind(this.comparator, this));
+        this.models.sort(_.bind(comparator, this));
       }
 
       if (!options.silent) this.trigger('sort', this, options);


### PR DESCRIPTION
With this patch...

``` js
var attr = 'name';
comparator: new String(attr) // broke, 'object'
comparator: String(attr) // works
comparator: attr // works
comparator: attr + '' // works
comparator: 'name' // works
```

But you can see the speed difference for typeof vs _.isString. Another case of how much weird crap should be supported?
