### PR TITLE
clarifying/correcting docs about View#remove

### DIFF
--- a/index.html
+++ b/index.html
@@ -2535,7 +2535,7 @@ var Bookmark = Backbone.View.extend({
       <br />
       Removes a view from the DOM, and calls
       <a href="#Events-stopListening">stopListening</a> to remove any bound
-      model events that the view has <a href="#Events-listenTo">listenTo</a>'d.
+      events that the view has <a href="#Events-listenTo">listenTo</a>'d.
     </p>
 
     <p id="View-make">


### PR DESCRIPTION
`remove`/`stopListening` does more than remove just _model_ events
