### PR TITLE
removed unused variable 'model' from 'save' function

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -425,7 +425,7 @@
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
     save: function(key, val, options) {
-      var attrs, model, success, method, xhr, attributes = this.attributes;
+      var attrs, success, method, xhr, attributes = this.attributes;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
       if (key == null || typeof key === 'object') {


### PR DESCRIPTION
There was an unused `model` variable in the `model.save` function. This removes it.
