### PR TITLE
Improve consistency: get rid of "a zealous early error breaking apps in inconvenient ways"

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1311,7 +1311,10 @@
       for (var key in events) {
         var method = events[key];
         if (!_.isFunction(method)) method = this[events[key]];
-        if (!method) throw new Error('Method "' + events[key] + '" does not exist');
+
+        // Ignore error if the method is not defined
+        if (!method) continue;
+
         var match = key.match(delegateEventSplitter);
         var eventName = match[1], selector = match[2];
         method = _.bind(method, this);

--- a/test/events.js
+++ b/test/events.js
@@ -273,6 +273,13 @@ $(document).ready(function() {
     _.extend({}, Backbone.Events).on('test').trigger('test');
   });
 
+  test("if callback is truthy but not a function, `on` should throws an error just like jQuery", 1, function() {
+    var view = _.extend({}, Backbone.Events).on('test', 'noop');
+    throws(function() {
+      view.trigger('test');
+    });
+  });
+
   test("remove all events for a specific context", 4, function() {
     var obj = _.extend({}, Backbone.Events);
     obj.on('x y all', function() { ok(true); });

--- a/test/view.js
+++ b/test/view.js
@@ -85,6 +85,13 @@ $(document).ready(function() {
     equal(view.counter, 3);
   });
 
+
+  test("delegateEvents ignore undefined methods", 0, function() {
+    var view = new Backbone.View({el: '<p></p>'});
+    view.delegateEvents({'click': 'undefinedMethod'});
+    view.$el.trigger('click');
+  });
+
   test("undelegateEvents", 6, function() {
     var counter1 = 0, counter2 = 0;
 


### PR DESCRIPTION
Since jQuery.on() and Backbone.Events.on are silently ignoring invalid callbacks,
Backbone.View.delegateEvents should too.

See #2184 for previous discussion about how Backbone is supposed to behave on obvious developer errors
