### PR TITLE
Add isPopulated and shouldFetch methods

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -986,4 +986,24 @@ $(document).ready(function() {
     collection.add(collection.models, {merge: true}); // don't sort
   });
 
+  test("isPopulated", function() {
+    var collection = new Backbone.Collection;
+    strictEqual(collection.isPopulated(), false);
+
+    collection = new Backbone.Collection([{key: 'value'}]);
+    strictEqual(collection.isPopulated(), true);
+
+    var collection = new Backbone.Collection;
+    collection._fetched = true;
+    strictEqual(collection.isPopulated(), true);
+  });
+
+  test("shouldFetch", function() {
+    var collection = new Backbone.Collection;
+    strictEqual(collection.shouldFetch(), false);
+    collection.url = '/test';
+    strictEqual(collection.shouldFetch(), true);
+    collection.add({key: 'value'});
+    strictEqual(collection.shouldFetch(), false);
+  });
 });

--- a/test/model.js
+++ b/test/model.js
@@ -1063,4 +1063,34 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test("isPopulated", function() {
+    var model = new Backbone.Model;
+    strictEqual(model.isPopulated(), false, '1');
+    model.set({key: 'value'});
+    strictEqual(model.isPopulated(), true, '2');
+
+    model = new (Backbone.Model.extend({
+      defaults: {
+        key: 'value'
+      }
+    }));
+    strictEqual(model.isPopulated(), false, '3');
+  });
+
+  test("shouldFetch", function() {
+    var model = new Backbone.Model;
+    strictEqual(model.shouldFetch(), false);
+    model.urlRoot = '/test';
+    strictEqual(model.shouldFetch(), true);
+    model.set({key: 'value'});
+    strictEqual(model.shouldFetch(), false);
+    model.clear();
+    strictEqual(model.shouldFetch(), true);
+    model.urlRoot = false;
+    strictEqual(model.shouldFetch(), false);
+    model.collection = new Backbone.Collection;
+    model.collection.url = '/test';
+    strictEqual(model.shouldFetch(), true);
+  });
+  
 });


### PR DESCRIPTION
This adds `isPopulated` and `shouldFetch` methods to `Backbone.Collection` and `Backbone.Model`, the behaviors implemented are:
- `collection.isPopulated()`: Has the collection been initialized with any models, or been fetched from the server, but the response has no models.
- `collection.shouldFetch()`: The collection should be fetched if it has a url but is not populated.
- `model.isPopulated()`: Have any non default keys been set on the model?
- `model.shouldFetch()`: If we have a url and are not populated we should fetch

In support these additions `Backbone.Model.prototype.url` now accepts a `{silent: bool}` argument to surpress the `urlError`. This defaults to false, so the previous behavior is preserved by default.
