### PR TITLE
Do not undelegate previous events

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1312,7 +1312,6 @@
     // not `change`, `submit`, and `reset` in Internet Explorer.
     delegateEvents: function(events) {
       if (!(events || (events = _.result(this, 'events')))) return this;
-      this.undelegateEvents();
       for (var key in events) {
         var method = events[key];
         if (!_.isFunction(method)) method = this[events[key]];


### PR DESCRIPTION
I want to programmatically add event handlers to a view.

I tend to do this a lot (just using `jQuery.fn.on`), but my current specific use case is extending a some different views with common share functionality without resorting to inheritance. I can't just extend the view's existing `events` hash because of key collisions (same event and selector).

Currently `View#delegateEvents` calls `View#undelegateEvents` first, making it impossible to add additional handlers on top of existing ones. In this pull request, I've removed the call.

I know that this needs tests and documentation changes, but I wanted to gauge interest first before I commit more time.
