### PR TITLE
Back to the original {add:true} on fetch

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -811,7 +811,8 @@
       if (options.parse === void 0) options.parse = true;
       var success = options.success;
       options.success = function(collection, resp, options) {
-        var method = options.update ? 'update' : 'reset';
+        var method = (options.add || options.update) ? 'update' : 'reset';
+        if (options.add) options = _.extend({remove: false}, options);
         collection[method](resp, options);
         if (success) success(collection, resp, options);
       };

--- a/test/collection.js
+++ b/test/collection.js
@@ -396,6 +396,17 @@ $(document).ready(function() {
     equal(this.syncArgs.options.parse, false);
   });
 
+  test("fetch with {add:true}", 1, function() {
+    var init = [{id:1, name:'Test1'},{id:2, name:'Test2'},{id:3, name:'Test3'}];
+    var update = [{id:4, name:'Test4'},{id:5, name:'Test5'}];
+    var collection = new Backbone.Collection(init);
+    collection.sync = function (type, model, options) {
+      options.success(this, update, options);
+    };
+    collection.fetch({add: true});
+    deepEqual(collection.toJSON(), init.concat(update));
+  });
+
   test("ensure fetch only parses once", 1, function() {
     var collection = new Backbone.Collection;
     var counter = 0;


### PR DESCRIPTION
There has been a little bit of confusion around how `add:true` should work with the addition of the `update` API (#2008, #1975, #2009). 

The `{add:true}` is a common enough case that it should also prevent the items from being removed - rather than needing to specify `{update:true, remove:false}`.

This pull request gives `collection.fetch({add:true})` the same implementation it had before, without affecting the `update` api call, with the ability to specify additional options such as `{merge:false}` if desired.
