### PR TITLE
Router.navigate should optionally fire also with same fragment

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1466,7 +1466,7 @@
       if (!History.started) return false;
       if (!options || options === true) options = {trigger: options};
       fragment = this.getFragment(fragment || '');
-      if (this.fragment === fragment) return;
+      if (this.fragment === fragment && options.forceFragment !== true) return;
       this.fragment = fragment;
       var url = this.root + fragment;
 


### PR DESCRIPTION
I found this useful when route callback is a GET remote request.
An alternative could be to fire the callback directly but since _extractParameters is very smart & useful to decode parameters, reimplementing the parsing & decoding logic elsewhere could be considered wasteful.
