### PR TITLE
Fix bug with `add(models, {parse: true, merge: true}`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -239,6 +239,7 @@
     this.attributes = {};
     if (options && options.collection) this.collection = options.collection;
     if (options && options.parse) attrs = this.parse(attrs, options) || {};
+    if (options) options.attrs = attrs;
     if (defaults = _.result(this, 'defaults')) {
       attrs = _.defaults({}, attrs, defaults);
     }
@@ -615,7 +616,8 @@
         if (existing = this.get(model)) {
           modelMap[existing.cid] = true;
           if (options.merge) {
-            existing.set(attrs === model ? model.attributes : attrs, options);
+            attrs = attrs === model ? model.attributes : options.attrs;
+            existing.set(attrs, options);
             if (sort && !doSort && existing.hasChanged(sortAttr)) doSort = true;
           }
           continue;

--- a/test/collection.js
+++ b/test/collection.js
@@ -224,6 +224,19 @@ $(document).ready(function() {
     equal(col.at(0).get('value'), 2);
   });
 
+  test("add with parse and merge", function() {
+    var Model = Backbone.Model.extend({
+      parse: function (data) {
+        return data.model;
+      }
+    });
+    var collection = new Backbone.Collection();
+    collection.model = Model;
+    collection.add({id: 1});
+    collection.add({model: {id: 1, name: 'Alf'}}, {parse: true, merge: true});
+    equal(collection.first().get('name'), 'Alf');
+  });
+
   test("add model to collection with sort()-style comparator", 3, function() {
     var col = new Backbone.Collection;
     col.comparator = function(a, b) {


### PR DESCRIPTION
This is a simple fix to the problem. Another approach would be to rework how `_prepareModel` works with `parse: true` to ensure the parsed data can be reached from outside the model `constructor`, most importantly in `add`.
