### PR TITLE
Bail from listenTo early.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -192,10 +192,11 @@
     // An inversion-of-control version of `on`. Tell *this* object to listen to
     // an event in another object ... keeping track of what it's listening to.
     listenTo: function(object, events, callback) {
+      if (!callback && _.isString(events)) return this;
       var listeners = this._listeners || (this._listeners = {});
       var id = object._listenerId || (object._listenerId = _.uniqueId('l'));
       listeners[id] = object;
-      object.on(events, callback || (typeof events == "object" ? this : callback), this);
+      object.on(events, callback || this, this);
       return this;
     },
 


### PR DESCRIPTION
Since `on` is a noop without a callback anyway, let's just bail from `listenTo` early.

@tgriesser Thoughts?
