### PR TITLE
Add {silent: true} option to model.url() to surpress error

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -503,8 +503,12 @@
     // Default URL for the model's representation on the server -- if you're
     // using Backbone's restful methods, override this to change the endpoint
     // that will be called.
-    url: function() {
-      var base = _.result(this, 'urlRoot') || _.result(this.collection, 'url') || urlError();
+    url: function(options) {
+      _.defaults(options || (options = {}), {
+        silent: false
+      });
+      var base = _.result(this, 'urlRoot') || _.result(this.collection, 'url');
+      if (!base) return !options.silent ? urlError() : false;
       if (this.isNew()) return base;
       return base + (base.charAt(base.length - 1) === '/' ? '' : '/') + encodeURIComponent(this.id);
     },

--- a/test/model.js
+++ b/test/model.js
@@ -78,12 +78,13 @@ $(document).ready(function() {
     equal(JSON.stringify(model.toJSON()), "{}");
   });
 
-  test("url", 3, function() {
+  test("url", 4, function() {
     doc.urlRoot = null;
     equal(doc.url(), '/collection/1-the-tempest');
     doc.collection.url = '/collection/';
     equal(doc.url(), '/collection/1-the-tempest');
     doc.collection = null;
+    strictEqual(doc.url({silent: true}), false);
     raises(function() { doc.url(); });
     doc.collection = collection;
   });


### PR DESCRIPTION
It is useful to check wether or not a model has a `url` without throwing an exception. This pull request adds a `{silent: true}` option which will surpress the exception if a url is not found.

If brevity is of concern another possibility would be to make it a boolean argument `surpressError`.
