### PR TITLE
Add backbone license URL to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,5 +17,10 @@
   },
   "main"          : "backbone.js",
   "version"       : "1.0.0",
-  "license"       : "MIT"
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/documentcloud/backbone/blob/master/LICENSE"
+    }
+  ]
 }


### PR DESCRIPTION
Probably should add in the backbone's license agreement as well.

https://npmjs.org/doc/json.html
