### PR TITLE
Fix #1305 - Decode escaped unicode characters in `location.hash`.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1053,6 +1053,8 @@
     // in Firefox where location.hash will always be decoded.
     getHash: function(window) {
       var match = (window || this).location.href.match(/#(.*)$/);
+      // #1305 - Some browsers escape unicode characters in `location.hash`.
+      if (match) try { return decodeURI(match[1]); } catch(e) {}
       return match ? match[1] : '';
     },
 

--- a/test/router.js
+++ b/test/router.js
@@ -516,4 +516,16 @@ $(document).ready(function() {
     strictEqual(router.z, '123');
   });
 
+  test("#1305 - Decode escaped unicode characters.", 1, function() {
+    location.replace('http://example.com#中/文');
+    Backbone.history.checkUrl();
+    strictEqual(Backbone.history.fragment, '中/文');
+  });
+
+  test("#1305 - Malformed URI", 1, function() {
+    location.replace('http://example.com#%E6');
+    Backbone.history.checkUrl();
+    strictEqual(Backbone.history.fragment, '%E6');
+  });
+
 });


### PR DESCRIPTION
By using `decodeURI` (as opposed to `decodeURIComponent`), we can ensure that unicode sequences are decoded while leaving special characters escaped (e.g. `/`).
