### PR TITLE
Add `difference` underscore.js method to Backbone.Collection

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -503,7 +503,7 @@ $(document).ready(function() {
     equal(coll.findWhere({a: 4}), void 0);
   });
 
-  test("Underscore methods", 14, function() {
+  test("Underscore methods", 15, function() {
     equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
     equal(col.any(function(model){ return model.id === 100; }), false);
     equal(col.any(function(model){ return model.id === 0; }), true);


### PR DESCRIPTION
Adds the `difference` underscore.js method to Collection, allowing for this

```
var arr = _.difference(myCollection.models, excludeThese)
```

to become this

```
var arr = myCollection.difference(excludeThese)
```

I added a test for it as well, which passes. However, when I forked off master, a failing test already existed.
