### PR TITLE
Model.clone() overwrites null attributes if default attribute value exists

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -530,7 +530,9 @@
 
     // Create a new model with identical attributes to this one.
     clone: function() {
-      return new this.constructor(this.attributes);
+      var clone = new this.constructor();
+      clone.set(this.attributes);
+      return clone;
     },
 
     // A model is new if it has never been saved to the server, and lacks an id.

--- a/test/model.js
+++ b/test/model.js
@@ -1082,4 +1082,19 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test("clone should be equivalent to parent model", 1, function() {
+    var Model = Backbone.Model.extend({
+      "defaults": {
+        'a': 1,
+        'b': null
+      }
+    });
+
+    var model = new Model();
+    model.set({ 'a': null, 'b': 1});
+
+    var clone = model.clone();
+    deepEqual(clone.attributes, model.attributes);
+  });
+
 });


### PR DESCRIPTION
The following seems like unexpected behavior and is causing some issues for us:

``` js
var Model = Backbone.Model.extend({'a': 1});
var model = new Model();
model.set('a', null); // model.attributes is now { 'a': null }
var clone = model.clone(); // clone.attributes is now { 'a': 1 }
```
