### PR TITLE
Exit early in Collection#create

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -824,8 +824,8 @@
     create: function(model, options) {
       options = options ? _.clone(options) : {};
       model = this._prepareModel(model, options);
-      var collection = this;
       if (!model) return false;
+      var collection = this;
       if (!options.wait) collection.add(model, options);
       var success = options.success;
       options.success = function(model, resp, options) {


### PR DESCRIPTION
If the model is invalid, there is no need to assign the collection value to `this`.
