### PR TITLE
return from Backbone.history.navigate whether a route was matched.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1491,7 +1491,7 @@
       } else {
         return this.location.assign(url);
       }
-      if (options.trigger) this.loadUrl(fragment);
+      if (options.trigger) return this.loadUrl(fragment);
     },
 
     // Update the hash location, either replacing the current entry, or adding

--- a/test/router.js
+++ b/test/router.js
@@ -204,6 +204,10 @@ $(document).ready(function() {
     equal(router.page, '20');
   });
 
+  test("reports matched route via nagivate", 1, function() {
+    ok(Backbone.history.navigate('search/manhattan/p20', true));
+  });
+
   test("route precedence via navigate", 6, function(){
     // check both 0.9.x and backwards-compatibility options
     _.each([ { trigger: true }, true ], function( options ){


### PR DESCRIPTION
It can be useful, particularly in Marionette apps where you have multiple routers.
