### PR TITLE
Fix for #2100

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -195,7 +195,7 @@
       var listeners = this._listeners || (this._listeners = {});
       var id = object._listenerId || (object._listenerId = _.uniqueId('l'));
       listeners[id] = object;
-      object.on(events, callback || this, this);
+      object.on(events, callback || (typeof events == "object" ? this : callback), this);
       return this;
     },
 

--- a/test/events.js
+++ b/test/events.js
@@ -100,6 +100,13 @@ $(document).ready(function() {
     e.trigger("foo");
   });
 
+  test("listenTo with empty callback doesn't throw an error", 1, function(){
+    var e = _.extend({}, Backbone.Events);
+    e.listenTo(e, "foo", null);
+    e.trigger("foo");
+    ok(true);
+  });
+
   test("trigger all for each event", 3, function() {
     var a, b, obj = { counter: 0 };
     _.extend(obj, Backbone.Events);


### PR DESCRIPTION
Ensures the second argument of the `listenTo` is an object before passing "this" as the second parameter (so that empty callbacks on `listenTo` are supported the same as they are with `on`).
