### PR TITLE
View#make returns $el for direct use by View#setElement.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1278,13 +1278,13 @@
     // For small amounts of DOM Elements, where a full-blown template isn't
     // needed, use **make** to manufacture elements, one at a time.
     //
-    //     var el = this.make('li', {'class': 'row'}, this.model.escape('title'));
+    //     var $el = this.make('li', {'class': 'row'}, this.model.escape('title'));
     //
     make: function(tagName, attributes, content) {
       var $el = Backbone.$('<' + tagName + '>');
       if (attributes) $el.attr(attributes);
       if (content != null) $el.html(content);
-      return $el[0];
+      return $el;
     },
 
     // Change the view's element (`this.el` property), including event

--- a/index.html
+++ b/index.html
@@ -2562,7 +2562,7 @@ var Bookmark = Backbone.View.extend({
       <br />
       Convenience function for creating a DOM element of the given type (<b>tagName</b>),
       with optional attributes and HTML content. Used internally to create the
-      initial <tt>view.el</tt>.
+      initial <tt>view.$el</tt>.
     </p>
 
 <pre class="runnable">

--- a/test/view.js
+++ b/test/view.js
@@ -30,19 +30,19 @@ $(document).ready(function() {
   });
 
   test("make", 3, function() {
-    var div = view.make('div', {id: 'test-div'}, "one two three");
+    var $div = view.make('div', {id: 'test-div'}, "one two three");
 
-    equal(div.tagName.toLowerCase(), 'div');
-    equal(div.id, 'test-div');
-    equal($(div).text(), 'one two three');
+    equal($div[0].tagName.toLowerCase(), 'div');
+    equal($div[0].id, 'test-div');
+    equal($div.text(), 'one two three');
   });
 
   test("make can take falsy values for content", 2, function() {
-    var div = view.make('div', {id: 'test-div'}, 0);
-    equal($(div).text(), '0');
+    var $div = view.make('div', {id: 'test-div'}, 0);
+    equal($div.text(), '0');
 
-    div = view.make('div', {id: 'test-div'}, '');
-    equal($(div).text(), '');
+    $div = view.make('div', {id: 'test-div'}, '');
+    equal($div.text(), '');
   });
 
   test("initialize", 1, function() {


### PR DESCRIPTION
In this way, `View#setElement` can just reuse the instance of `Backbone.$`.  This is a breaking change, but a rather small one since, to my knowledge, `View#make` is not heavily relied upon.
