### PR TITLE
Remove old `bind`/`unbind` aliases

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -218,10 +218,6 @@
     }
   };
 
-  // Aliases for backwards compatibility.
-  Events.bind   = Events.on;
-  Events.unbind = Events.off;
-
   // Allow the `Backbone` object to serve as a global event bus, for folks who
   // want global "pubsub" in a convenient place.
   _.extend(Backbone, Events);

--- a/index.html
+++ b/index.html
@@ -691,7 +691,7 @@ object.trigger("alert", "an event");
     </p>
 
     <p id="Events-on">
-      <b class="header">on</b><code>object.on(event, callback, [context])</code><span class="alias">Alias: bind</span>
+      <b class="header">on</b><code>object.on(event, callback, [context])</code>
       <br />
       Bind a <b>callback</b> function to an object. The callback will be invoked
       whenever the <b>event</b> is fired.
@@ -736,7 +736,7 @@ book.on({
 </pre>
 
     <p id="Events-off">
-      <b class="header">off</b><code>object.off([event], [callback], [context])</code><span class="alias">Alias: unbind</span>
+      <b class="header">off</b><code>object.off([event], [callback], [context])</code>
       <br />
       Remove a previously-bound <b>callback</b> function from an object. If no
       <b>context</b> is specified, all of the versions of the callback with


### PR DESCRIPTION
I feel like these are dead weight (very light weight, but nevertheless weight). People who are going to be using `1.0` are unlikely to still be using these...I think.
