### PR TITLE
Add event priority

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -66,6 +66,7 @@
 
   // Regular expression used to split event strings.
   var eventSplitter = /\s+/;
+  var prioritySplitter = '!';
 
   // Implement fancy features of the Events API such as multiple event
   // names `"change blur"` and jQuery-style event maps `{change: action}`
@@ -121,8 +122,14 @@
     on: function(name, callback, context) {
       if (!eventsApi(this, 'on', name, [callback, context]) || !callback) return this;
       this._events || (this._events = {});
+      var ev = {callback: callback, context: context, ctx: context || this};
+      var split = name.split(prioritySplitter);
+      name = split[0];
+      var priority = ev.priority = +split[1] || 0;
       var events = this._events[name] || (this._events[name] = []);
-      events.push({callback: callback, context: context, ctx: context || this});
+      var i = _.sortedIndex(events, ev, 'priority'), l = events.length;
+      while (i < l && priority === events[i].priority) ++i;
+      events.splice(i, 0, ev);
       return this;
     },
 

--- a/test/events.js
+++ b/test/events.js
@@ -400,4 +400,16 @@ $(document).ready(function() {
     _.extend({}, Backbone.Events).once('event').trigger('event');
   });
 
+  test("event priority", function () {
+    var obj = _.extend({}, Backbone.Events);
+    var p = '';
+    obj.on({
+      event: function () { p += '3'; },
+      'event!-2': function () { p += '1'; },
+      'event!1': function () { p += '5'; },
+      'event!-1': function () { p += '2'; },
+    }).on('event', function () { p += '4'; }).trigger('event event');
+    equal(p, '1234512345');
+  });
+
 });


### PR DESCRIPTION
Sparked by #2163, the order in which event callbacks are invoked is completely depending on the order in which they are added. This patch would allow events to be given a priority where the higher priority callbacks are invoked first.

``` js
model.on('change:name', function () {}); // normal, doesn't care about order
model.on('change:name!-1', function () {}); // before 'change:name'
model.on('change:name!1', function () {}); // after 'change:name'
model.on('change:name!-2', function () {}); // even before the 'change:name!-1'
```

Let's chat. Is this valuable or not worth the overhead?
