### PR TITLE
Strip fragment's search params before route matching in loadUrl

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1000,20 +1000,6 @@
       return new RegExp('^' + route + '$');
     },
 
-    //from http://stackoverflow.com/questions/901115/how-can-i-get-query-string-values
-    _parseSearchParams: function(search) {
-      var match,
-        plusRegExp = /\+/g,  // Regex for replacing addition symbol with a space
-        searchRegExp = /([^&=]+)=?([^&]*)/g,
-        decode = function (s) { return decodeURIComponent(s.replace(plusRegExp, " ")); },
-        params = {};
-
-      while (match = searchRegExp.exec(search)) {
-        params[decode(match[1])] = decode(match[2]);
-      }
-      return params;
-    },
-
     // Given a route, and a URL fragment that it matches, return the array of
     // extracted parameters.
     _extractParameters: function(route, fragment) {
@@ -1023,7 +1009,7 @@
         params = route.exec(pathname).slice(1);
 
       if(search && search.length) {
-        params.push(this._parseSearchParams(search));
+        params.push(search);
       }
       return params;
     }

--- a/test/router.js
+++ b/test/router.js
@@ -234,10 +234,10 @@ $(document).ready(function() {
     location.replace('http://example.com#query/mandel?a=b&c=d');
     Backbone.history.checkUrl();
     equal(router.entity, 'mandel');
-    deepEqual(router.queryArgs, {'a': 'b', 'c': 'd'});
+    equal(router.queryArgs, 'a=b&c=d');
     equal(lastRoute, 'query');
     equal(lastArgs[0], 'mandel');
-    deepEqual(lastArgs[1], {'a': 'b', 'c': 'd'});
+    equal(lastArgs[1], 'a=b&c=d');
   });
 
   test("routes (anything)", 1, function() {


### PR DESCRIPTION
This is based on discussion with @braddunbar in https://github.com/documentcloud/backbone/issues/891

Based on my description he made this change: https://github.com/documentcloud/backbone/pull/2122
But that prevents the search params from getting into the history/url bar.

Here, just strip the search params for the purpose of route matching only.
