### PR TITLE
Remove leftover attachable url documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1611,8 +1611,7 @@ var Library = Backbone.Collection.extend({
 <pre>
 var tabs = new TabSet([tab1, tab2, tab3]);
 var spaces = new Backbone.Collection([], {
-  model: Space,
-  url: '/spaces'
+  model: Space
 });
 </pre>
 


### PR DESCRIPTION
I was answering #2453 with a confidence that I removed all of the attachable `url` and `urlRoot` options and then I stumbled on this :)
