### PR TITLE
Fixed to pass with edge version of Underscore

### DIFF
--- a/test/model.js
+++ b/test/model.js
@@ -324,7 +324,7 @@ $(document).ready(function() {
         "two": 2
       }
     });
-    var model = new Defaulted();
+    var model = new Defaulted({two: undefined});
     equal(model.get('one'), 1);
     equal(model.get('two'), 2);
     Defaulted = Backbone.Model.extend({
@@ -335,7 +335,7 @@ $(document).ready(function() {
         };
       }
     });
-    model = new Defaulted();
+    model = new Defaulted({two: undefined});
     equal(model.get('one'), 3);
     equal(model.get('two'), 4);
   });


### PR DESCRIPTION
Due to changes in https://github.com/documentcloud/underscore/commit/0ab5bdccd41e55fb02331ec7d2d0053e0bdac9e3 need to fix `Backbone.Model` test. It would be helpful because some people may use Backbone's unit tests in their Backbone-related projects (plugins for example).
