### PR TITLE
No need for Model::changed

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -264,9 +264,6 @@
   // Attach all inheritable methods to the Model prototype.
   _.extend(Model.prototype, Events, {
 
-    // A hash of attributes whose current and previous value differ.
-    changed: null,
-
     // The value returned during the last failed validation.
     validationError: null,
 


### PR DESCRIPTION
If you are using this as a documentation, just ignore the PR. Otherwise, it's always defined as an own property in the `Model` constructor.
