### PR TITLE
Cleanup Todo example

### DIFF
--- a/examples/todos/todos.js
+++ b/examples/todos/todos.js
@@ -43,7 +43,7 @@ $(function(){
 
     // Filter down the list of all todo items that are finished.
     done: function() {
-      return this.filter(function(todo){ return todo.get('done'); });
+      return this.where({done: true});
     },
 
     // Filter down the list to only todo items that are still not finished.
@@ -59,9 +59,7 @@ $(function(){
     },
 
     // Todos are sorted by their original insertion order.
-    comparator: function(todo) {
-      return todo.get('order');
-    }
+    comparator: 'order'
 
   });
 


### PR DESCRIPTION
Clarity tweaks for the Todo example:
- The `initialize` logic in the Todo model is redundant to the way `defaults` works. In its present form it's fairly confusing IMO, and there are better examples of how to use `initialize` elsewhere in the app.
- `where` was added back in underscore 1.4.0 for simple cases of `filter` such as this one.
- `Collection#comparator` can take a string for simple attribute sort.
