### PR TITLE
Add an escape option to Model#toJSON

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -261,7 +261,27 @@
 
     // Return a copy of the model's `attributes` object.
     toJSON: function(options) {
-      return _.clone(this.attributes);
+      var json;
+      options || (options = {});
+
+      if (!options.escape) return _.clone(this.attributes);
+
+      json = {};
+      // Escape specified attributes.
+      if (_.isString(options.escape)) {
+        _.each(this.attributes, function (value, name) {
+          json[name] = name === options.escape ? _.escape(value) : value;
+        });
+      } else if (_.isArray(options.escape)) {
+        _.each(this.attributes, function (value, name) {
+          json[name] = _.contains(options.escape, name) ? _.escape(value) : value;
+        });
+      } else {
+        _.each(this.attributes, function (value, name) {
+          json[name] = _.escape(value);
+        });
+      }
+      return _.clone(json);
     },
 
     // Proxy `Backbone.sync` by default.

--- a/test/model.js
+++ b/test/model.js
@@ -160,6 +160,14 @@ $(document).ready(function() {
     equal(doc.escape('audience'), '');
   });
 
+  test("toJSON", 4, function () {
+    var model = new Backbone.Model({amp: '&', gt: '>'});
+    deepEqual(model.toJSON(), {amp: '&', gt: '>'});
+    deepEqual(model.toJSON({escape: true}), {amp: '&amp;', gt: '&gt;'});
+    deepEqual(model.toJSON({escape: 'amp'}), {amp: '&amp;', gt: '>'});
+    deepEqual(model.toJSON({escape: ['gt']}), {amp: '&', gt: '&gt;'});
+  });
+
   test("has", 10, function() {
     var model = new Backbone.Model();
 


### PR DESCRIPTION
This patch adds an escape option to `Model#toJSON`.

Example:

``` javascript
var model = new Backbone.Model({amp: '&', gt: '<'});
model.toJSON();  //=> {amp: '&', gt: '<'}
model.toJSON({escape: true});  //=> {amp: '&amp;', gt: '&gt;'}
model.toJSON({escape: 'amp'});  //=> {amp: '&amp;', gt: '<'}
model.toJSON({escape: ['gt']});  //=> {amp: '&', gt: '&gt;'}
```
### Why I need this?

I often use`Model#toJSON` with `_.template`. Then I have to use `<%- %>` instead of `<%= %>` to escape attributes because of XSS security vulnerability, but I think there are two problems.
1. `<%- %>` and `<%= %>` are too similar.
2. It is hard to test template strings since designers change them frequently.
