### PR TITLE
add generic route event

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -963,7 +963,7 @@
       Backbone.history.route(route, _.bind(function(fragment) {
         var args = this._extractParameters(route, fragment);
         callback && callback.apply(this, args);
-        this.trigger.call(this, 'route', name, args);
+        this.trigger('route', name, args);
         this.trigger.apply(this, ['route:' + name].concat(args));
         Backbone.history.trigger('route', this, name, args);
       }, this));


### PR DESCRIPTION
Hello,

I often got the use case that I want to inform some object (e.g. nav view) on route changes.

Unfortunately currently it is only possible to inform that object on specific route changes even I often just want to get informed about any route change and get the triggered route as parameter.

To implement this I just added one line code which now triggers on the router a "route" event with the first parameter being the route name and the other parameters being the arguments we would have at a "route:example" event.

Regards,
Bodo
