### PR TITLE
Fixed a minor bug in examples/todos/todos.js

### DIFF
--- a/examples/todos/todos.js
+++ b/examples/todos/todos.js
@@ -211,7 +211,7 @@ $(function(){
 
     // Add all items in the **Todos** collection at once.
     addAll: function() {
-      Todos.each(this.addOne);
+      Todos.each(this.addOne, this);
     },
 
     // If you hit return in the main input field, create new **Todo** model,


### PR DESCRIPTION
AppView.addOne was being called without the correct context from addAll.
The method still worked, since window.$("#todo-list") returns the correct element, 
but it may be confusing for people learning backbone.js.
