### PR TITLE
Issue number in comments.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1016,7 +1016,7 @@
     this.handlers = [];
     _.bindAll(this, 'checkUrl');
 
-    // Ensure that `History` can be used outside of the browser.
+    // gh-1653: Ensure that `History` can be used outside of the browser.
     if (typeof window !== 'undefined') {
       this.location = window.location;
       this.history = window.history;
@@ -1212,7 +1212,7 @@
         var href = location.href.replace(/(javascript:|#).*$/, '');
         location.replace(href + '#' + fragment);
       } else {
-        // Some browsers require that `hash` contains a leading #.
+        // gh-1649: Some browsers require that `hash` contains a leading #.
         location.hash = '#' + fragment;
       }
     }


### PR DESCRIPTION
These were removed due to #1937, but I think it's good to keep a reference to the issue number for easy lookup and context for readers.  Using the `gh-xxxx` form should prevent issues with the docs.
