### PR TITLE
Changed the model's set function so that the 'nested' variable isn't req...

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -291,7 +291,7 @@
     // Set a hash of model attributes on the object, firing `"change"` unless
     // you choose to silence it.
     set: function(key, val, options) {
-      var attr, attrs, unset, changes, silent, nested, changing, prev, current;
+      var attr, attrs, unset, changes, silent, changing, prev, current;
       if (key == null) return this;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
@@ -308,7 +308,6 @@
       unset           = options.unset;
       silent          = options.silent;
       changes         = [];
-      nested          = false;
       changing        = this._changing;
       this._changing  = true;
 
@@ -329,7 +328,6 @@
         val = attrs[attr];
         if (!_.isEqual(current[attr], val)) changes.push(attr);
         if (!_.isEqual(prev[attr], val)) {
-          nested = true;
           this.changed[attr] = val;
         } else {
           delete this.changed[attr];
@@ -337,7 +335,7 @@
         unset ? delete current[attr] : current[attr] = val;
       }
 
-      this._pending = !!changes.length;
+      if (changes.length) this._pending = true;
 
       // Trigger all relevant attribute changes.
       if (!silent) {
@@ -348,7 +346,6 @@
 
       if (changing) return this;
       if (!silent) {
-        if (!this._pending && nested) this.trigger('change', this, options);
         while (this._pending) {
           this._pending = false;
           this.trigger('change', this, options);


### PR DESCRIPTION
...uired

There used to be a line that read: `this._pending = !!changes.length;`
This caused `this._pending`  to sometimes be set to `false` when model.set is called from within a change event. It would, for instance, happen during this test:

``` javascript
 test("final `change` event is fired when interim changes set an attribute without changing it's value", 1, function () {
    var model = new Backbone.Model({foo: 1, bar: 2});
    model.on('change:foo', function() {
      model.set({bar: 2});
      console.log('property changeevnt');
    });
    model.on('change', function() {
      ok(true);
    });
    model.set({foo: 10});
  });
```

During `model.set({bar: 2});`, `this._pending` gets set to `false` and therefore no `change` event would get triggered (without the use of `nested`).  `nested` was used to trigger this event like so:

``` javascript
if (!this._pending && nested) this.trigger('change', this, options);
```

This commit changes the method so that `nested` is no longer required.

Note: the test is't in the test sweet, and all the current tests pass. Merry Christmas.

Signed-off-by: Adriaan Labuschagne adriaanlabuschagne@gmail.com
