### PR TITLE
Fix for ignored {parse: false} on save

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -479,7 +479,7 @@
       options.success = function(resp) {
         // Ensure attributes are restored during synchronous saves.
         model.attributes = attributes;
-        var serverAttrs = model.parse(resp, options);
+        var serverAttrs = (options.parse ? model.parse(resp, options) : resp);
         if (options.wait) serverAttrs = _.extend(attrs || {}, serverAttrs);
         if (_.isObject(serverAttrs) && !model.set(serverAttrs, options)) {
           return false;

--- a/test/model.js
+++ b/test/model.js
@@ -1108,4 +1108,20 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test("Should not re-parse the model after save if {parse: false} is specified", 1, function() {
+    var count = 0;
+    var Model = Backbone.Model.extend({
+      sync: function(method, model, options) {
+        options.success({item: 'value'});
+      },
+      parse: function(attr) {
+        count++;
+        return attr;
+      }
+    });
+    var model = new Model({item: 'test'}, {parse: true});
+    model.save({item: 'value'}, {parse: false});
+    equal(count, 1);
+  });
+
 });


### PR DESCRIPTION
If `{parse: false}` is passed in the options during a save, the model should not attempt to parse the response after the save completes.
