### PR TITLE
Check the parameters passed to Events.listenTo and Events.listenToOnce m...

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -216,6 +216,9 @@
   // listening to.
   _.each(listenMethods, function(implementation, method) {
     Events[method] = function(obj, name, callback) {
+      if(!obj||(typeof obj!=="object")) throw new Error("The first passed parameter must be a valid non-null object!");
+      if(!(""+name)) throw new Error("The second passed parameter must be or be able to converted to  a non-empty string!");
+      if(typeof callback!=="function") throw new Error("The third passed parameter must be a valid function!");
       var listeners = this._listeners || (this._listeners = {});
       var id = obj._listenerId || (obj._listenerId = _.uniqueId('l'));
       listeners[id] = obj;


### PR DESCRIPTION
Codes added here is to check the parameters passed to Events.listenTo and Events.listenToOnce methods.
This patch is for the Issue #2562 created by @danwashusen. 
The things frustrating @danwashusen is that the error info thrown is not the actual cause. The root cause is the first  parameter passed to Events.listenTo method is null/undefined but  Backbone has not checked the passed parameters. I think it is a common issue for Backbone.It is unfriendly to the developers. It may cause the error info is matterless to the true root cause. It is necessary to check the passed parameters and throw corresponding errors.It is helpful for developers to locate the error more accurately.
