### PR TITLE
Forgot to import _.drop?

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -903,7 +903,7 @@
     'inject', 'reduceRight', 'foldr', 'find', 'detect', 'filter', 'select',
     'reject', 'every', 'all', 'some', 'any', 'include', 'contains', 'invoke',
     'max', 'min', 'sortedIndex', 'toArray', 'size', 'first', 'head', 'take',
-    'initial', 'rest', 'tail', 'last', 'without', 'indexOf', 'shuffle',
+    'initial', 'rest', 'tail', 'drop', 'last', 'without', 'indexOf', 'shuffle',
     'lastIndexOf', 'isEmpty'];
 
   // Mix in each Underscore method as a proxy to `Collection#models`.


### PR DESCRIPTION
Collection instance doesn't have drop method, nevertheless it has rest and tail methods.
`_.drop` is an alias of `_.rest` and `_.tail`.
