### PR TITLE
Add deep comparison support for Collection#where

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -720,7 +720,7 @@
       if (_.isEmpty(attrs)) return [];
       return this.filter(function(model) {
         for (var key in attrs) {
-          if (attrs[key] !== model.get(key)) return false;
+          if (!_.isEqual(attrs[key], model.get(key))) return false;
         }
         return true;
       });

--- a/test/collection.js
+++ b/test/collection.js
@@ -461,13 +461,14 @@ $(document).ready(function() {
     equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });
 
-  test("where", 6, function() {
+  test("where", 7, function() {
     var coll = new Backbone.Collection([
       {a: 1},
       {a: 1},
       {a: 1, b: 2},
       {a: 2, b: 2},
-      {a: 3}
+      {a: 3},
+      {a: {b: {c: 3}}}
     ]);
     equal(coll.where({a: 1}).length, 3);
     equal(coll.where({a: 2}).length, 1);
@@ -475,6 +476,7 @@ $(document).ready(function() {
     equal(coll.where({b: 1}).length, 0);
     equal(coll.where({b: 2}).length, 2);
     equal(coll.where({a: 1, b: 2}).length, 1);
+    equal(coll.where({a: {b: {c: 3}}}).length, 1);
   });
 
   test("Underscore methods", 13, function() {


### PR DESCRIPTION
Sometimes I have nested resources in my API responses and I often find myself trying to search for the whole nested resource.

Let me give you an example if my wording is kinda confusing:

``` coffee
class Check extends Backbone.Model
  unsubscribe: ->
    Subscription.unsubscribe(this)

class Subscription extends Backbone.Model
  # The response looks like `[{id: 1, check: {id: 1}}]`
  @unsubscribe: (check) ->
    _(@collection.where(check: check.attributes)).invoke('destroy')
```

The drawback it that it is slowing down `Collection#where` a bit, but I find it pretty useful. Tell me what you guys think. If you like it I can open a PR for underscore too.
