### PR TITLE
Model#fetch respects { parse: false } option

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -431,7 +431,9 @@
       var model = this;
       var success = options.success;
       options.success = function(resp) {
-        if (!model.set(model.parse(resp, options), options)) return false;
+        var attrs = resp;
+        if (options.parse) attrs = model.parse(resp, options);
+        if (!model.set(attrs, options)) return false;
         if (success) success(model, resp, options);
         model.trigger('sync', model, resp, options);
       };

--- a/test/model.js
+++ b/test/model.js
@@ -1108,4 +1108,13 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test("fetch respects {parse: false} option", 0, function() {
+    var model = new Backbone.Model();
+    model.sync = function(method, model, options) {
+      options.success();
+    };
+
+    model.parse = function() { ok(false) };
+    model.fetch({ parse: false });
+  });
 });


### PR DESCRIPTION
Checking for `{ parse: false }` in `Model#fetch`. Currently `Model#parse` is always called.
