### PR TITLE
Fix typo in collection.set example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1792,7 +1792,7 @@ ships.add([
 <pre>
 var vanHalen = new Collection([eddie, alex, stone, roth]);
 
-vanHalen.update([eddie, alex, stone, hagar]);
+vanHalen.set([eddie, alex, stone, hagar]);
 
 // Fires a "remove" event for roth, and an "add" event for "hagar".
 // Updates any of stone, alex, and eddie's attributes that may have


### PR DESCRIPTION
The example for collection.set called an undefined function "update". Fixes #2396.
