### PR TITLE
Use empty route name for anonymous routes.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -981,7 +981,11 @@
     //
     route: function(route, name, callback) {
       if (!_.isRegExp(route)) route = this._routeToRegExp(route);
-      if (!callback) callback = _.isFunction(name) ? name : this[name];
+      if (_.isFunction(name)) {
+        callback = name;
+        name = '';
+      }
+      if (!callback) callback = this[name];
       var router = this;
       Backbone.history.route(route, function(fragment) {
         var args = router._extractParameters(route, fragment);

--- a/test/router.js
+++ b/test/router.js
@@ -286,7 +286,10 @@ $(document).ready(function() {
     equal(router.anything, 'doesnt-match-a-route');
   });
 
-  test("routes (function)", 2, function() {
+  test("routes (function)", 3, function() {
+    router.on('route', function(name) {
+      ok(name === '');
+    });
     equal(ExternalObject.value, 'unset');
     location.replace('http://example.com#function/set');
     Backbone.history.checkUrl();


### PR DESCRIPTION
Without this patch, `route:<name>` is triggered with `callback.toString()` which likely contains spaces and will trigger events erroneously.
