### PR TITLE
trigger a 'set' event on Collection.set

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -733,6 +733,10 @@
 
       // Trigger `sort` if the collection was sorted.
       if (sort || (order && order.length)) this.trigger('sort', this, options);
+      
+      // Trigger `set` event
+      this.trigger('set', this, options);
+      
       return this;
     },
 


### PR DESCRIPTION
Example: 

```
var c = new Backbone.Collection([
    { id: "1", name: "larry" },
    { id: "2", name: "moe" },
    { id: "3", name: "curley" }
]);

c.on("set", function() {
    // triggers only once in this case
});

c.set([
    { id: "1", name: "Larry" },
    { id: "2", name: "Moe" },
    { id: "3", name: "Curley" }
]);
```

This has been something I usually shim for my projects and I know that it is an opinionated change but I figured I'd put it out there. I'd understand if it's not something that you guys don't want to pull.
