### PR TITLE
Add backbone's license info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,5 +16,6 @@
     "test": "phantomjs test/vendor/runner.js test/index.html?noglobals=true && coffee test/model.coffee"
   },
   "main"          : "backbone.js",
-  "version"       : "1.0.0"
+  "version"       : "1.0.0",
+  "license"       : "MIT"
 }


### PR DESCRIPTION
NPM spec allows for backbone's license in the package.json, so for completeness, I added it in :)
https://npmjs.org/doc/json.html
