### PR TITLE
Return a rejected promise instead of false on invalid model save

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -519,7 +519,7 @@
 
       if (this.isNew()) {
         options.success();
-        return Backbone.Deferred().reject();
+        return Backbone.Deferred().resolve();
       }
       wrapError(this, options);
 

--- a/backbone.js
+++ b/backbone.js
@@ -519,7 +519,7 @@
 
       if (this.isNew()) {
         options.success();
-        return false;
+        return Backbone.Deferred().reject();
       }
       wrapError(this, options);
 

--- a/backbone.js
+++ b/backbone.js
@@ -445,7 +445,7 @@
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
     save: function(key, val, options) {
-      var attrs, method, xhr, attributes = this.attributes;
+      var attrs, method, xhr, dfd = new $.Deferred, attributes = this.attributes;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
       if (key == null || typeof key === 'object') {
@@ -461,9 +461,9 @@
       // `set(attr).save(null, opts)` with validation. Otherwise, check if
       // the model will be valid when the attributes, if any, are set.
       if (attrs && !options.wait) {
-        if (!this.set(attrs, options)) return false;
+        if (!this.set(attrs, options)) return dfd.rejectWith(this);
       } else {
-        if (!this._validate(attrs, options)) return false;
+        if (!this._validate(attrs, options)) return dfd.rejectWith(this);
       }
 
       // Set temporary attributes if `{wait: true}`.

--- a/backbone.js
+++ b/backbone.js
@@ -1206,7 +1206,9 @@
 
   // Set the default promises library to proxy to `$`.
   // Override this if you'd like to use a different library.
-  Backbone.Deferred = Backbone.$.Deferred;
+  Backbone.Deferred = function() {
+    return Backbone.$.Deferred.apply(Backbone.$, arguments);
+  }
 
   // Backbone.Router
   // ---------------

--- a/backbone.js
+++ b/backbone.js
@@ -445,7 +445,7 @@
     // If the server returns an attributes hash that differs, the model's
     // state will be `set` again.
     save: function(key, val, options) {
-      var attrs, method, xhr, dfd = new $.Deferred, attributes = this.attributes;
+      var attrs, method, xhr, dfd = Backbone.Deferred(), attributes = this.attributes;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
       if (key == null || typeof key === 'object') {
@@ -461,9 +461,9 @@
       // `set(attr).save(null, opts)` with validation. Otherwise, check if
       // the model will be valid when the attributes, if any, are set.
       if (attrs && !options.wait) {
-        if (!this.set(attrs, options)) return dfd.rejectWith(this);
+        if (!this.set(attrs, options)) return dfd.reject();
       } else {
-        if (!this._validate(attrs, options)) return dfd.rejectWith(this);
+        if (!this._validate(attrs, options)) return dfd.reject();
       }
 
       // Set temporary attributes if `{wait: true}`.
@@ -1203,6 +1203,10 @@
   Backbone.ajax = function() {
     return Backbone.$.ajax.apply(Backbone.$, arguments);
   };
+
+  // Set the default promises library to proxy to `$`.
+  // Override this if you'd like to use a different library.
+  Backbone.Deferred = Backbone.$.Deferred;
 
   // Backbone.Router
   // ---------------

--- a/test/model.js
+++ b/test/model.js
@@ -959,13 +959,11 @@ $(document).ready(function() {
     var model = new Backbone.Model;
     model.validate = function(){ return 'invalid'; };
     model.sync = function(){ ok(false); };
-    model.save()
-      .done(function() {
-        ok(false);
-      })
-      .fail(function() {
-        ok(true);
-      });
+    model.save().then(function() {
+      ok(false);
+    }, function() {
+      ok(true);
+    });
   });
 
   test("#1377 - Save without attrs triggers 'error'.", 2, function() {
@@ -976,13 +974,11 @@ $(document).ready(function() {
     });
     var model = new Model({id: 1});
     model.on('invalid', function(){ ok(true); });
-    model.save()
-      .done(function() {
-        ok(false);
-      })
-      .fail(function() {
-        ok(true);
-      });
+    model.save().then(function() {
+      ok(false);
+    }, function() {
+      ok(true);
+    });
   });
 
   test("#1545 - `undefined` can be passed to a model constructor without coersion", function() {

--- a/test/model.js
+++ b/test/model.js
@@ -489,7 +489,7 @@ $(document).ready(function() {
     ok(_.isEqual(this.syncArgs.model, doc));
 
     var newModel = new Backbone.Model;
-    equal(newModel.destroy(), false);
+    equal(newModel.destroy().state(), 'rejected');
   });
 
   test("non-persisted destroy", 1, function() {

--- a/test/model.js
+++ b/test/model.js
@@ -959,10 +959,16 @@ $(document).ready(function() {
     var model = new Backbone.Model;
     model.validate = function(){ return 'invalid'; };
     model.sync = function(){ ok(false); };
-    strictEqual(model.save(), false);
+    model.save()
+      .done(function() {
+        ok(false);
+      })
+      .fail(function() {
+        ok(true);
+      });
   });
 
-  test("#1377 - Save without attrs triggers 'error'.", 1, function() {
+  test("#1377 - Save without attrs triggers 'error'.", 2, function() {
     var Model = Backbone.Model.extend({
       url: '/test/',
       sync: function(method, model, options){ options.success(); },
@@ -970,7 +976,13 @@ $(document).ready(function() {
     });
     var model = new Model({id: 1});
     model.on('invalid', function(){ ok(true); });
-    model.save();
+    model.save()
+      .done(function() {
+        ok(false);
+      })
+      .fail(function() {
+        ok(true);
+      });
   });
 
   test("#1545 - `undefined` can be passed to a model constructor without coersion", function() {

--- a/test/model.js
+++ b/test/model.js
@@ -489,7 +489,7 @@ $(document).ready(function() {
     ok(_.isEqual(this.syncArgs.model, doc));
 
     var newModel = new Backbone.Model;
-    equal(newModel.destroy().state(), 'rejected');
+    equal(newModel.destroy().state(), 'resolved');
   });
 
   test("non-persisted destroy", 1, function() {

--- a/test/sync.js
+++ b/test/sync.js
@@ -164,7 +164,7 @@ $(document).ready(function() {
     model.validate = function(attrs) {
       return !attrs.accept;
     }
-    result = model.save({accept: false});
+    var result = model.save({accept: false});
     strictEqual(result.state(), 'rejected');
     result = model.save({accept: true});
     strictEqual(result.state(), 'resolved');

--- a/test/sync.js
+++ b/test/sync.js
@@ -155,6 +155,21 @@ $(document).ready(function() {
     Backbone.sync('create', model);
   });
 
+  test("Backbone.Deferred", 2, function() {
+    Backbone.sync = function(settings){
+      return Backbone.Deferred().resolve();
+    };
+    var model = new Backbone.Model();
+    model.url = '/test';
+    model.validate = function(attrs) {
+      return !attrs.accept;
+    }
+    result = model.save({accept: false});
+    strictEqual(result.state(), 'rejected');
+    result = model.save({accept: true});
+    strictEqual(result.state(), 'resolved');
+  });
+
   test("Call provided error callback on error.", 1, function() {
     var model = new Backbone.Model;
     model.url = '/test';


### PR DESCRIPTION
From the discussion in #2345, returning false from a failed save prevents a clean chaining API (`model.save().done(...).fail(...)`). Using deferreds, we can reject a promise instead to avoid the discrepancy.

This pull doesn't introduce any new options vars (i.e. `isValid`), instead suggesting a separate event listener for the model's `invalid` event or querying `model.isValid()` directly within the failed handler. The `invalid` event will always be fired before the deferred is rejected and returned. The fail handler is fired for both failed validation as well as any ajax errors which makes it difficult to mutate the options object or keep the two callbacks' arguments consistent.