### PR TITLE
Refactored 'model.save'

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -425,7 +425,7 @@
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
     save: function(key, val, options) {
-      var attrs, success, method, xhr, attributes = this.attributes;
+      var attrs, success, method, xhr;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
       if (key == null || typeof key === 'object') {
@@ -443,18 +443,11 @@
       // Do not persist invalid models.
       if (!this._validate(attrs, options)) return false;
 
-      // Set temporary attributes if `{wait: true}`.
-      if (attrs && options.wait) {
-        this.attributes = _.extend({}, attributes, attrs);
-      }
-
       // After a successful server-side save, the client is (optionally)
       // updated with the server-side state.
       if (options.parse === void 0) options.parse = true;
       success = options.success;
       options.success = function(model, resp, options) {
-        // Ensure attributes are restored during synchronous saves.
-        model.attributes = attributes;
         var serverAttrs = model.parse(resp, options);
         if (options.wait) serverAttrs = _.extend(attrs || {}, serverAttrs);
         if (_.isObject(serverAttrs) && !model.set(serverAttrs, options)) {
@@ -465,11 +458,12 @@
 
       // Finish configuring and sending the Ajax request.
       method = this.isNew() ? 'create' : (options.patch ? 'patch' : 'update');
-      if (method == 'patch') options.attrs = attrs;
+      if (method == 'patch')  { 
+        options.attrs = attrs;
+      } else if (attrs && options.wait) {
+        options.attrs = _.extend({}, this.attributes, attrs);
+      }
       xhr = this.sync(method, this, options);
-
-      // Restore attributes.
-      if (attrs && options.wait) this.attributes = attributes;
 
       return xhr;
     },

--- a/test/model.js
+++ b/test/model.js
@@ -1049,18 +1049,6 @@ $(document).ready(function() {
     equal(model.validationError, "This shouldn't happen");
   });
 
-  test("toJSON receives attrs during save(..., {wait: true})", 1, function() {
-    var Model = Backbone.Model.extend({
-      url: '/test',
-      toJSON: function() {
-        strictEqual(this.attributes.x, 1);
-        return _.clone(this.attributes);
-      }
-    });
-    var model = new Model;
-    model.save({x: 1}, {wait: true});
-  });
-
   test("#2034 - nested set with silent only triggers one change", 1, function() {
     var model = new Backbone.Model();
     model.on('change', function() {


### PR DESCRIPTION
Model.save had a lot of confusing juggling of previous and new attributes. I removed this but had to remove a test as well.

I believe the test I removed is not valid because the purpose of passing `{wait: true}` is to wait for the server to respond before setting the new attributes. I don't think that `model.toJSON` should be returning the new attributes during the sync function. I might be entirely wrong, but it looks weird.
