### PR TITLE
implement dirty method on model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -409,6 +409,14 @@
       return changed;
     },
 
+    // Force an attribute to be synced on next saving even if the value didn't
+    // change.
+    dirty: function(attr) {
+      var val = this.get(attr)
+      this.changed[attr] = val
+      this._previousAttributes[attr] = val
+    },
+
     // Get the previous value of an attribute, recorded at the time the last
     // `"change"` event was fired.
     previous: function(attr) {

--- a/test/model.js
+++ b/test/model.js
@@ -1108,4 +1108,12 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test("dirty function make", 3, function() {
+    var model = new Backbone.Model({a: 1});
+    model.dirty('a');
+    equal(model.hasChanged('a'), true);
+    equal(model.changedAttributes().a, 1);
+    equal(model.previous('a'), 1);
+  });
+
 });


### PR DESCRIPTION
Sometimes I want to force an attribute to be sync even if the value didn't change or set to same value. That's why I suggest to add a dirty method on a model.
