### PR TITLE
Fix Model#isValid

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -542,12 +542,12 @@
 
     // Check if the model is currently in a valid state.
     isValid: function(options) {
-      return !this.validate || !this.validate(this.attributes, options);
+      return this._validate({}, _.extend(options || {}, { validate: true }));
     },
 
     // Run validation against the next complete set of model attributes,
     // returning `true` if all is well. Otherwise, fire an
-    // `"invalid"` event and call the invalid callback, if specified.
+    // `"invalid"` event and return `false`.
     _validate: function(attrs, options) {
       if (!options.validate || !this.validate) return true;
       attrs = _.extend({}, this.attributes, attrs);

--- a/index.html
+++ b/index.html
@@ -335,6 +335,7 @@
       <li>– <a href="#Model-destroy">destroy</a></li>
       <li>– <a href="#Model-validate">validate</a></li>
       <li>– <a href="#Model-validationError">validationError</a></li>
+      <li>– <a href="#Model-isValid">isValid</a></li>
       <li>– <a href="#Model-url">url</a></li>
       <li>– <a href="#Model-urlRoot">urlRoot</a></li>
       <li>– <a href="#Model-parse">parse</a></li>
@@ -1235,7 +1236,7 @@ book.save({author: "Teddy"});
       <b>save</b> accepts <tt>success</tt> and <tt>error</tt> callbacks in the
       options hash, which are passed <tt>(model, response, options)</tt> and
       <tt>(model, xhr, options)</tt> as arguments, respectively.
-      If a server-side validation fails, return a non-<tt>200</tt> 
+      If a server-side validation fails, return a non-<tt>200</tt>
       HTTP response code, along with an error response in text or JSON.
     </p>
 
@@ -1320,6 +1321,35 @@ one.save({
       <br />
       The value returned by <a href="#Model-validate">validate</a> during the last failed validation.
     </p>
+
+    <p id="Model-isValid">
+      <b class="header">isValid</b><code>model.isValid</code>
+      <br />
+      Run <a href="#Model-validate">validate</a> to check the model state.
+    </p>
+
+<pre class="runnable">
+var Chapter = Backbone.Model.extend({
+  validate: function(attrs, options) {
+    if (attrs.end &lt; attrs.start) {
+      return "can't end before it starts";
+    }
+  }
+});
+
+var one = new Chapter({
+  title : "Chapter One: The Beginning"
+});
+
+one.set({
+  start: 15,
+  end:   10
+});
+
+if (!one.isValid()) {
+  alert(one.get("title") + " " + one.validationError);
+}
+</pre>
 
     <p id="Model-url">
       <b class="header">url</b><code>model.url()</code>
@@ -1746,7 +1776,7 @@ var book = Library.get(110);
       <b class="header">slice</b><code>collection.slice(begin, end)</code>
       <br />
       Return a shallow copy of this collection's models, using the same options as
-      native 
+      native
       <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/slice">Array#slice</a>.
     </p>
 
@@ -3828,6 +3858,9 @@ ActiveRecord::Base.include_root_in_json = false
         <tt>Model#save</tt> and no longer enforced by default upon
         construction or in <tt>Model#set</tt>, unless the <tt>{validate:true}</tt>
         option is passed.
+      </li>
+      <li>
+        <tt>Model#isValid</tt> works harmoniously with the rest of the validation system.
       </li>
       <li>
         <tt>View#make</tt> has been removed. You'll need to use <tt>$</tt> directly to


### PR DESCRIPTION
`Model#isValid` now runs the internal `Model#_validate` method. Also added to docs.
