### PR TITLE
Test case for cid order when adding model hashes

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -986,4 +986,9 @@ $(document).ready(function() {
     collection.add(collection.models, {merge: true}); // don't sort
   });
 
+  test("vivifying models creates incrementally increasing `cid`s", function() {
+    var col = new Backbone.Collection([{foo: 1}, {foo: 2}, {foo: 3}]);
+    ok(col.at(0).cid < col.at(1).cid && col.at(1).cid < col.at(2).cid);
+  });
+
 });


### PR DESCRIPTION
`Collection#add` in 0.9.9 inserts object hashes in reverse. This has the unintended consequence of creating `cid`s on the vivified models in reverse order as well, which broke code that relies on the `cid` as the marker for model insertion order. This behavior is reversed back to 0.9.2 behavior on `master`. This test case aims to ensure this behavior persists.
