### PR TITLE
noRedirect option for Backbone.History

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1372,6 +1372,7 @@
       this._wantsHashChange = this.options.hashChange !== false;
       this._wantsPushState  = !!this.options.pushState;
       this._hasPushState    = !!(this.options.pushState && this.history && this.history.pushState);
+      this._noRedirect      = this.options.noRedirect;
       var fragment          = this.getFragment();
       var docMode           = document.documentMode;
       var oldIE             = (isExplorer.exec(navigator.userAgent.toLowerCase()) && (!docMode || docMode <= 7));
@@ -1400,19 +1401,23 @@
       var loc = this.location;
       var atRoot = loc.pathname.replace(/[^\/]$/, '$&/') === this.root;
 
-      // If we've started off with a route from a `pushState`-enabled browser,
-      // but we're currently in a browser that doesn't support it...
-      if (this._wantsHashChange && this._wantsPushState && !this._hasPushState && !atRoot) {
-        this.fragment = this.getFragment(null, true);
-        this.location.replace(this.root + this.location.search + '#' + this.fragment);
-        // Return immediately as browser will do redirect to new url
-        return true;
+      // If we should redirect in case we went from from a `pushState`-enabled browser
+      // to not supporting pushState or other way around
+      if (!this._noRedirect) {
+        // If we've started off with a route from a `pushState`-enabled browser,
+        // but we're currently in a browser that doesn't support it...
+        if (this._wantsHashChange && this._wantsPushState && !this._hasPushState && !atRoot) {
+          this.fragment = this.getFragment(null, true);
+          this.location.replace(this.root + this.location.search + '#' + this.fragment);
+          // Return immediately as browser will do redirect to new url
+          return true;
 
-      // Or if we've started out with a hash-based route, but we're currently
-      // in a browser where it could be `pushState`-based instead...
-      } else if (this._wantsPushState && this._hasPushState && atRoot && loc.hash) {
-        this.fragment = this.getHash().replace(routeStripper, '');
-        this.history.replaceState({}, document.title, this.root + this.fragment + loc.search);
+        // Or if we've started out with a hash-based route, but we're currently
+        // in a browser where it could be `pushState`-based instead...
+        } else if (this._wantsPushState && this._hasPushState && atRoot && loc.hash) {
+          this.fragment = this.getHash().replace(routeStripper, '');
+          this.history.replaceState({}, document.title, this.root + this.fragment + loc.search);
+        }
       }
 
       if (!this.options.silent) return this.loadUrl();


### PR DESCRIPTION
Hi!

I'm building a mobile web-app based on backbone (obviously) and found myself in a position where I want to have different states within one URL. I tried using hash for that since I use pushState for normal navigation.

The problem with that is when I hit refresh Backbone tries to be too smart for its own good and redirects me from for example http://localhost:3000/#datepicker to http://localhost:3000/datepicker which just shows a 404 error.

My attempt to solve this issue it is to introduce new option for Backbone.History that just stops that redirect behavior to occur, if you don't care for non-pushState browsers altogether (and I don't hence all mobile browsers support it).

If there's another way to solve this issue without creating a mess of extra routes in the router please let me know :) I might've missed something.
