### PR TITLE
Fix for #2392 - cleanup events on invalid or duplicate models

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -565,6 +565,12 @@
       if (!error) return true;
       this.trigger('invalid', this, error, _.extend(options || {}, {validationError: error}));
       return false;
+    },
+
+    // Removes event listeners on duplicate or invalid models.
+    _cleanEvents: function () {
+      this.off();
+      this.stopListening();
     }
 
   });
@@ -684,6 +690,7 @@
             existing.set(model.attributes, options);
             if (sortable && !sort && existing.hasChanged(sortAttr)) sort = true;
           }
+          existing._cleanEvents();
 
         // This is a new model, push it to the `toAdd` list.
         } else if (options.add) {
@@ -908,6 +915,7 @@
       var model = new this.model(attrs, options);
       if (!model._validate(attrs, options)) {
         this.trigger('invalid', this, attrs, options);
+        model._cleanEvents();
         return false;
       }
       return model;

--- a/test/model.js
+++ b/test/model.js
@@ -1099,4 +1099,29 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test('#2392 - cleanup invalid model listeners', 1, function () {
+    var count = 0;
+    var collection = new Backbone.Collection();
+    var Model = Backbone.Model.extend({
+      initialize : function () {
+        this.listenTo(collection, 'refresh', function () {
+          count++;
+        });
+        this.on('remove', function () {
+          this.off();
+          this.stopListening();
+        }, this);
+      }
+    });
+    var Collection2 = Backbone.Collection.extend({
+      model : Model
+    });
+    var collection2 = new Collection2();
+    collection2.set([{id:1}, {id:2}]); 
+    collection.trigger('refresh');
+    collection2.set([{id:1}, {id:2}]);
+    collection.trigger('refresh');
+    equal(count, 4);
+  });
+
 });


### PR DESCRIPTION
This might not be a common occurrence, but I have a feeling it'll be a tough one to track down when it does happen, since creating a temporary one-off model internally is the only way to reliably check if a model already exists in a collection (due to various issues with parse and how the `id` is set on models).

If there are listeners bound during initialize for a model which is dropped after failing `_prepareModel` or which isn't used because a duplicate exists, then we should cleanup the listeners on that model to be safe.
