### PR TITLE
unset multiple model attributes at once

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -356,10 +356,21 @@
       return this;
     },
 
-    // Remove an attribute from the model, firing `"change"` unless you choose
-    // to silence it. `unset` is a noop if the attribute doesn't exist.
+    // Remove one or more attributes from the model, firing `"change"` unless you choose
+    // to silence it. `unset` is a noop if the attribute(s) do not exist.
     unset: function(attr, options) {
-      return this.set(attr, void 0, _.extend({}, options, {unset: true}));
+      var attrs;
+
+      // handle both array and string values for attr
+      if(_.isArray(attr)) {
+        attrs = {};
+        for (var key in attr) attrs[attr[key]] = void 0;
+      }
+      else {
+        (attrs = {})[attr] = void 0;
+      }
+
+      return this.set(attrs, _.extend({}, options, {unset: true}));
     },
 
     // Clear all attributes on the model, firing `"change"` unless you choose

--- a/test/model.js
+++ b/test/model.js
@@ -253,6 +253,20 @@ $(document).ready(function() {
     model.set({result: void 0});
   });
 
+  test("unset with array as first argument", 5, function() {
+    var all_changed = 0, a_changed = 0, b_changed = 0;
+    var model = new Backbone.Model({a: 1, b: 2});
+    model.on("change", function(){ all_changed++; });
+    model.on("change:a", function(){ a_changed++; });
+    model.on("change:b", function(){ b_changed++; });
+    model.unset(['a','b']);
+    equal(model.get('a'), void 0, "a should have been unset");
+    equal(model.get('b'), void 0, "b should have been unset");
+    equal(a_changed, 1, 'one change event fired for a.');
+    equal(b_changed, 1, 'one change event fired for b');
+    equal(all_changed, 1, 'unset fires only one change event when unsetting multiple attributes.');
+  });
+
   test("multiple unsets", 1, function() {
     var i = 0;
     var counter = function(){ i++; };


### PR DESCRIPTION
Adds support for unsetting multiple model attributes at once by passing an array as the first argument to model#unset. A unit test for this functionality is also included.

For example:

``` javascript
myModel.unset( _.without( _.keys( myModel.attributes ), "id" ) );
```

Will unset all attributes except for the `id` attribute.
