### PR TITLE
Consistently turn on `parse` flag in `save`, like `fetch` already does

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -450,6 +450,7 @@
 
       // After a successful server-side save, the client is (optionally)
       // updated with the server-side state.
+      if (options.parse === void 0) options.parse = true;
       success = options.success;
       options.success = function(model, resp, options) {
         // Ensure attributes are restored during synchronous saves.

--- a/test/model.js
+++ b/test/model.js
@@ -734,6 +734,13 @@ $(document).ready(function() {
     model.save({x: 1}, {wait: true});
   });
 
+  test("save turns on parse flag", function () {
+    var Model = Backbone.Model.extend({
+      sync: function(method, model, options) { ok(options.parse); }
+    });
+    new Model().save();
+  });
+
   test("nested `set` during `'change:attr'`", 2, function() {
     var events = [];
     var model = new Backbone.Model();


### PR DESCRIPTION
This bit me today. Trying to run `parse` through multiple layers of models/collections fails because the option isn't set in `save` like it is in `fetch`.
