### PR TITLE
Collection set + merge test should disable merge

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -962,7 +962,7 @@ $(document).ready(function() {
     col.set({id: 1, key: 'other'});
     equal(col.first().get('key'), 'other');
 
-    col.set({id: 1, other: 'value'});
+    col.set({id: 1, other: 'value'}, {merge: false});
     equal(col.first().get('key'), 'other');
     equal(col.length, 1);
   });


### PR DESCRIPTION
`collection.set` by default merges the attributes, for the test to
pass (or check both the cases) it should be disabled in the second
set.

Ref: https://github.com/documentcloud/backbone/commit/f61bd29d3065f70345215532704280dd0b7c2ffe
