### PR TITLE
Documentation paragraph for a common misconception about routes with trailing slashes.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2184,6 +2184,13 @@ var Workspace = Backbone.Router.extend({
     </p>
 
     <p>
+      Trailing slashes are treated as part of the URL, and (correctly) treated 
+      as a unique route when accessed. <tt>docs</tt> and <tt>docs/</tt> will fire
+      different callbacks. If you can't avoid generating both types of URLs, you 
+      can define a <tt>"docs(/)"</tt> matcher to capture both cases.
+    </p>
+
+    <p>
       When the visitor presses the back button, or enters a URL, and a particular
       route is matched, the name of the action will be fired as an
       <a href="#Events">event</a>, so that other objects can listen to the router,


### PR DESCRIPTION
Common enough issue with a good built in solution in optional matches in routes. I'd only discovered it in an old issue, so surfaced it to the docs. https://github.com/documentcloud/backbone/issues/848#issuecomment-9258484
