### PR TITLE
Use update internally in Collection#add 

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -410,7 +410,7 @@ $(document).ready(function() {
     };
     collection.url = '/test';
     collection.fetch();
-    this.syncArgs.options.success({foo: 'bar'});
+    this.syncArgs.options.success();
     equal(counter, 1);
   });
 
@@ -1011,7 +1011,7 @@ $(document).ready(function() {
     }));
     var ajax = Backbone.ajax;
     Backbone.ajax = function (params) {
-      _.defer(params.success, {foo: 'bar'});
+      _.defer(params.success);
       return {someHeader: 'headerValue'};
     };
     collection.fetch({


### PR DESCRIPTION
Per the discussion on [#2261](https://github.com/documentcloud/backbone/pull/2261/files#r2983581), this is a first stab at offloading the model manipulation logic from `Collection#add` to a more centralized change hub at `Collection#update`.

All tests currently pass, but if you can think of any that would break in this implementation, let's be sure to account for it.
