### PR TITLE
Make Events#listenTo implicitly listen to this if no object is specified

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -192,6 +192,9 @@
     // An inversion-of-control version of `on`. Tell *this* object to listen to
     // an event in another object ... keeping track of what it's listening to.
     listenTo: function(object, events, callback) {
+      if (_.isFunction(events) || (events === callback && events == null)) {
+        callback = events, events = object, object = this;
+      }
       var listeners = this._listeners || (this._listeners = {});
       var id = object._listenerId || (object._listenerId = _.uniqueId('l'));
       listeners[id] = object;

--- a/test/events.js
+++ b/test/events.js
@@ -100,6 +100,18 @@ $(document).ready(function() {
     e.trigger("foo");
   });
 
+  test("listenTo yourself implicity", 1, function() {
+    var e = _.extend({}, Backbone.Events);
+    e.listenTo("foo", function() { ok(true); });
+    e.trigger("foo");
+  });
+
+  test("listenTo yourself implicity with event maps", 1, function() {
+    var a = _.extend({}, Backbone.Events);
+    a.listenTo({change: function() { ok(true); }});
+    a.trigger('change');
+  });
+
   test("trigger all for each event", 3, function() {
     var a, b, obj = { counter: 0 };
     _.extend(obj, Backbone.Events);


### PR DESCRIPTION
Since @philfreo mentioned that he uses `listenTo(this, /*...*/)`, got the idea that since people are using it for the `this` object already it may be of a benefit of them to have a nicer API for this.

The idea is that if you are going to listen to yourself, you can omit the passing of yourself as the object and we can figure it out for you. It works for both `this.listenTo('event', this.eventHandler)` and  `this.listenTo({event: this.eventHandler})` use-cases.

Happy new year, guys :fireworks:
