### PR TITLE
Backbone assumes that Backbone.ajax will be asynchronous.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1434,8 +1434,8 @@
     }
 
     // Make the request, allowing the user to override any Ajax options.
-    var xhr = options.xhr = Backbone.ajax(_.extend(params, options));
     model.trigger('request', model, xhr, options);
+    var xhr = options.xhr = Backbone.ajax(_.extend(params, options));
     return xhr;
   };
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -155,6 +155,25 @@ $(document).ready(function() {
     Backbone.sync('create', model);
   });
 
+	test("Asynchronous and synchronous Backbone.ajax method should fire 'request' event before the 'sync' event.", function() {
+		var collection = new Backbone.Collection;
+		var requestEventFired = false;
+
+		collection.url = '/test';
+		Backbone.ajax = function(settings){
+			return settings.success();
+		};
+
+		collection.on('request', function() {
+			ok(!requestEventFired, "request fired in order");
+			requestEventFired = true;
+		});
+		collection.on('sync', function() {
+			ok(requestEventFired, "sync fired in order");
+		});
+		collection.fetch();
+	});
+
   test("Call provided error callback on error.", 1, function() {
     var model = new Backbone.Model;
     model.url = '/test';


### PR DESCRIPTION
Backbone assumes that Backbone.ajax will be an asynchronous method. In the case of a user supplied Backbone.ajax method that caches requests in memory (and returns cached results) or performs some other logic that returns immediately, the 'sync' event will be fired before the 'request' event. It seems logical that the 'request' event should be fired before the request is actually performed. As documented, the current implementation makes sense unless the scenario as described occurs. This might suggest that the 'request' event is indeed correct in its current form and that another event 'beforeRequest' might be more appropriate.
