### PR TITLE
Add support for specifying explicit PATCH fields in Model.toJSON

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -277,7 +277,11 @@
 
     // Return a copy of the model's `attributes` object.
     toJSON: function(options) {
-      return _.clone(this.attributes);
+      if (options.patch && options.fields) {
+        return _.pick(this.attributes, options.fields);
+      } else {
+        return _.clone(this.attributes);
+      }
     },
 
     // Proxy `Backbone.sync` by default -- but override this if you need
@@ -488,7 +492,7 @@
       wrapError(this, options);
 
       method = this.isNew() ? 'create' : (options.patch ? 'patch' : 'update');
-      if (method === 'patch') options.attrs = attrs;
+      if (attrs && method === 'patch') options.attrs = attrs;
       xhr = this.sync(method, this, options);
 
       // Restore attributes.

--- a/test/model.js
+++ b/test/model.js
@@ -453,6 +453,11 @@ $(document).ready(function() {
     equal(this.syncArgs.options.attrs.d, 4);
     equal(this.syncArgs.options.attrs.a, undefined);
     equal(this.ajaxSettings.data, "{\"b\":2,\"d\":4}");
+
+    doc.save(null, {patch: true, fields: ['b', 'd']});
+    equal(this.syncArgs.options.attrs, undefined);
+    equal(_.size(this.syncArgs.options.fields), 2);
+    equal(this.ajaxSettings.data, "{\"b\":2,\"d\":4}");
   });
 
   test("save in positional style", 1, function() {


### PR DESCRIPTION
This is to support sending a PATCH request without needing to pass `attrs` explicitly into `save`. This introduces a new option `fields` that is an array of attribute keys that is used by `Model.toJSON` when `options.patch` is true. Simply:

``` javascript
model.save({'a': 1, 'b': 2}, {patch: true});
// vs.
model.save(null, {patch: true, fields: ['a', 'b']});
```

In case you want to save the data after the attributes have already been set.
