### PR TITLE
Added 'remove' event when view is removed()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1034,6 +1034,7 @@
     remove: function() {
       this.$el.remove();
       this.stopListening();
+      this.trigger('remove', this);
       return this;
     },
 

--- a/test/view.js
+++ b/test/view.js
@@ -327,4 +327,23 @@ $(document).ready(function() {
     equal(counter, 4);
   });
 
+  test("removed from DOM and triggers 'remove' event", 3, function() {
+    var View = Backbone.View.extend({
+      el: '<p>test</p>'
+    });
+
+    var view = new View();
+    document.body.appendChild(view.render().el);
+    ok(view.$el.width());
+
+    var removeEventCalled = false;
+    view.on('remove', function() {
+      removeEventCalled = true;
+    });
+
+    view.remove();
+    ok(!view.$el.width());
+    equal(removeEventCalled, true);
+  });
+
 });


### PR DESCRIPTION
When it comes to integrating with third-party libraries and, in general, code that retains a connection with the view and communicates via events, knowing when the view is removed is an important piece of information.

Consider a library that takes a Backbone.View and sends it events whenever something happens, be it DOM mutations or server communications. It would be really great if the library could listen for when the view gets removed and stop processing for that view.

With the minimal addition of the view `remove` event, any code that interacts and depends on the view would be able to free resources appropriately at the opportune moment, that is for the duration of the view's existence. This can be thought of the view's equivalent of a model 'destroy'.
