### PR TITLE
Clarify collection request/sync event behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -823,7 +823,7 @@ view.stopListening(model);
       <li><b>"change:[attribute]"</b> (model, value, options) &mdash; when a specific attribute has been updated. </li>
       <li><b>"destroy"</b> (model, collection, options) &mdash; when a model is <a href="#Model-destroy">destroyed</a>. </li>
       <li><b>"request"</b> (model, xhr, options) &mdash; when a model (or collection) has started a request to the server. </li>
-      <li><b>"sync"</b> (model, resp, options) &mdash; when a model has been successfully synced with the server. </li>
+      <li><b>"sync"</b> (model, resp, options) &mdash; when a model (or collection) has been successfully synced with the server. </li>
       <li><b>"error"</b> (model, xhr, options) &mdash; when a model's <a href="#Model-save">save</a> call fails on the server. </li>
       <li><b>"invalid"</b> (model, error, options) &mdash; when a model's <a href="#Model-validate">validation</a> fails on the client. </li>
       <li><b>"route:[name]"</b> (params) &mdash; Fired by the router when a specific route is matched.</li>

--- a/test/collection.js
+++ b/test/collection.js
@@ -675,13 +675,28 @@ $(document).ready(function() {
     col.create(m, opts);
   });
 
-  test("#1412 - Trigger 'sync' event.", 2, function() {
+  test("#1412 - Trigger 'request' and 'sync' events.", 4, function() {
     var collection = new Backbone.Collection;
     collection.url = '/test';
-    collection.on('sync', function() { ok(true); });
     Backbone.ajax = function(settings){ settings.success(); };
+
+    collection.on('request', function(obj, xhr, options) {
+      ok(obj === collection, "collection has correct 'request' event after fetching");
+    });
+    collection.on('sync', function(obj, response, options) {
+      ok(obj === collection, "collection has correct 'sync' event after fetching");
+    });
     collection.fetch();
+    collection.off();
+
+    collection.on('request', function(obj, xhr, options) {
+      ok(obj === collection.get(1), "collection has correct 'request' event after one of its models save");
+    });
+    collection.on('sync', function(obj, response, options) {
+      ok(obj === collection.get(1), "collection has correct 'sync' event after one of its models save");
+    });
     collection.create({id: 1});
+    collection.off();
   });
 
   test("#1447 - create with wait adds model.", 1, function() {


### PR DESCRIPTION
This behavior wasn't clear to me from the docs.

Might even want to rename the 1st param in the Events Catalog from `model` to `obj` (though I left it as `model` in this PR)
