### PR TITLE
change 'events' argument name to 'name' in #off doc

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -142,7 +142,7 @@
 
     // Remove one or many callbacks. If `context` is null, removes all
     // callbacks with that function. If `callback` is null, removes all
-    // callbacks for the event. If `events` is null, removes all bound
+    // callbacks for the event. If `name` is null, removes all bound
     // callbacks for all events.
     off: function(name, callback, context) {
       var list, ev, events, names, i, l, j, k;


### PR DESCRIPTION
argument name changed from `events` to `name` in last release

``` javascript
  off: function(name, callback, context) {
```
