### PR TITLE
Pass along ajax details in `sync`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1427,14 +1427,14 @@
 
     var success = options.success;
     options.success = function(resp) {
-      if (success) success(model, resp, options);
-      model.trigger('sync', model, resp, options);
+      if (success) success(model, resp, options, arguments);
+      model.trigger('sync', model, resp, options, arguments);
     };
 
     var error = options.error;
-    options.error = function(xhr) {
-      if (error) error(model, xhr, options);
-      model.trigger('error', model, xhr, options);
+    options.error = function() {
+      if (error) error(model, xhr, options, arguments);
+      model.trigger('error', model, xhr, options, arguments);
     };
 
     // Make the request, allowing the user to override any Ajax options.


### PR DESCRIPTION
Everyone wins this way...

``` js
model.fetch({
  success: function (model, resp, options) {
    options.textStatus; // win
  },
  error: function (model, xhr, options) {
    options.textStatus; // win
    options.errorThrown; // win
  }
});
```

/cc @tgriesser @braddunbar @jashkenas

Reference: http://api.jquery.com/jQuery.ajax/
