### PR TITLE
Add changelog entries for 'invalid' event

### DIFF
--- a/index.html
+++ b/index.html
@@ -664,6 +664,10 @@
         The <tt>Model#change</tt> method has been removed, as delayed attribute
         changes are no longer available.
       </li>
+      <li>
+        Model validation now fires <tt>invalid</tt> event instead of
+        <tt>error</tt>.
+      </li>
     </ul>
 
     <h2 id="Events">Backbone.Events</h2>
@@ -3851,6 +3855,10 @@ ActiveRecord::Base.include_root_in_json = false
       </li>
       <li>
         <tt>parse</tt> now receives <tt>options</tt> as its second argument.
+      </li>
+      <li>
+        Model validation now fires <tt>invalid</tt> event instead of
+        <tt>error</tt>.
       </li>
     </ul>
 


### PR DESCRIPTION
Hi,

Noticed that 'error' callbacks stopped working (for client side model validations) after upgrading and couldn't find anything mentioning this in the changelog.

Related to b76ca8338bf4d962e18aa951380084e0d529caad
