### PR TITLE
In tests, I tweaked model.parse(opt) to be model.parse(attrs) for descriptiveness

### DIFF
--- a/test/model.js
+++ b/test/model.js
@@ -46,9 +46,9 @@ $(document).ready(function() {
 
   test("initialize with parsed attributes", 1, function() {
     var Model = Backbone.Model.extend({
-      parse: function(obj) {
-        obj.value += 1;
-        return obj;
+      parse: function(attrs) {
+        attrs.value += 1;
+        return attrs;
       }
     });
     var model = new Model({value: 1}, {parse: true});
@@ -69,8 +69,8 @@ $(document).ready(function() {
 
   test("parse can return null", 1, function() {
     var Model = Backbone.Model.extend({
-      parse: function(obj) {
-        obj.value += 1;
+      parse: function(attrs) {
+        attrs.value += 1;
         return null;
       }
     });


### PR DESCRIPTION
I was looking through the tests to get a better understanding of backbone.  I figured the tests would be a great source of documentation for the granular aspects.  :)

For the model parse() tests, I saw that the input arg was `obj`.  I thought `attrs` would be a bit more descriptive.  This makes it align with the source.  What do you guys think?  

In the end, this is a very microscopic change, but this is my first commit to open source, so I figured I'd try to see what happens!  :)
