### PR TITLE
updated View#make to use Backbone.$ exclusively

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1281,10 +1281,10 @@
     //     var el = this.make('li', {'class': 'row'}, this.model.escape('title'));
     //
     make: function(tagName, attributes, content) {
-      var el = document.createElement(tagName);
-      if (attributes) Backbone.$(el).attr(attributes);
-      if (content != null) Backbone.$(el).html(content);
-      return el;
+      var $el = Backbone.$("<" + tagName + "/>");
+      if (attributes) $el.attr(attributes);
+      if (content != null) $el.html(content);
+      return $el[0];
     },
 
     // Change the view's element (`this.el` property), including event


### PR DESCRIPTION
This is a pull request to match the question here: 

https://github.com/documentcloud/backbone/issues/2025#issuecomment-11687148

The goal of this request is to remove as much dependency on the `document` object as possible.  This allows for using Backbone's View object seamlessly in non-browser environments.  It's the last remaining method.

This should also increase performance, by not duplicating the wrapping of the base element. 

All tests pass.
