### PR TITLE
Increment this._pending for each change. Possibly fixes issue #2034 (if it is an issue)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -243,6 +243,7 @@
     }
     this.set(attrs, options);
     this.changed = {};
+    this._pending = 0;
     this.initialize.apply(this, arguments);
   };
 
@@ -335,7 +336,7 @@
         unset ? delete current[attr] : current[attr] = val;
       }
 
-      if (changes.length) this._pending = true;
+      if (changes.length && !silent) this._pending++;
 
       // Trigger all relevant attribute changes.
       if (!silent) {
@@ -347,11 +348,11 @@
       if (changing) return this;
       if (!silent) {
         while (this._pending) {
-          this._pending = false;
+          this._pending--;
           this.trigger('change', this, options);
         }
       }
-      this._pending = false;
+      this._pending = 0;
       this._changing = false;
       return this;
     },

--- a/test/model.js
+++ b/test/model.js
@@ -786,7 +786,7 @@ $(document).ready(function() {
     model.set({x: true});
   });
 
-  test("nested `'change'` with silent", 3, function() {
+  test("nested `'change'` with silent", 2, function() {
     var count = 0;
     var model = new Backbone.Model();
     model.on('change:y', function() { ok(false); });
@@ -797,9 +797,6 @@ $(document).ready(function() {
           model.set({y: true}, {silent: true});
           break;
         case 1:
-          deepEqual(this.changedAttributes(), {x: true, y: true});
-          break;
-        case 2:
           deepEqual(this.changedAttributes(), {z: true});
           break;
         default:
@@ -810,7 +807,7 @@ $(document).ready(function() {
     model.set({z: true});
   });
 
-  test("nested `'change:attr'` with silent", 0, function() {
+  test("nested `'change:attr'` with silent. Silent does not fire it's own event", 0, function() {
     var model = new Backbone.Model();
     model.on('change:y', function(){ ok(false); });
     model.on('change', function() {
@@ -1001,7 +998,7 @@ $(document).ready(function() {
     equal(model.changedAttributes(), false);
   });
 
-  test("#1964 - final `change` event is always fired, regardless of interim changes", 1, function () {
+  test("#1964 - final `change` event is always fired, regardless of interim changes", 2, function () {
     var model = new Backbone.Model();
     model.on('change:property', function() {
       model.set('property', 'bar');


### PR DESCRIPTION
All events model.set calls that cause a change to be added to the changes array are now added up
in the this._pending variable. This allows the original model.set that started a chain of sets (through
triggering events) to fire one 'change' event for each set that caused a change to be added to the 'changes' array.
This fixes issue #2034
