### PR TITLE
Bugfix to tests for Backbone.Collection underscore methods.

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -487,10 +487,10 @@ $(document).ready(function() {
     equal(col.indexOf(b), 1);
     equal(col.size(), 4);
     equal(col.rest().length, 3);
-    ok(!_.include(col.rest()), a);
-    ok(!_.include(col.rest()), d);
+    ok(!_.include(col.rest(), a));
+    ok(_.include(col.rest(), d));
     ok(!col.isEmpty());
-    ok(!_.include(col.without(d)), d);
+    ok(!_.include(col.without(d), d));
     equal(col.max(function(model){ return model.id; }).id, 3);
     equal(col.min(function(model){ return model.id; }).id, 0);
     deepEqual(col.chain()


### PR DESCRIPTION
Unless I'm missing something obvious in what these tests are supposed to test, it looks like `_.include` was not being called correctly in the tests for underscore methods on Backbone.Collection, with the result that the behaviour of _.without and _.rest were not correctly tested.
