### PR TITLE
Fix for #2017 - Check for object on save set

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -461,7 +461,7 @@
         model.attributes = attributes;
         var serverAttrs = model.parse(resp, options);
         if (options.wait) serverAttrs = _.extend(attrs || {}, serverAttrs);
-        if (!model.set(serverAttrs, options)) return false;
+        if (typeof serverAttrs === 'object' && !model.set(serverAttrs, options)) return false;
         if (success) success(model, resp, options);
       };
 

--- a/test/model.js
+++ b/test/model.js
@@ -423,6 +423,18 @@ $(document).ready(function() {
     equal(model.get('title'), 'Twelfth Night');
   });
 
+  test("save with non-object success response", 1, function () {
+    var model = new Backbone.Model();
+    model.sync = function(method, model, options) {
+      options.success(model, '', options);
+    };
+    model.save({testing:'empty'}, {
+      success: function (model) {
+        deepEqual(model.attributes, {testing:'empty'});
+      }
+    });
+  });
+
   test("fetch", 2, function() {
     doc.fetch();
     equal(this.syncArgs.method, 'read');


### PR DESCRIPTION
The set in the success handler shouldn't be tried if `serverAttrs` isn't an object - Brought up in #2017 when an empty string is returned as a success.

``` js
if (!model.set(serverAttrs, options)) return false;
// becomes
// if (!model.set('', options)) return false;
```
