### PR TITLE
Remove silent option from Model#set.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -294,7 +294,7 @@
     // Set a hash of model attributes on the object, firing `"change"` unless
     // you choose to silence it.
     set: function(key, val, options) {
-      var attr, attrs, unset, changes, silent, changing, prev, current;
+      var attr, attrs, unset, changes, changing, prev, current;
       if (key == null) return this;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
@@ -312,7 +312,6 @@
 
       // Extract attributes and options.
       unset           = options.unset;
-      silent          = options.silent;
       changes         = [];
       changing        = this._changing;
       this._changing  = true;
@@ -339,19 +338,15 @@
       }
 
       // Trigger all relevant attribute changes.
-      if (!silent) {
-        if (changes.length) this._pending = true;
-        for (var i = 0, l = changes.length; i < l; i++) {
-          this.trigger('change:' + changes[i], this, current[changes[i]], options);
-        }
+      if (changes.length) this._pending = true;
+      for (var i = 0, l = changes.length; i < l; i++) {
+        this.trigger('change:' + changes[i], this, current[changes[i]], options);
       }
 
       if (changing) return this;
-      if (!silent) {
-        while (this._pending) {
-          this._pending = false;
-          this.trigger('change', this, options);
-        }
+      while (this._pending) {
+        this._pending = false;
+        this.trigger('change', this, options);
       }
       this._pending = false;
       this._changing = false;

--- a/index.html
+++ b/index.html
@@ -970,12 +970,11 @@ new Book({
     <p id="Model-set">
       <b class="header">set</b><code>model.set(attributes, [options])</code>
       <br />
-      Set a hash of attributes (one or many) on the model. If any of the attributes
-      change the model's state, a <tt>"change"</tt> event will be triggered, unless
-      <tt>{silent: true}</tt> is passed as an option. Change events for specific
-      attributes are also triggered, and you can bind to those as well, for example:
-      <tt>change:title</tt>, and <tt>change:content</tt>. You may also pass
-      individual keys and values.
+      Set a hash of attributes (one or many) on the model. If any of the
+      attributes change the model's state, a <tt>"change"</tt> event will be
+      triggered. Change events for specific attributes are also triggered, and
+      you can bind to those as well, for example: <tt>change:title</tt>, and
+      <tt>change:content</tt>. You may also pass individual keys and values.
     </p>
 
 <pre>
@@ -1017,15 +1016,15 @@ if (note.has("title")) {
     <p id="Model-unset">
       <b class="header">unset</b><code>model.unset(attribute, [options])</code>
       <br />
-      Remove an attribute by deleting it from the internal attributes hash.
-      Fires a <tt>"change"</tt> event unless <tt>silent</tt> is passed as an option.
+      Remove an attribute by deleting it from the attributes hash.  Fires
+      <tt>"change"</tt> and <tt>"change:attr"</tt> events.
     </p>
 
     <p id="Model-clear">
       <b class="header">clear</b><code>model.clear([options])</code>
       <br />
-      Removes all attributes from the model, including the <tt>id</tt> attribute. Fires a <tt>"change"</tt> event unless
-      <tt>silent</tt> is passed as an option.
+      Removes all attributes from the model, including the <tt>id</tt>
+      attribute. Fires <tt>"change"</tt> and <tt>"change:attr"</tt> events.
     </p>
 
     <p id="Model-id">
@@ -1284,7 +1283,7 @@ book.destroy({success: function(model, response) {
       error object that describes the error programmatically. If <b>validate</b>
       returns an error, <tt>set</tt> and <tt>save</tt> will not continue, and the
       model attributes will not be modified.
-      Failed validations trigger an <tt>"invalid"</tt> event, and set the 
+      Failed validations trigger an <tt>"invalid"</tt> event, and set the
       <tt>validationError</tt> property on the model with the value returned by
       this method.
     </p>
@@ -3810,6 +3809,15 @@ ActiveRecord::Base.include_root_in_json = false
     </p>
 
     <h2 id="changelog">Change Log</h2>
+
+    <b class="header">Edge</b> &mdash; <small><i>Unreleased</i></small><br/>
+
+    <ul style="margin-top: 5px;">
+      <li>
+        The <tt>silent</tt> option has been removed from <tt>Model#set</tt>.
+        Custom options should be used to accomplish this effect instead.
+      </li>
+    </ul>
 
     <b class="header">0.9.10</b> &mdash; <small><i>Jan. 15, 2013</i></small> &mdash; <a href="https://github.com/documentcloud/backbone/compare/0.9.9...0.9.10">Diff</a><br />
     <ul style="margin-top: 5px;">

--- a/test/model.js
+++ b/test/model.js
@@ -242,14 +242,11 @@ $(document).ready(function() {
   });
 
   test("set falsy values in the correct order", 2, function() {
-    var model = new Backbone.Model({result: 'result'});
+    var model = new Backbone.Model({result: false});
     model.on('change', function() {
       equal(model.changed.result, void 0);
       equal(model.previous('result'), false);
     });
-    model.set({result: void 0}, {silent: true});
-    model.set({result: null}, {silent: true});
-    model.set({result: false}, {silent: true});
     model.set({result: void 0});
   });
 
@@ -649,15 +646,12 @@ $(document).ready(function() {
     ok('x' in model.attributes);
   });
 
-  test("hasChanged works outside of change events, and true within", 6, function() {
-    var model = new Backbone.Model({x: 1});
+  test("hasChanged works outside of change events, and true within", 4, function() {
+    var model = new Backbone.Model;
     model.on('change:x', function() {
       ok(model.hasChanged('x'));
       equal(model.get('x'), 1);
     });
-    model.set({x: 2}, {silent: true});
-    ok(model.hasChanged());
-    equal(model.hasChanged('x'), true);
     model.set({x: 1});
     ok(model.hasChanged());
     equal(model.hasChanged('x'), true);
@@ -684,14 +678,14 @@ $(document).ready(function() {
 
   test("`hasChanged` for falsey keys", 2, function() {
     var model = new Backbone.Model();
-    model.set({x: true}, {silent: true});
+    model.set({x: true});
     ok(!model.hasChanged(0));
     ok(!model.hasChanged(''));
   });
 
   test("`previous` for falsey keys", 2, function() {
     var model = new Backbone.Model({0: true, '': true});
-    model.set({0: false, '': false}, {silent: true});
+    model.set({0: false, '': false});
     equal(model.previous(0), true);
     equal(model.previous(''), true);
   });
@@ -741,21 +735,24 @@ $(document).ready(function() {
     new Model().save();
   });
 
-  test("nested `set` during `'change:attr'`", 2, function() {
+  test("nested `set` during `'change:attr'`", 1, function() {
     var events = [];
-    var model = new Backbone.Model();
+    var model = new Backbone.Model;
     model.on('all', function(event) { events.push(event); });
     model.on('change', function() {
-      model.set({z: true}, {silent:true});
+      model.set({z: true});
     });
     model.on('change:x', function() {
       model.set({y: true});
     });
     model.set({x: true});
-    deepEqual(events, ['change:y', 'change:x', 'change']);
-    events = [];
-    model.set({z: true});
-    deepEqual(events, []);
+    deepEqual(events, [
+      'change:y',
+      'change:x',
+      'change:z',
+      'change',
+      'change'
+    ]);
   });
 
   test("nested `change` only fires once", 1, function() {
@@ -793,16 +790,14 @@ $(document).ready(function() {
     model.set({x: true});
   });
 
-  test("nested `change` with silent", 3, function() {
+  test("nested change", 3, function() {
     var count = 0;
     var model = new Backbone.Model();
-    model.on('change:y', function() { ok(false); });
     model.on('change', function() {
       switch(count++) {
         case 0:
           deepEqual(this.changedAttributes(), {x: true});
-          model.set({y: true}, {silent: true});
-          model.set({z: true});
+          model.set({y: true, z: true});
           break;
         case 1:
           deepEqual(this.changedAttributes(), {x: true, y: true, z: true});
@@ -818,29 +813,7 @@ $(document).ready(function() {
     model.set({z: false});
   });
 
-  test("nested `change:attr` with silent", 0, function() {
-    var model = new Backbone.Model();
-    model.on('change:y', function(){ ok(false); });
-    model.on('change', function() {
-      model.set({y: true}, {silent: true});
-      model.set({z: true});
-    });
-    model.set({x: true});
-  });
-
-  test("multiple nested changes with silent", 1, function() {
-    var model = new Backbone.Model();
-    model.on('change:x', function() {
-      model.set({y: 1}, {silent: true});
-      model.set({y: 2});
-    });
-    model.on('change:y', function(model, val) {
-      equal(val, 2);
-    });
-    model.set({x: true});
-  });
-
-  test("multiple nested changes with silent", 1, function() {
+  test("multiple nested changes", 1, function() {
     var changes = [];
     var model = new Backbone.Model();
     model.on('change:b', function(model, val) { changes.push(val); });
@@ -849,14 +822,6 @@ $(document).ready(function() {
     });
     model.set({b: 0});
     deepEqual(changes, [0, 1]);
-  });
-
-  test("basic silent change semantics", 1, function() {
-    var model = new Backbone.Model;
-    model.set({x: 1});
-    model.on('change', function(){ ok(true); });
-    model.set({x: 2}, {silent: true});
-    model.set({x: 1});
   });
 
   test("nested set multiple times", 1, function() {
@@ -960,28 +925,6 @@ $(document).ready(function() {
     .save(null, {wait: true});
   });
 
-  test("#1664 - Changing from one value, silently to another, back to original triggers a change.", 1, function() {
-    var model = new Backbone.Model({x:1});
-    model.on('change:x', function() { ok(true); });
-    model.set({x:2},{silent:true});
-    model.set({x:3},{silent:true});
-    model.set({x:1});
-  });
-
-  test("#1664 - multiple silent changes nested inside a change event", 2, function() {
-    var changes = [];
-    var model = new Backbone.Model();
-    model.on('change', function() {
-      model.set({a:'c'}, {silent:true});
-      model.set({b:2}, {silent:true});
-      model.unset('c', {silent:true});
-    });
-    model.on('change:a change:b change:c', function(model, val) { changes.push(val); });
-    model.set({a:'a', b:1, c:'item'});
-    deepEqual(changes, ['a',1,'item']);
-    deepEqual(model.attributes, {a: 'c', b: 2});
-  });
-
   test("#1791 - `attributes` is available for `parse`", function() {
     var Model = Backbone.Model.extend({
       parse: function() { this.has('a'); } // shouldn't throw an error
@@ -990,22 +933,9 @@ $(document).ready(function() {
     expect(0);
   });
 
-  test("silent changes in last `change` event back to original triggers change", 2, function() {
-    var changes = [];
-    var model = new Backbone.Model();
-    model.on('change:a change:b change:c', function(model, val) { changes.push(val); });
-    model.on('change', function() {
-      model.set({a:'c'}, {silent:true});
-    });
-    model.set({a:'a'});
-    deepEqual(changes, ['a']);
-    model.set({a:'a'});
-    deepEqual(changes, ['a', 'a']);
-  });
-
   test("#1943 change calculations should use _.isEqual", function() {
     var model = new Backbone.Model({a: {key: 'value'}});
-    model.set('a', {key:'value'}, {silent:true});
+    model.set('a', {key:'value'});
     equal(model.changedAttributes(), false);
   });
 
@@ -1059,15 +989,6 @@ $(document).ready(function() {
     });
     var model = new Model;
     model.save({x: 1}, {wait: true});
-  });
-
-  test("#2034 - nested set with silent only triggers one change", 1, function() {
-    var model = new Backbone.Model();
-    model.on('change', function() {
-      model.set({b: true}, {silent: true});
-      ok(true);
-    });
-    model.set({a: true});
   });
 
 });


### PR DESCRIPTION
The most common use case for the `silent` option is to prevent specific handlers from being called for performance or UI reasons.  The problem with this is that _all_ handlers are silenced, not just the one in question.  This can always be better handled with custom options, which could even be named `silent`.  ;)

``` js
var model = new Backbone.Model;
model.on('change', function(model, options) {
  if (options.silent) return;
});
model.set(..., {silent: true});
```

In all cases I'm aware of, silencing change notifications is an anti-pattern that should not be supported.

@tgriesser I would love a second pair of eyes on the tests to make sure I didn't remove any legitimate cases.
