### PR TITLE
Add `extend` method to collection

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -634,6 +634,12 @@
       return this.set(models, _.defaults(options || {}, addOptions));
     },
 
+    // Extend the collection with the collection in argument
+    extend: function(collection, options) {
+      this.add(collection.models, options);
+      return this;
+    },
+
     // Remove a model, or a list of models from the set.
     remove: function(models, options) {
       models = _.isArray(models) ? models.slice() : [models];

--- a/test/collection.js
+++ b/test/collection.js
@@ -271,6 +271,77 @@ $(document).ready(function() {
     deepEqual(col.pluck('id'), [1, 2, 3]);
   });
 
+
+  test('extend', 6, function(){
+    var col = new Backbone.Collection();
+
+    var collections = [
+      new Backbone.Collection([{id: 0}, {id: 1}, {id: 2}]),
+      new Backbone.Collection([{id: 3}, {id: 4}, {id: 5}])
+    ];
+
+    _.each(collections, function(collection){
+      col.extend(collection);
+    });
+
+    for (var i = 0; i <= 5; i++) {
+      equal(col.at(i).get('id'), i);
+    }
+  });
+
+  test('extend; should ignore duplicate models', 5 , function() {
+    var col = new Backbone.Collection();
+
+    var collections = [
+      new Backbone.Collection([{id: 0}, {id: 1}, {id: 2}]),
+      new Backbone.Collection([{id: 3}, {id: 2}, {id: 4}])
+    ];
+
+    _.each(collections, function(collection){
+      col.extend(collection);
+    });
+
+    for (var i = 0; i <= 4; i++) {
+      equal(col.at(i).get('id'), i);
+    }
+  });
+
+  test('extend; should merge duplicate models', 5 , function() {
+    var col = new Backbone.Collection()
+
+    var collections = [
+      new Backbone.Collection([{id: 0, foo: true}, {id: 1, foo: true},
+                               {id: 2, foo: false}]),
+      new Backbone.Collection([{id: 3, foo: true}, {id: 2, foo: true},
+                               {id: 4, foo: true}])
+    ];
+
+    _.each(collections, function(collection){
+      col.extend(collection, {merge: true});
+    });
+
+    col.each(function(object) {
+      equal(object.get('foo'), true);
+    });
+  });
+
+  test('extend; extend in the middle of collection', 5 , function() {
+    var col = new Backbone.Collection()
+
+    var collections = [
+      new Backbone.Collection([{id: 1}, {id: 2}, {id: 5}]),
+      new Backbone.Collection([{id: 3}, {id: 4}])
+    ];
+
+    _.each(collections, function(collection){
+      col.extend(collection, {at: 2});
+    });
+
+    for (var i = 0; i <= 4; i++) {
+      equal(col.at(i).get('id'), i+1);
+    }
+  });
+
   test("remove", 5, function() {
     var removed = null;
     var otherRemoved = null;


### PR DESCRIPTION
Allow collections to be extended by the models
in the arguments. Basically a sugar for doing
`target.add(collection.models)`.

Usage: target.extend(collection, [options])

`extend` is confusing with `Collection.extend`, so
maybe a better name can be thought of for it.

Signed-off-by: Rohan Jain crodjer@gmail.com
