### PR TITLE
Removing context from listenTo/stoplistening

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -190,27 +190,25 @@
 
     // An inversion-of-control version of `on`. Tell *this* object to listen to
     // an event in another object ... keeping track of what it's listening to.
-    listenTo: function(object, events, callback, context) {
-      context = context || this;
+    listenTo: function(object, events, callback) {
       var listeners = this._listeners || (this._listeners = {});
       var id = object._listenerId || (object._listenerId = _.uniqueId('l'));
       listeners[id] = object;
-      object.on(events, callback || context, context);
+      object.on(events, callback || this, this);
       return this;
     },
 
     // Tell this object to stop listening to either specific events ... or
     // to every object it's currently listening to.
-    stopListening: function(object, events, callback, context) {
-      context = context || this;
+    stopListening: function(object, events, callback) {
       var listeners = this._listeners;
       if (!listeners) return;
       if (object) {
-        object.off(events, callback, context);
+        object.off(events, callback, this);
         if (!events && !callback) delete listeners[object._listenerId];
       } else {
         for (var id in listeners) {
-          listeners[id].off(null, null, context);
+          listeners[id].off(null, null, this);
         }
         this._listeners = {};
       }

--- a/index.html
+++ b/index.html
@@ -773,10 +773,10 @@ object.off();
     </p>
 
     <p id="Events-listenTo">
-      <b class="header">listenTo</b><code>object.listenTo(other, event, callback, [context])</code>
+      <b class="header">listenTo</b><code>object.listenTo(other, event, callback)</code>
       <br />
       Tell an <b>object</b> to listen to a particular event on an <b>other</b> object.
-      The advantage of using this form, instead of <tt>other.on(event, callback, [context])</tt>,
+      The advantage of using this form, instead of <tt>other.on(event, callback)</tt>,
       is that <b>listenTo</b> allows the <b>object</b> to keep track of the events,
       and they can be removed all at once later on.
     </p>
@@ -786,7 +786,7 @@ view.listenTo(model, 'change', view.render);
 </pre>
 
     <p id="Events-stopListening">
-      <b class="header">stopListening</b><code>object.stopListening([other], [event], [callback], [context])</code>
+      <b class="header">stopListening</b><code>object.stopListening([other], [event], [callback])</code>
       <br />
       Tell an <b>object</b> to stop listening to events. Either call
       <b>stopListening</b> with no arguments to have the <b>object</b> remove

--- a/test/events.js
+++ b/test/events.js
@@ -86,30 +86,6 @@ $(document).ready(function() {
     b.trigger('change');
   });
 
-  test("listenTo with context", 1, function() {
-    var a = _.extend({}, Backbone.Events);
-    var ctx = {};
-    a.listenTo(a, 'foo', function(){ equal(this, ctx); }, ctx);
-    a.trigger('foo');
-  });
-
-  test("stopListening with context", 2, function() {
-    var a = _.extend({}, Backbone.Events);
-    var ctx = {};
-    var calledWithContext = false;
-    var calledWithoutContext = false;
-
-    a.listenTo(a, 'foo', function(){ calledWithContext = true; }, ctx);
-    a.listenTo(a, 'foo', function(){ calledWithoutContext = true; });
-
-    a.stopListening(a, 'foo', null, ctx);
-
-    a.trigger('foo');
-
-    equal(false, calledWithContext);
-    equal(true, calledWithoutContext);
-  });
-
   test("trigger all for each event", 3, function() {
     var a, b, obj = { counter: 0 };
     _.extend(obj, Backbone.Events);


### PR DESCRIPTION
Per discussion in #2015 - a custom mediator object to manage the contexts provided to on/off would be better suited than the complications added by the fourth argument to `listenTo` and `stopListening`.
