### PR TITLE
Allow `this.el` to be a node array

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1277,7 +1277,7 @@
     setElement: function(element, delegate) {
       if (this.$el) this.undelegateEvents();
       this.$el = element instanceof Backbone.$ ? element : Backbone.$(element);
-      this.el = this.$el[0];
+      this.el = this.$el.length > 1 ? this.$el.get() : this.$el[0];
       if (delegate !== false) this.delegateEvents();
       return this;
     },


### PR DESCRIPTION
Looking at Backbone [`setElement` method](https://github.com/documentcloud/backbone/blob/master/backbone.js#L1277-L1283), it appear that one can set a jQuery dom node collections as `this.$el`, but that only the first element in this collection will be used as `this.el`.

I was wondering if it weren't more consistent to allow `this.el` to be a `nodeList` so that elements matched by `this.$el` and `this.el` are always consistent.

We were speaking about this [inconsistency in LayoutManager](https://github.com/tbranyen/backbone.layoutmanager/pull/247) new "full template" feature. We were looking at allowing (or not) multiple root elements for a "full template" view, and all in all, allowing them seems to work good with almost everything, except that `this.$el` and `this.el` wouldn't match anymore.

_I'm sending this as a pull request so it's easier to see implication. If you feel like that's a good thing to merge in, I'll add unit test_
