### PR TITLE
Removing View.make

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1272,18 +1272,6 @@
       return this;
     },
 
-    // For small amounts of DOM Elements, where a full-blown template isn't
-    // needed, use **make** to manufacture elements, one at a time.
-    //
-    //     var el = this.make('li', {'class': 'row'}, this.model.escape('title'));
-    //
-    make: function(tagName, attributes, content) {
-      var $el = Backbone.$('<' + tagName + '>');
-      if (attributes) $el.attr(attributes);
-      if (content != null) $el.html(content);
-      return $el[0];
-    },
-
     // Change the view's element (`this.el` property), including event
     // re-delegation.
     setElement: function(element, delegate) {
@@ -1353,7 +1341,8 @@
         var attrs = _.extend({}, _.result(this, 'attributes'));
         if (this.id) attrs.id = _.result(this, 'id');
         if (this.className) attrs['class'] = _.result(this, 'className');
-        this.setElement(this.make(_.result(this, 'tagName'), attrs), false);
+        var $el = Backbone.$('<' + _.result(this, 'tagName') + '>').attr(attrs);
+        this.setElement($el, false);
       } else {
         this.setElement(_.result(this, 'el'), false);
       }

--- a/test/view.js
+++ b/test/view.js
@@ -29,22 +29,6 @@ $(document).ready(function() {
     strictEqual(view.$('a b').html(), 'test');
   });
 
-  test("make", 3, function() {
-    var div = view.make('div', {id: 'test-div'}, "one two three");
-
-    equal(div.tagName.toLowerCase(), 'div');
-    equal(div.id, 'test-div');
-    equal($(div).text(), 'one two three');
-  });
-
-  test("make can take falsy values for content", 2, function() {
-    var div = view.make('div', {id: 'test-div'}, 0);
-    equal($(div).text(), '0');
-
-    div = view.make('div', {id: 'test-div'}, '');
-    equal($(div).text(), '');
-  });
-
   test("initialize", 1, function() {
     var View = Backbone.View.extend({
       initialize: function() {


### PR DESCRIPTION
From the discussion in #2029 - I don't see any clear reason for using `View.make`, it's a simple helper function that is only used once internally and doesn't have anything to do with the view object, yet can only really be used when a view has been created (unless you call it directly from the prototype).
