### PR TITLE
Made History.route overwrite old routes

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1427,9 +1427,27 @@
     },
 
     // Add a route to be tested when the fragment changes. Routes added later
-    // may override previous routes.
+    // may override previous routes.  Identical routes added later will
+    // overwrite previous routes.
     route: function(route, callback) {
-      this.handlers.unshift({route: route, callback: callback});
+      var i, newHandler, regExpRoute;
+      newHandler = { route: route, callback: callback };
+
+      if (_.isRegExp(route)) {
+        regExpRoute = route;
+      } else {
+        regExpRoute = Backbone.Router.prototype._routeToRegExp(route);
+      }
+
+      for (i = 0; i < this.handlers.length; i++) {
+        if (this.handlers[i].route.toString() === regExpRoute.toString()) {
+          this.handlers[i] = newHandler;
+          return this;
+        }
+      }
+
+      this.handlers.unshift(newHandler);
+      return this;
     },
 
     // Checks the current URL to see if it has changed, and if it has,

--- a/test/router.js
+++ b/test/router.js
@@ -167,6 +167,15 @@ $(document).ready(function() {
     equal(router.testing, 101);
   });
 
+  test("adding duplicate routes overwrites old routes", 2, function(){
+    var oldLength = Backbone.history.handlers.length;
+    router.route('new_route','new_route');
+    var newLength = Backbone.history.handlers.length;
+    equal(newLength, oldLength + 1);
+    router.route('new_route','new_route');
+    equal(newLength, Backbone.history.handlers.length);
+  });
+
   test("routes (simple)", 4, function() {
     location.replace('http://example.com#search/news');
     Backbone.history.checkUrl();


### PR DESCRIPTION
History.route was only capable of adding more and more routes.  This feature detects identical routes and overwrites the callback with the new callback supplied.
