### PR TITLE
Collection.get with id and cid for a model which has id not set

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -606,7 +606,7 @@
 
         // If a duplicate is found, prevent it from being added and
         // optionally merge it into the existing model.
-        if (existing = this.get(model)) {
+        if (existing = this.get(attrs)) {
           if (options.merge) {
             existing.set(attrs === model ? model.attributes : attrs, options);
             if (sort && !doSort && existing.hasChanged(sortAttr)) doSort = true;

--- a/test/collection.js
+++ b/test/collection.js
@@ -249,6 +249,14 @@ $(document).ready(function() {
     equal(col.indexOf(tom), 2);
   });
 
+  test("add with id and cid where the model has no id", function() {
+    var m = new Backbone.Model({key: 'value'});
+    var c = new Backbone.Collection([m]);
+    c.add([{id: 1, cid: m.cid}], {merge: true});
+    equal(c.length, 1);
+    equal(c.get(1), m);
+  });
+
   test("comparator that depends on `this`", 2, function() {
     var col = new Backbone.Collection;
     col.negative = function(num) {
@@ -933,6 +941,14 @@ $(document).ready(function() {
     col.update({id: 1, other: 'value'});
     equal(col.first().get('key'), 'other');
     equal(col.length, 1);
+  });
+
+  test("update with id and cid where the model has no id", function() {
+    var m = new Backbone.Model({key: 'value'});
+    var c = new Backbone.Collection([m]);
+    c.update([{id: 1, cid: m.cid}]);
+    equal(c.length, 1);
+    equal(c.get(1), m);
   });
 
   test("#1894 - Push should not trigger a sort", 0, function() {


### PR DESCRIPTION
I tried to use `coll.get({id:XY, cid:'cXY'})` for a model present in the collection which hasn't the id set. Get does not return any value in this case. Found a simple fix, test is added to the commit as well.
