### PR TITLE
Add Backbone.wrapError and Backbone.wrapSuccess methods

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1423,22 +1423,29 @@
       params.processData = false;
     }
 
-    var success = options.success;
-    options.success = function(resp) {
-      if (success) success(model, resp, options);
-      model.trigger('sync', model, resp, options);
-    };
-
-    var error = options.error;
-    options.error = function(xhr) {
-      if (error) error(model, xhr, options);
-      model.trigger('error', model, xhr, options);
-    };
+    options.success = Backbone.wrapSuccess(model, options);
+    options.error = Backbone.wrapError(model, options);
 
     // Make the request, allowing the user to override any Ajax options.
     var xhr = options.xhr = Backbone.ajax(_.extend(params, options));
     model.trigger('request', model, xhr, options);
     return xhr;
+  };
+
+  Backbone.wrapSuccess = function(model, options) {
+    var success = options.success;
+    return function(resp) {
+      if (success) success(model, resp, options);
+      model.trigger('sync', model, resp, options);
+    };
+  };
+
+  Backbone.wrapError = function(model, options) {
+    var error = options.error;
+    return function(xhr) {
+      if (error) error(model, xhr, options);
+      model.trigger('error', model, xhr, options);
+    };
   };
 
   // Set the default implementation of `Backbone.ajax` to proxy through to `$`.

--- a/test/sync.js
+++ b/test/sync.js
@@ -155,6 +155,32 @@ $(document).ready(function() {
     Backbone.sync('create', model);
   });
 
+  test("Can override generated success handlers", 2, function() {
+    var model = new Backbone.Model,
+        oldWrapSuccess = Backbone.wrapSuccess;
+    Backbone.wrapSuccess = function(model, options) {
+      ok(true);
+      return oldWrapSuccess.apply(this, arguments);
+    };
+    model.url = '/test';
+    Backbone.sync('read', model);
+    equal(this.ajaxSettings.url, '/test');
+    Backbone.wrapSuccess = oldWrapSuccess;
+  });
+
+  test("Can override generated error handlers", 1, function() {
+    var model = new Backbone.Model,
+        oldWrapError = Backbone.wrapError;
+    Backbone.wrapError = function(model, options) {
+      ok(true);
+      return oldWrapError.apply(this, arguments);
+    };
+    model.url = '/test';
+    Backbone.sync('read', model);
+    this.ajaxSettings.error();
+    Backbone.wrapError = oldWrapError;
+  });
+
   test("Call provided error callback on error.", 1, function() {
     var model = new Backbone.Model;
     model.url = '/test';


### PR DESCRIPTION
Added per the discussion in: https://github.com/documentcloud/backbone/issues/2031

Note that I choose to add the methods directly on the `Backbone` object as `Backbone.sync` is frequently overridden.
