### PR TITLE
Guard against undefined options in Model#_validate

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -547,7 +547,7 @@
     // returning `true` if all is well. Otherwise, fire an
     // `"invalid"` event and call the invalid callback, if specified.
     _validate: function(attrs, options) {
-      if (!options.validate || !this.validate) return true;
+      if (!options || !options.validate || !this.validate) return true;
       attrs = _.extend({}, this.attributes, attrs);
       var error = this.validationError = this.validate(attrs, options) || null;
       if (!error) return true;


### PR DESCRIPTION
Was playing around with the internals and forgot to pass up the `options` object to `_validate`. Got a `ReferenceError`.
