### PR TITLE
Proxy underscore's _.result on models, views and collections

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -567,6 +567,11 @@
       if (!error) return true;
       this.trigger('invalid', this, error, _.extend(options || {}, {validationError: error}));
       return false;
+    },
+
+    // Proxy underscore's _.result
+    result: function(attr) {
+      return _.result(this, attr);
     }
 
   });
@@ -938,6 +943,11 @@
         if (model.id != null) this._byId[model.id] = model;
       }
       this.trigger.apply(this, arguments);
+    },
+
+    // Proxy underscore's _.result
+    result: function(attr) {
+      return _.result(this, attr);
     }
 
   });
@@ -1105,6 +1115,11 @@
       } else {
         this.setElement(_.result(this, 'el'), false);
       }
+    },
+
+    // Proxy underscore's _.result
+    result: function(attr) {
+      return _.result(this, attr);
     }
 
   });

--- a/index.html
+++ b/index.html
@@ -338,7 +338,7 @@
       <li>– <a href="#Model-fetch">fetch</a></li>
       <li>– <a href="#Model-save">save</a></li>
       <li>– <a href="#Model-destroy">destroy</a></li>
-      <li>– <a href="#Model-Underscore-Methods"><b>Underscore Methods (6)</b></a></li>
+      <li>– <a href="#Model-Underscore-Methods"><b>Underscore Methods (7)</b></a></li>
       <li>– <a href="#Model-validate">validate</a></li>
       <li>– <a href="#Model-validationError">validationError</a></li>
       <li>– <a href="#Model-isValid">isValid</a></li>
@@ -363,7 +363,7 @@
       <li>– <a href="#Collection-models">models</a></li>
       <li>– <a href="#Collection-toJSON">toJSON</a></li>
       <li>– <a href="#Collection-sync">sync</a></li>
-      <li>– <a href="#Collection-Underscore-Methods"><b>Underscore Methods (28)</b></a></li>
+      <li>– <a href="#Collection-Underscore-Methods"><b>Underscore Methods (29)</b></a></li>
       <li>– <a href="#Collection-add">add</a></li>
       <li>– <a href="#Collection-remove">remove</a></li>
       <li>– <a href="#Collection-reset">reset</a></li>
@@ -1316,6 +1316,7 @@ book.destroy({success: function(model, response) {
       <li><a href="http://underscorejs.org/#invert">invert</a></li>
       <li><a href="http://underscorejs.org/#pick">pick</a></li>
       <li><a href="http://underscorejs.org/#omit">omit</a></li>
+      <li><a href="http://underscorejs.org/#result">result</a></li>
     </ul>
 
 <pre>
@@ -1692,6 +1693,7 @@ alert(JSON.stringify(collection));
       <li><a href="http://underscorejs.org/#lastIndexOf">lastIndexOf</a></li>
       <li><a href="http://underscorejs.org/#isEmpty">isEmpty</a></li>
       <li><a href="http://underscorejs.org/#chain">chain</a></li>
+      <li><a href="http://underscorejs.org/#result">result (not an iterator)</a></li>
     </ul>
 
 <pre>

--- a/test/collection.js
+++ b/test/collection.js
@@ -1140,4 +1140,14 @@ $(document).ready(function() {
     equal(collection.length, 2);
   });
 
+  test("exposes _.result", function() {
+    var collection = new Backbone.Collection();
+    collection.foo = "foo";
+    collection.bar = function() {
+      return this.foo + "bar";
+    }
+    equal(collection.result("foo"), "foo");
+    equal(collection.result("bar"), "foobar");
+  });
+
 });

--- a/test/model.js
+++ b/test/model.js
@@ -1108,4 +1108,14 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test("exposes _.result", function() {
+    var model = new Backbone.Model();
+    model.foo = "foo";
+    model.bar = function() {
+      return this.foo + "bar";
+    }
+    equal(model.result("foo"), "foo");
+    equal(model.result("bar"), "foobar");
+  });
+
 });

--- a/test/view.js
+++ b/test/view.js
@@ -327,4 +327,14 @@ $(document).ready(function() {
     equal(counter, 4);
   });
 
+  test("exposes _.result", function() {
+    var view = new Backbone.View();
+    view.foo = "foo";
+    view.bar = function() {
+      return this.foo + "bar";
+    }
+    equal(view.result("foo"), "foo");
+    equal(view.result("bar"), "foobar");
+  });
+
 });


### PR DESCRIPTION
It's quite often that I want my parent classes to use options from the subviews and I want to allow both a function or a static string.

Therefore I've added the method `result` to views, models and collections.

This

``` javascript
view.result('foo');
```

is now equal to this

``` javascript
_.result(view, 'foo');
```
