### PR TITLE
Documentation Fix: Art.sy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3145,17 +3145,17 @@ var model = localBackbone.Model.extend(...);
     <h2 id="examples-artsy">Art.sy</h2>
 
     <p>
-      <a href="http://art.sy">Art.sy</a> is a place to discover art you'll
+      <a href="http://artsy.net">Art.sy</a> is a place to discover art you'll
       love. Art.sy is built on Rails, using
       <a href="https://github.com/intridea/grape">Grape</a> to serve a robust
-      <a href="http://art.sy/api">JSON API</a>. The main site is a single page
+      <a href="http://artsy.net/api">JSON API</a>. The main site is a single page
       app written in Coffeescript and uses Backbone to provide structure around
       this API. An admin panel and partner CMS have also been extracted into
       their own API-consuming Backbone projects.
     </p>
 
     <div style="text-align: center;">
-      <a href="http://art.sy">
+      <a href="http://artsy.net">
         <img width="550" height="550" data-original="docs/images/artsy.png" alt="Art.sy" class="example_image" />
       </a>
     </div>


### PR DESCRIPTION
Art.sy lost it's .sy domain and is now at http://artsy.net
