### PR TITLE
Clarified Collection.create documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1958,9 +1958,9 @@ Accounts.fetch();
       Equivalent to instantiating a model with a hash of attributes,
       saving the model to the server, and adding the model to the set after being
       successfully created. Returns
-      the model, or <tt>false</tt> if a validation error prevented the
-      model from being created. Pass <tt>{validate: true}</tt> if you'd like validation
-      to run on the model. In order for this to work, you should set the
+      the model, or <tt>false</tt> if you pass <tt>{validate: true}</tt>
+      and a validation error prevented the model from being created. In order
+      for this to work, you should set the
       <a href="#Collection-model">model</a> property of the collection.
       The <b>create</b> method can accept either an attributes hash or an
       existing, unsaved model object.


### PR DESCRIPTION
## Description

In the current documentation for `Collection.create`, it is stated that `false` will be returned if model validation fails.

I've clarified that you must pass the `{validation: true}` option in order for `create` to return false if model validation fails.

Currently, unless a developer dives fairly deep into the code, it isn't clear from the documentation why `create` will return a model event if model validation fails.
## Code References

Here the `Collection._prepareModel` method determines wether to return an instance of the model or `false`, depending on the result of `Model._validate`.

https://github.com/hiwaylon/backbone/blob/master/backbone.js#L871

Here the `Model._validate` method checks the `validate` option and the existence of the `validate` method on the model. Only if both are `true` will it run validation.

https://github.com/hiwaylon/backbone/blob/master/backbone.js#L545
