### PR TITLE
Use `toJSON` in Model `clone` to take advantage of nested model and collection

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -517,7 +517,7 @@
 
     // Create a new model with identical attributes to this one.
     clone: function() {
-      return new this.constructor(this.attributes);
+      return new this.constructor(this.toJSON());
     },
 
     // A model is new if it has never been saved to the server, and lacks an id.


### PR DESCRIPTION
This change doesn't give much significant results as long as you are not using nested model and collection.
It will add more value when you just override `toJSON` method, and `clone` method will start behaving accordingly.

``` javascript
var Mailbox = Backbone.Model.extend({
  initialize: function (attributes, options) {
    this.personalInfo = new PersonalInfo(attributes.personalInfo);
    this.messages = new Messages(attributes.messages);    
  },
  toJSON: function () {            
    return _.extends(_.clone(this.attributes), {
        personalInfo: this.get('personalInfo').toJSON(),
        messages: this.get('messages').toJSON()
    });
  }
});
```

`new Mailbox(data).clone()` will have following raw data : 

``` javascript
{   
    personalInfo : {
        name: 'John Doe'
        ...
    },
    messages : [
        {
            from: 'backbonejs@gmail.com',
            body: 'hello'
        }
        ...
    ]    
    ...
}
```
