### PR TITLE
Add underscore methods (map, keys, values) to models

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -545,9 +545,8 @@
   });
 
   // Underscore methods that we want to implement on the Model.
-  var methods =  ['each', 'forEach', 'map', 'collect', 'contains', 'include',
-    'sortBy', 'groupBy', 'size', 'keys', 'values', 'pairs', 'invert', 'pick',
-    'omit', 'isEqual', 'isEmpty', 'chain'];
+  var methods =  ['each', 'forEach', 'sortBy', 'groupBy', 'size', 'keys',
+    'values', 'invert', 'pick', 'omit', 'isEqual', 'isEmpty', 'chain'];
 
   // Mix in each Underscore method as a proxy to `Model#attributes`.
   _.each(methods, function(method) {

--- a/test/model.js
+++ b/test/model.js
@@ -111,12 +111,11 @@ $(document).ready(function() {
     equal(model.url(), '/nested/1/collection/2');
   });
 
-  test("underscore methods", 19, function() {
+  test("underscore methods", 15, function() {
     var model = new Backbone.Model({ 'foo': 'a', 'bar': 'b', 'baz': 'c' });
     var model2 = model.clone();
     deepEqual(model.keys(), ['foo', 'bar', 'baz']);
     deepEqual(model.values(), ['a', 'b', 'c']);
-    deepEqual(model.pairs(), [['foo', 'a'], ['bar', 'b'], ['baz', 'c']]);
     deepEqual(model.invert(), { 'a': 'foo', 'b': 'bar', 'c': 'baz' });
     deepEqual(model.pick('foo', 'baz'), {'foo': 'a', 'baz': 'c'});
     deepEqual(model.omit('foo', 'bar'), {'baz': 'c'});
@@ -127,8 +126,6 @@ $(document).ready(function() {
     equal(model.isEqual({ 'foo': 'a', 'bop': 'd' }), false);
     equal(model.isEmpty(), false);
     equal(model.size(), 3);
-    equal(model.contains('foo'), false);
-    equal(model.contains('b'), true);
     equal(model.chain().keys().contains('foo').value(), true);
     deepEqual(model.sortBy(function(val) { return val === 'b' }), ["c", "a", "b"]);
     deepEqual(model.groupBy(), {
@@ -136,10 +133,6 @@ $(document).ready(function() {
       'b': ['b'],
       'c': ['c']
     });
-    var prefixed = model.map(function(val, key, attrs){
-      return 'book-' + key;
-    });
-    deepEqual(prefixed, ['book-foo', 'book-bar', 'book-baz']);
   });
 
   test("clone", 10, function() {


### PR DESCRIPTION
Re-opening accidentally-closed #2040 per @jashkenas:  Which underscore methods (if any) should Backbone.Model natively mixin for `attributes` access?

Model is a unique scenario where the hash of attributes may but likely doesn't contain related, iterable data, of the kind for which underscore's collection methods are particularly suited.

The current method list in the patch is as follows: `each`, `map`, `contains`, `sortBy`, `groupBy`, `size`, `keys`, `values`, `pairs`, `invert`, `pick`, `omit`, `isEqual`, `isEmpty`, and `chain` (plus aliases).

I'm in favor of keeping all except `pairs` and `invert` (as per @wyuenho on #2040, either they both stay or both go), and perhaps special-casing `isEqual` (to compare against another model) and `contains` (to look at keys in addition to or instead of values). `groupBy` and `sortBy` could be particularly useful, but probably less so when acting on the values of the attributes hash, more likely on its keys, e.g. in grouping by prefixed named keys.
