### PR TITLE
Dispense with View#options merging.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -981,11 +981,16 @@
   // having to worry about render order ... and makes it easy for the view to
   // react to specific changes in the state of your models.
 
+  // Options with special meaning *(e.g. model, collection, id, className)* are
+  // attached directly to the view.  See `viewOptions` for an exhaustive
+  // list.
+
   // Creating a Backbone.View creates its initial element outside of the DOM,
   // if an existing element is not provided...
   var View = Backbone.View = function(options) {
     this.cid = _.uniqueId('view');
-    options = this._configure(options || {});
+    options || (options = {});
+    _.extend(this, _.pick(options, viewOptions));
     this._ensureElement();
     this.initialize.apply(this, arguments);
     this.delegateEvents();
@@ -1080,16 +1085,6 @@
     undelegateEvents: function() {
       this.$el.off('.delegateEvents' + this.cid);
       return this;
-    },
-
-    // Performs the initial configuration of a View with a set of options.
-    // Keys with special meaning *(e.g. model, collection, id, className)* are
-    // attached directly to the view.  See `viewOptions` for an exhaustive
-    // list.
-    _configure: function(options) {
-      if (this.options) options = _.extend({}, _.result(this, 'options'), options);
-      _.extend(this, _.pick(options, viewOptions));
-      return options;
     },
 
     // Ensure that the View has a DOM element to render into.

--- a/test/view.js
+++ b/test/view.js
@@ -153,24 +153,6 @@ $(document).ready(function() {
     strictEqual(new View().el.id, 'id');
   });
 
-  test("with options function", 2, function() {
-
-    var View = Backbone.View.extend({
-
-      options: function() {
-        return {title: 'title'};
-      },
-
-      initialize: function(options) {
-        strictEqual(options.title, 'title');
-        strictEqual(options.fixed, true);
-      }
-
-    });
-
-    new View({fixed: true});
-  });
-
   test("with attributes", 2, function() {
     var View = Backbone.View.extend({
       attributes: {


### PR DESCRIPTION
As discussed in #2458, using defaults is unnecessary when attaching options directly to new instances.

For example, this code

``` js
var View = Backbone.View.extend({
  options: {
    foo: 15,
    bar: false
  },
  initialize: function(options) {
    _.extend(this, _.pick(options, 'foo', 'bar'));
  }
});
```

is better written as and functionally equivalent to

``` js
var View = Backbone.View.extend({
  foo: 15,
  bar: false,
  initialize: function(options) {
    _.extend(this, _.pick(options, 'foo', 'bar'));
  }
});
```

With that in mind, there is really no need for merging options with `View#options`.
