### PR TITLE
Improve Travis-CI Badge Rendering in Docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,9 @@
     a img {
       border: 0;
     }
+    a[href^='https://travis-ci'] {
+      display: block;
+    }
     h1, h2, h3, h4, h5, h6 {
       padding-top: 20px;
     }
@@ -561,7 +564,7 @@
         <td>
           <i>Unreleased, use at your own risk</i>
           <a href="https://travis-ci.org/documentcloud/backbone">
-            <img width="89" height="13" src="https://travis-ci.org/documentcloud/backbone.png" />
+            <img src="https://travis-ci.org/documentcloud/backbone.png" />
           </a>
         </td>
       </tr>


### PR DESCRIPTION
- destretch by removing dimensions, also future proofs size changes
- forcibly move to next line
- uses css attr selector, other strategies may be better

![Screen Shot 2013-02-26 at 8 26 16 PM](https://f.cloud.github.com/assets/3456/199473/718a3044-8085-11e2-8467-23f733e02e1e.png)
