### PR TITLE
Fire 'invalid' callback when _validate fails

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -879,6 +879,7 @@
       options.collection = this;
       var model = new this.model(attrs, options);
       if (!model._validate(attrs, options)) {
+        this.trigger('invalid', this, attrs, options);
         return false;
       }
       return model;


### PR DESCRIPTION
This is the behavior described in the comment for _validate and also makes it consistent with the handling of server errors through the 'error' callback.  Discussion about this began here: https://github.com/documentcloud/backbone/pull/2280
