### PR TITLE
Add keepOld option to View#delegateEvents.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1061,9 +1061,9 @@
     // Omitting the selector binds the event to `this.el`.
     // This only works for delegate-able events: not `focus`, `blur`, and
     // not `change`, `submit`, and `reset` in Internet Explorer.
-    delegateEvents: function(events) {
+    delegateEvents: function(events, keepOld) {
       if (!(events || (events = _.result(this, 'events')))) return this;
-      this.undelegateEvents();
+      if (!keepOld) this.undelegateEvents();
       for (var key in events) {
         var method = events[key];
         if (!_.isFunction(method)) method = this[events[key]];

--- a/test/view.js
+++ b/test/view.js
@@ -114,6 +114,37 @@ $(document).ready(function() {
     equal(counter2, 3);
   });
 
+  test("delegateEvents keeps old methods with option", 8, function() {
+    var counter1 = 0, counter2 = 0;
+
+    var view = new Backbone.View({el: '<p><a id="test"></a></p>'});
+    view.increment = function(){ counter1++; };
+    view.incr2 = function(){ counter1++; };
+    view.$el.on('click', function(){ counter2++; });
+
+    var events = {'click #test': 'increment'};
+
+    view.delegateEvents(events);
+    view.$('#test').trigger('click');
+    equal(counter1, 1);
+    equal(counter2, 1);
+
+    view.$('#test').trigger('click');
+    equal(counter1, 2);
+    equal(counter2, 2);
+
+    view.delegateEvents({'click #test': 'incr2'}, true);
+    view.$('#test').trigger('click');
+    equal(counter1, 4);
+    equal(counter2, 3);
+
+    view.delegateEvents({'click #test': 'incr2'}, false);
+    view.$('#test').trigger('click');
+    equal(counter1, 5);
+    equal(counter2, 4);
+
+  });
+
   test("_ensureElement with DOM node el", 1, function() {
     var View = Backbone.View.extend({
       el: document.body


### PR DESCRIPTION
Currently you cannot use `delegateEvents` to bind events temporary. Because all your previous are unbound. This makes delegateEvents(obj) pretty useless.

Also, why delegations that don’t have valid methods are simply _ignored_? Why not throw early `TypeError`? This can save developers a lot of time spent debugging.
