### PR TITLE
Update `parse`s at model level, simpler `get`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -719,8 +719,7 @@
     // Get a model from the set by id.
     get: function(obj) {
       if (obj == null) return void 0;
-      this._idAttr || (this._idAttr = this.model.prototype.idAttribute);
-      return this._byId[obj.id || obj.cid || obj[this._idAttr] || obj];
+      return this._byId[obj.id || obj.cid || obj];
     },
 
     // Get the model at the given index.
@@ -776,7 +775,7 @@
     update: function(models, options) {
       options = _.extend({add: true, merge: true, remove: true}, options);
       if (options.parse) models = this.parse(models, options);
-      var model, i, l, existing;
+      var attrs, model, i, l, existing;
       var add = [], remove = [], modelMap = {};
 
       // Allow a single model (or no argument) to be passed.
@@ -787,11 +786,14 @@
 
       // Determine which models to add and merge, and which to remove.
       for (i = 0, l = models.length; i < l; i++) {
-        model = models[i];
+        if (!(model = this._prepareModel(attrs = models[i], options))) {
+          this.trigger('invalid', this, attrs, options);
+          continue;
+        }
         existing = this.get(model);
         if (options.remove && existing) modelMap[existing.cid] = true;
         if ((options.add && !existing) || (options.merge && existing)) {
-          add.push(model);
+          add.push(attrs);
         }
       }
       if (options.remove) {

--- a/test/collection.js
+++ b/test/collection.js
@@ -70,22 +70,20 @@ $(document).ready(function() {
     equal(col.get(col.first().cid), col.first());
   });
 
-  test("get with non-default ids", 4, function() {
+  test("get with non-default ids", 5, function() {
     var col = new Backbone.Collection();
-    var MongoModel = Backbone.Model.extend({
-      idAttribute: '_id'
-    });
+    var MongoModel = Backbone.Model.extend({idAttribute: '_id'});
     var model = new MongoModel({_id: 100});
-    col.push(model);
+    col.add(model);
     equal(col.get(100), model);
-    model.set({_id: 101});
-    equal(col.get(101), model);
+    equal(col.get(model.cid), model);
+    equal(col.get(model), model);
+    equal(col.get(101), void 0);
 
-    var Col2 = Backbone.Collection.extend({ model: MongoModel });
-    var col2 = new Col2();
-    col2.push(model);
-    equal(col2.get({_id: 101}), model);
-    equal(col2.get(model.clone()), model);
+    var col2 = new Backbone.Collection();
+    col2.model = MongoModel;
+    col2.add(model.attributes);
+    equal(col2.get(model.clone()), col2.first());
   });
 
   test("update index when id changes", 3, function() {
@@ -934,6 +932,23 @@ $(document).ready(function() {
     col.update({id: 1, other: 'value'});
     equal(col.first().get('key'), 'other');
     equal(col.length, 1);
+  });
+
+  test("`update` and model level `parse`", function() {
+    var Model = Backbone.Model.extend({
+      parse: function (res) { return res.model; }
+    });
+    var Collection = Backbone.Collection.extend({
+      model: Model,
+      parse: function (res) { return res.models; }
+    });
+    var model = new Model({id: 1});
+    var collection = new Collection(model);
+    collection.update({models: [
+      {model: {id: 1}},
+      {model: {id: 2}}
+    ]}, {parse: true});
+    equal(collection.first(), model);
   });
 
   test("#1894 - Push should not trigger a sort", 0, function() {


### PR DESCRIPTION
Assuming simple response data at the model level isn't as reliable as I initially thought. This patch would fix #2095 (check the added test) as well as address some recent `get` complications #2247 #2189 #2091 etc by simplifying it to only accept a single `id`, `cid`, or `model` (no raw data).

The downside is that there will be an initialization for each model, regardless of whether it is going to be added or merged to the collection. However, `update` has never needed to be blazing fast, so I don't see this as much of an issue.
