### PR TITLE
Allow array of event handlers in View#delegateEvents.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1297,8 +1297,9 @@
     //
     //     {
     //       'mousedown .title':  'edit',
-    //       'click .button':     'save'
-    //       'click .open':       function(e) { ... }
+    //       'click .button':     'save',
+    //       'click .open':       function(e) { ... },
+    //       'mouseover .map':    ['showTip', 'moveTip']
     //     }
     //
     // pairs. Callbacks will be bound to the view, with `this` set properly.
@@ -1310,17 +1311,20 @@
       if (!(events || (events = _.result(this, 'events')))) return this;
       this.undelegateEvents();
       for (var key in events) {
-        var method = events[key];
-        if (!_.isFunction(method)) method = this[events[key]];
-        if (!method) throw new Error('Method "' + events[key] + '" does not exist');
-        var match = key.match(delegateEventSplitter);
-        var eventName = match[1], selector = match[2];
-        method = _.bind(method, this);
-        eventName += '.delegateEvents' + this.cid;
-        if (selector === '') {
-          this.$el.on(eventName, method);
-        } else {
-          this.$el.on(eventName, selector, method);
+        var methods = _.isArray(events[key]) ? events[key] : [events[key]];
+        for (var i = methods.length - 1; i >= 0; i--) {
+          var method = methods[i];
+          if (!_.isFunction(method)) method = this[method];
+          if (!method) throw new Error('Method "' + method + '" does not exist');
+          var match = key.match(delegateEventSplitter);
+          var eventName = match[1], selector = match[2];
+          method = _.bind(method, this);
+          eventName += '.delegateEvents' + this.cid;
+          if (selector === '') {
+            this.$el.on(eventName, method);
+          } else {
+            this.$el.on(eventName, selector, method);
+          }
         }
       }
       return this;

--- a/test/view.js
+++ b/test/view.js
@@ -85,6 +85,26 @@ $(document).ready(function() {
     equal(view.counter, 3);
   });
 
+  test("delegateEvents allows array of callbacks", 4, function() {
+    var counter1 = 0, counter2 = 0;
+
+    var view = new Backbone.View({el: '<p><a id="test"></a></p>'});
+    view.increment1 = function(){ counter1++; };
+    view.increment2 = function(){ counter2++; };
+
+    var events = {'click #test': ['increment1', 'increment2']};
+
+    view.delegateEvents(events);
+    view.$('#test').trigger('click');
+    equal(counter1, 1);
+    equal(counter2, 1);
+
+
+    view.$('#test').trigger('click');
+    equal(counter1, 2);
+    equal(counter2, 2);
+  });
+
   test("undelegateEvents", 6, function() {
     var counter1 = 0, counter2 = 0;
 


### PR DESCRIPTION
It can be useful to define multiple independent event handlers for a single event + selector combination. This helps promote reusable event handler methods, for example:

``` javascript

Backbone.View.extend({
  events: {
    "mouseover .map":    ["showTip", "moveTip"],
    "mousemove .map":    "moveTip",
    "mouseout .map":     "hideTip"
  }
});
```
