### PR TITLE
Throw an error if the callback parameter is missing in Events.prototype.on and Events.prototype.once

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -119,7 +119,9 @@
     // to a `callback` function. Passing `"all"` will bind the callback to
     // all events fired.
     on: function(name, callback, context) {
-      if (!eventsApi(this, 'on', name, [callback, context]) || !callback) return this;
+      if (!callback && !_.isObject(name)) throw new Error('Missing callback parameter');
+
+      if (!eventsApi(this, 'on', name, [callback, context])) return this;
       this._events || (this._events = {});
       var events = this._events[name] || (this._events[name] = []);
       events.push({callback: callback, context: context, ctx: context || this});
@@ -129,7 +131,9 @@
     // Bind events to only be triggered a single time. After the first time
     // the callback is invoked, it will be removed.
     once: function(name, callback, context) {
-      if (!eventsApi(this, 'once', name, [callback, context]) || !callback) return this;
+      if (!callback && !_.isObject(name)) throw new Error('Missing callback parameter');
+
+      if (!eventsApi(this, 'once', name, [callback, context])) return this;
       var self = this;
       var once = _.once(function() {
         self.off(name, once);

--- a/test/events.js
+++ b/test/events.js
@@ -115,11 +115,11 @@ $(document).ready(function() {
     e.trigger("foo");
   });
 
-  test("listenTo with empty callback doesn't throw an error", 1, function(){
+  test("listenTo with empty callback throw an error", 1, function(){
     var e = _.extend({}, Backbone.Events);
-    e.listenTo(e, "foo", null);
-    e.trigger("foo");
-    ok(true);
+    throws(function(){
+      e.listenTo(e, "foo", null);
+    }, "Missing callback parameter");
   });
 
   test("trigger all for each event", 3, function() {
@@ -237,8 +237,11 @@ $(document).ready(function() {
     strictEqual(counter, 2);
   });
 
-  test("if no callback is provided, `on` is a noop", 0, function() {
-    _.extend({}, Backbone.Events).on('test').trigger('test');
+  test("if no callback is provided, `on` throws an error", 1, function() {
+    var dispatcher = _.extend({}, Backbone.Events);
+    throws(function() {
+      dispatcher.on('test');
+    }, "Missing callback parameter");
   });
 
   test("remove all events for a specific context", 4, function() {
@@ -396,8 +399,11 @@ $(document).ready(function() {
     Backbone.trigger('all');
   });
 
-  test("once without a callback is a noop", 0, function() {
-    _.extend({}, Backbone.Events).once('event').trigger('event');
+  test("once without a callback throws an error", 1, function() {
+    var dispatcher = _.extend({}, Backbone.Events);
+    throws(function() {
+      dispatcher.once('event');
+    }, 'Missing callback parameter');
   });
 
 });


### PR DESCRIPTION
Rationale:
- As stated by @jashkenas in #1008 binding a event without passing a callback is "an error by definition".
- "Errors should never pass silently".
- If I reference a method that do not exists in a view `events` hash,
  it will throw and error when I instanciate the view, and I'll fix that issue in a minute.
- Before #1008 a typo like `.on('change', this.rander, this)` would have thrown an error quickly.
  Now since 0.9.9 these typos became a noop, so the only way to spot this kind of issues is to wonder
  why your callback is never called.

I know this is a backward incompatible change, but it will only break dead code writen for 0.9.9 or 0.9.10.
