### PR TITLE
Attaching url and urlRoot on the model if passed

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -244,6 +244,8 @@
     var attrs = attributes || {};
     this.cid = _.uniqueId('c');
     this.attributes = {};
+    if (options && options.url) this.url = options.url;
+    if (options && options.urlRoot) this.urlRoot = options.urlRoot;
     if (options && options.collection) this.collection = options.collection;
     if (options && options.parse) attrs = this.parse(attrs, options) || {};
     if (defaults = _.result(this, 'defaults')) {

--- a/test/model.js
+++ b/test/model.js
@@ -111,6 +111,13 @@ $(document).ready(function() {
     equal(model.url(), '/nested/1/collection/2');
   });
 
+  test('url and urlRoot are directly attached if passed in the options', 2, function () {
+    var model = new Backbone.Model({a: 1}, {url: '/test'});
+    var model2 = new Backbone.Model({a: 2}, {urlRoot: '/test2'});
+    equal(model.url, '/test');
+    equal(model2.urlRoot, '/test2');
+  });
+
   test("underscore methods", 5, function() {
     var model = new Backbone.Model({ 'foo': 'a', 'bar': 'b', 'baz': 'c' });
     var model2 = model.clone();


### PR DESCRIPTION
Re-opening from #2109, to keep consistency with the change on the collection in #2354 - directly attaches the `url` and `urlRoot` attributes on the model if they're passed in the options hash.
