### PR TITLE
Reverting changes from #2003 and 1f3f45252f

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -362,9 +362,7 @@ $(document).ready(function() {
 
   test("model destroy removes from all collections", 3, function() {
     var e = new Backbone.Model({id: 5, title: 'Othello'});
-    e.sync = function(method, model, options) {
-      options.success(model, [], options);
-    };
+    e.sync = function(method, model, options) { options.success(); };
     var colE = new Backbone.Collection([e]);
     var colF = new Backbone.Collection([e]);
     e.destroy();
@@ -405,7 +403,7 @@ $(document).ready(function() {
     };
     collection.url = '/test';
     collection.fetch();
-    this.syncArgs.options.success([]);
+    this.syncArgs.options.success();
     equal(counter, 1);
   });
 
@@ -702,9 +700,7 @@ $(document).ready(function() {
   test("#1447 - create with wait adds model.", 1, function() {
     var collection = new Backbone.Collection;
     var model = new Backbone.Model;
-    model.sync = function(method, model, options){
-      options.success(model, [], options);
-    };
+    model.sync = function(method, model, options){ options.success(); };
     collection.on('add', function(){ ok(true); });
     collection.create(model, {wait: true});
   });

--- a/test/model.js
+++ b/test/model.js
@@ -401,7 +401,7 @@ $(document).ready(function() {
       if (attrs.admin) return "Can't change admin status.";
     };
     model.sync = function(method, model, options) {
-      options.success.call(this, this, {admin: true}, options);
+      options.success.call(this, {admin: true});
     };
     model.on('invalid', function(model, error) {
       lastError = error;
@@ -435,7 +435,7 @@ $(document).ready(function() {
   test("save in positional style", 1, function() {
     var model = new Backbone.Model();
     model.sync = function(method, model, options) {
-      options.success(model, {}, options);
+      options.success();
     };
     model.save('title', 'Twelfth Night');
     equal(model.get('title'), 'Twelfth Night');
@@ -444,8 +444,8 @@ $(document).ready(function() {
   test("save with non-object success response", 2, function () {
     var model = new Backbone.Model();
     model.sync = function(method, model, options) {
-      options.success(model, '', options);
-      options.success(model, null, options);
+      options.success('', options);
+      options.success(null, options);
     };
     model.save({testing:'empty'}, {
       success: function (model) {
@@ -720,7 +720,7 @@ $(document).ready(function() {
   test("#1030 - `save` with `wait` results in correct attributes if success is called during sync", 2, function() {
     var model = new Backbone.Model({x: 1, y: 2});
     model.sync = function(method, model, options) {
-      options.success(model, {}, options);
+      options.success();
     };
     model.on("change:x", function() { ok(true); });
     model.save({x: 3}, {wait: true});
@@ -893,7 +893,7 @@ $(document).ready(function() {
       }
     };
     model.sync = function(method, model, options) {
-      options.success(model, {}, options);
+      options.success();
     };
     model.save({id: 1}, opts);
     model.fetch(opts);
@@ -902,9 +902,8 @@ $(document).ready(function() {
 
   test("#1412 - Trigger 'sync' event.", 3, function() {
     var model = new Backbone.Model({id: 1});
-    model.url = '/test';
+    model.sync = function (method, model, options) { options.success(); }
     model.on('sync', function(){ ok(true); });
-    Backbone.ajax = function(settings){ settings.success(); };
     model.fetch();
     model.save();
     model.destroy();
@@ -950,7 +949,7 @@ $(document).ready(function() {
     var Model = Backbone.Model.extend({
       sync: function(method, model, options) {
         setTimeout(function(){
-          options.success(model, {}, options);
+          options.success();
           start();
         }, 0);
       }
@@ -1068,6 +1067,24 @@ $(document).ready(function() {
       ok(true);
     });
     model.set({a: true});
+  });
+
+  test("Backbone.wrapError triggers `'error'`", 18, function() {
+    var resp = {};
+    var options = {};
+    var model = new Backbone.Model();
+    model.on('error', error);
+    var callback = Backbone.wrapError(null, model, options);
+    callback(model, resp);
+    callback(resp);
+    callback = Backbone.wrapError(error, model, options);
+    callback(model, resp);
+    callback(resp);
+    function error(_model, _resp, _options) {
+      ok(model === _model);
+      ok(resp === _resp);
+      ok(options === _options);
+    }
   });
 
 });


### PR DESCRIPTION
The changes in 1f3f45252f were made to consolidate the `error` and `success` handlers to be called/triggered within `Backbone.sync` function. This change makes the other collection/model methods DRY-er internally, but it also encapsulates the event triggers within `Backbone.sync`, making it more difficult to create custom `sync` handlers directly on the model/collection for cases where the default Backbone sync behavior isn't desired.

A good example would be a case where an application is interacting with multiple api's at once - where most models are using a traditional path with correct http codes and response formats, but one is passing through a json-p endpoint where everything returns a 200, and the error code/response is contained in the response. 

Previously you'd only need to extend sync like so:

``` js
model.sync: function (method, model, options) {
   var success = options.success;
   return Backbone.sync(method, model, _.extend(options, {
     dataType: 'jsonp',
     success: function (data, status, xhr) {
        options.success = success;
        var method = (data.code !== 200) ? 'error' : 'success';
        options[method](data.content);
     }
   });
}
```

now, you need to also take care of the trigger, and prevent the "sync" event/success handlers which are now is now called internally. To get the same functionality you'd effectively need to add something like this:

``` js
var methodMap = {
  'create': 'POST',
  'update': 'PUT',
  'patch':  'PATCH',
  'delete': 'DELETE',
  'read':   'GET'
};
var urlError = function () {
  throw new Error('A "url" property or function must be specified');
};
model.sync: function (method, model, options) { 
   var success = options.success;
   return $.ajax(_.extend(options, {
     type: methodMap[method],
     url: _.result(model, 'url') || urlError(),
     contentType: 'application/json',
     dataType: 'jsonp',
     success: function (data, status, xhr) {
        var method = (data.code !== 200) ? 'error' : 'success';
        options[method](data.content);
        options.success = success;
        if (method === 'error') {
          model.trigger('error', model, xhr, options);
        } else {
          model.trigger('sync', model, resp, options);
        }
     }
   }));
}
```

The same functionality which was just a few lines previously is now much more work to patch, basically requiring a new sync implementation - and if more functionality is moved at some point out of the individual methods and into the Backbone.sync handler, the developer needs to add more code to create these custom handlers. The `Backbone.wrapError` (while undocumented as a public API) served as a convenient place to centralize any error logic, keeping everything else contained in the methods themselves.

The changes from #2003 were aiming to standardize the arguments to make Backbone more "agnostic" with regards to the sync handler, but it seems to complicate the api unnecessarily - of the (`resp`, `status`, `xhr`), the `resp` is the only argument used by Backbone internally. So as long as the first argument is a valid object, any type of sync handler can be dropped in without issue.

I could go for keeping 1f3f452 if the argument for keeping these pieces outside of the "Backbone.sync" handler isn't strong enough, but #2003 seems to be a step backward for keeping the "sync" simple, with the need to [pass along an options object](https://github.com/documentcloud/backbone/pull/2005/files#L2L677) and model rather than shadowing them from the function calling sync.

Related: #2161, #2140, #2031, #2145, #2094

If this is something we want to eventually merge, I can update the docs as well.

/cc @kpdecker
