### PR TITLE
Disabled replace option in Backbone.History for android webkit browsers

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1062,6 +1062,9 @@
   // Has the history handling already been started?
   History.started = false;
 
+  // Is this Android webkit
+  var isAndroidWebkit   = (/Android(?!.*Chrome).*/.exec(navigator.userAgent.toLowerCase()));
+
   // Set up all inheritable **Backbone.History** properties and methods.
   _.extend(History.prototype, Events, {
 
@@ -1232,7 +1235,7 @@
     // Update the hash location, either replacing the current entry, or adding
     // a new one to the browser history.
     _updateHash: function(location, fragment, replace) {
-      if (replace) {
+      if (replace && !isAndroidWebkit) {
         var href = location.href.replace(/(javascript:|#).*$/, '');
         location.replace(href + '#' + fragment);
       } else {


### PR DESCRIPTION
The standard android webkit browser ( not Chrome ) does not support location.replace(), even though it exposes the function. Calling it does nothing. This means that calling

``` javascript
myRouter.navigate('anyvalue', {replace: true});
```

fails on android browsers (nothing happens). This patch makes android browsers fall back to normal hash navigations as if the replace option was false. The consequence is that there will be an extra history item, but everything else will be working as expected.
