### PR TITLE
Fetch with update: true behaves like fetch with add: true in 0.9.2

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -758,7 +758,7 @@
     // Smartly update a collection with a change set of models, adding,
     // removing, and merging as necessary.
     update: function(models, options) {
-      options = _.extend({add: true, merge: true, remove: true}, options);
+      options = _.extend({add: true, merge: true, remove: false}, options);
       if (options.parse) models = this.parse(models, options);
       var model, i, l, existing;
       var add = [], remove = [], modelMap = {};
@@ -808,7 +808,7 @@
     },
 
     // Fetch the default set of models for this collection, resetting the
-    // collection when they arrive. If `add: true` is passed, appends the
+    // collection when they arrive. If `update: true` is passed, appends the
     // models to the collection instead of resetting.
     fetch: function(options) {
       options = options ? _.clone(options) : {};

--- a/test/collection.js
+++ b/test/collection.js
@@ -841,32 +841,35 @@ $(document).ready(function() {
     strictEqual(c.length, 2);
     strictEqual(m2.get('a'), 0);
 
-    // default options add/remove/merge as appropriate
+    // default options adds new models, keeps old models and merges
     c.update([{id: 2, a: 1}, m3]);
-    strictEqual(c.length, 2);
+    equal(c.contains(m1), true);
+    equal(c.contains(m2), true);
+    equal(c.contains(m3), true);
+    strictEqual(c.length, 3);
     strictEqual(m2.get('a'), 1);
 
     // Test removing models not passing an argument
     c.off('remove').on('remove', function(model) {
       ok(model === m2 || model === m3);
     });
-    c.update([]);
-    strictEqual(c.length, 0);
+    c.update([m1], {remove: true});
+    strictEqual(c.length, 1);
   });
 
-  test("update with only cids", 3, function() {
+  test("update with only cids does not insert duplicates", 3, function() {
     var m1 = new Backbone.Model;
     var m2 = new Backbone.Model;
     var c = new Backbone.Collection;
     c.update([m1, m2]);
     equal(c.length, 2);
-    c.update([m1]);
+    c.update([m1], {remove: true});
     equal(c.length, 1);
     c.update([m1, m1, m1, m2, m2], {remove: false});
     equal(c.length, 2);
   });
 
-  test("update with only idAttribute", 3, function() {
+  test("update with only idAttribute does not insert duplicates", 3, function() {
     var m1 = { _id: 1 };
     var m2 = { _id: 2 };
     var col = Backbone.Collection.extend({
@@ -877,7 +880,7 @@ $(document).ready(function() {
     var c = new col;
     c.update([m1, m2]);
     equal(c.length, 2);
-    c.update([m1]);
+    c.update([m1], {remove: true});
     equal(c.length, 1);
     c.update([m1, m1, m1, m2, m2], {remove: false});
     equal(c.length, 2);


### PR DESCRIPTION
In 0.9.2., fetch with `add: true` would add in new models but not blow away old models. According to the 0.9.9 release notes, `update: true` is the equivalent option in 0.9.9. 
    If you were previously using collection.fetch({add: true}), use {update: true} now instead.

However, in the 0.9.9 release, `update: true` actually blows away old models. This is surprising behavior since the release notes state that it's the 0.9.9 equivalent of `add: true`. This commit sets the default options to update to not remove old models.

Fixes documentcloud/backbone#2008
