### PR TITLE
Fix #2099 - sortedIndex use model attributes for string iterator

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -882,6 +882,14 @@
         if (model.id != null) this._byId[model.id] = model;
       }
       this.trigger.apply(this, arguments);
+    },
+
+    sortedIndex: function (model, value, context) {
+      value || (value = this.comparator);
+      var iterator = _.isFunction(value) ? value : function(model) {
+        return model.get(value);
+      }
+      return _.sortedIndex(this.models, model, iterator, context);
     }
 
   });
@@ -890,9 +898,9 @@
   var methods = ['forEach', 'each', 'map', 'collect', 'reduce', 'foldl',
     'inject', 'reduceRight', 'foldr', 'find', 'detect', 'filter', 'select',
     'reject', 'every', 'all', 'some', 'any', 'include', 'contains', 'invoke',
-    'max', 'min', 'sortedIndex', 'toArray', 'size', 'first', 'head', 'take',
-    'initial', 'rest', 'tail', 'drop', 'last', 'without', 'indexOf', 'shuffle',
-    'lastIndexOf', 'isEmpty', 'chain'];
+    'max', 'min', 'toArray', 'size', 'first', 'head', 'take', 'initial', 'rest',
+    'tail', 'drop', 'last', 'without', 'indexOf', 'shuffle', 'lastIndexOf',
+    'isEmpty', 'chain'];
 
   // Mix in each Underscore method as a proxy to `Collection#models`.
   _.each(methods, function(method) {

--- a/test/collection.js
+++ b/test/collection.js
@@ -497,6 +497,20 @@ $(document).ready(function() {
          [4, 0]);
   });
 
+  test("sortedIndex", function () {
+    var a = new Backbone.Model({key: 1});
+    var b = new Backbone.Model({key: 2});
+    var c = new Backbone.Model({key: 3});
+    var collection = new (Backbone.Collection.extend({
+      comparator: 'key'
+    }))([b, c, a]);
+    equal(collection.sortedIndex(b), 1);
+    equal(collection.sortedIndex(b, 'key'), 1);
+    equal(collection.sortedIndex(b, function (model) {
+      return model.get('key');
+    }), 1);
+  });
+
   test("reset", 10, function() {
     var resetCount = 0;
     var models = col.models;


### PR DESCRIPTION
With an added bonus

``` js
collection.sortedIndex(model);
```

will use `collection.comparator` as iterator.
