### PR TITLE
Copy url from options in the Collection constructor

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -567,6 +567,7 @@
   // its models in sort order, as they're added and removed.
   var Collection = Backbone.Collection = function(models, options) {
     options || (options = {});
+    if (options.url) this.url = options.url;
     if (options.model) this.model = options.model;
     if (options.comparator !== void 0) this.comparator = options.comparator;
     this._reset();

--- a/index.html
+++ b/index.html
@@ -1522,11 +1522,15 @@ var Library = Backbone.Collection.extend({
       may be included as an option. Passing <tt>false</tt> as the
       comparator option will prevent sorting. If you define an
       <b>initialize</b> function, it will be invoked when the collection is
-      created.
+      created. The constructor copies following fields from the options into
+      instance variables: <tt>url</tt>, <tt>model</tt> and <tt>comparator</tt>.
     </p>
 
 <pre>
 var tabs = new TabSet([tab1, tab2, tab3]);
+var spaces = new Backbone.Collection([], {
+  url: "/spaces", model: Space
+});
 </pre>
 
     <p id="Collection-models">

--- a/test/collection.js
+++ b/test/collection.js
@@ -1049,4 +1049,18 @@ $(document).ready(function() {
     collection.add(collection.models, {merge: true}); // don't sort
   });
 
+  test("Copy known options into instance fields in the constructor", function() {
+      var model = new Backbone.Model();
+      var collection = new Backbone.Collection([], { model: model });
+      equal(collection.model, model);
+
+      var url = "/somewhere";
+      var collection = new Backbone.Collection([], { url: url });
+      equal(collection.url, url);
+
+      var comparator = function() {};
+      var collection = new Backbone.Collection([], { comparator: comparator });
+      equal(collection.comparator, comparator);
+  });
+
 });


### PR DESCRIPTION
Sometimes I don't want to create a new derived Collection class just to be able to set the url. I find it easier to pass the url to the constructor inside the options:

```
var foos = new Backbone.Collection([], { url: "/foos" });
```

The Collection constructor currently respects two options: `model` and `comparator`, and copies them into instance fields. This commit changes the constructor to do the same for `url`.

Included is a test and a small change in the documentation to list which options the Collection constructor supports.

This is similar to #2109, which is in the same spirit but for Backbone.Model.
