### PR TITLE
Collection#create returns result from Model#save

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -871,16 +871,17 @@
     // wait for the server to agree.
     create: function(model, options) {
       options = options ? _.clone(options) : {};
-      if (!(model = this._prepareModel(model, options))) return false;
-      if (!options.wait) this.add(model, options);
+      if (!(model = this._prepareModel(model, options))) return Backbone.Deferred.reject();
+      if (!options.wait) model = this.add(model, options);
       var collection = this;
       var success = options.success;
       options.success = function(resp) {
-        if (options.wait) collection.add(model, options);
+        if (options.wait) model = collection.add(model, options);
         if (success) success(model, resp, options);
       };
-      model.save(null, options);
-      return model;
+      return model.save(null, options).then(function() {
+         return model;
+      });
     },
 
     // **parse** converts a response into a list of models to be added to the


### PR DESCRIPTION
It feels natural that all asynchronous methods return an xhr. `create` is, as far as I can see, the only one that does not. I can see the value in it returning a model, as it might be created from an object within `create`, but I feel returning an xhr leads to a better API. It's also more consistent with the other async methods. If the model is needed directly after `create` is called instead of when the event is triggered, I think it's better to create it yourself, call save on it and add it to the collection.

I have not fixed the failing tests as I thought I'd first see what you guys think. (I didn't find any earlier discussion on it, but that might just be my limited searching skills.)

Any thoughts?
