### PR TITLE
Restoring simple change method

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -249,9 +249,6 @@
   // Attach all inheritable methods to the Model prototype.
   _.extend(Model.prototype, Events, {
 
-    // A hash of attributes whose current and previous value differ.
-    changed: null,
-
     // The default name for the JSON `id` attribute is `"id"`. MongoDB and
     // CouchDB users may want to set this to `"_id"`.
     idAttribute: 'id',
@@ -526,6 +523,14 @@
     // A model is new if it has never been saved to the server, and lacks an id.
     isNew: function() {
       return this.id == null;
+    },
+
+    // Call this method to manually fire a `change` event for this model.
+    // Calling this will cause all objects observing the model to update.
+    change: function(options) {
+      this.trigger('change', this, options || {});
+      this._previousAttributes = _.clone(this.attributes);
+      this.changed = {};
     },
 
     // Check if the model is currently in a valid state.

--- a/test/model.js
+++ b/test/model.js
@@ -338,6 +338,31 @@ $(document).ready(function() {
     equal(model.get('name'), 'Rob');
   });
 
+  test("change and hasChanged", 5, function () {
+    var model = new Backbone.Model({name : "Tim", age : 10});
+        model.on('change', function () { ok(true); });
+      equal(model.hasChanged(), false);
+      model.set({name: 'Rob'}, {silent: true});
+      equal(model.hasChanged(), true);
+      model.change();
+      equal(model.hasChanged(), false);
+      model.set({name: 'Rob'});
+      equal(model.hasChanged(), false);
+  });
+
+  test("change with options", function() {
+    var value;
+    var model = new Backbone.Model({name: 'Rob'});
+    model.bind('change', function(model, options) {
+      value = options.prefix + model.get('name');
+    });
+    model.set({name: 'Bob'}, {silent: true});
+    model.change({prefix: 'Mr. '});
+    equal(value, 'Mr. Bob');
+    model.set({name: 'Sue'}, {prefix: 'Ms. '});
+    equal(value, 'Ms. Sue');
+  });
+
   test("changedAttributes", 3, function() {
     var model = new Backbone.Model({a: 'a', b: 'b'});
     deepEqual(model.changedAttributes(), false);


### PR DESCRIPTION
With @jashkenas's simplification of "silent" changes - the model's `change` function got dropped. Since silent changes are still permitted, I think it is important to keep a stripped down `change` function - firing a change on the model and resetting the model's `_previousAttributes`. This functionality has been around in some form since 0.1.0 and is pretty simple when the logic of firing the delayed attributes is dropped.
