### PR TITLE
Do not load the hash as a fallback.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1448,7 +1448,7 @@
       }
       if (current === this.fragment) return false;
       if (this.iframe) this.navigate(current);
-      this.loadUrl() || this.loadUrl(this.getHash());
+      this.loadUrl();
     },
 
     // Attempt to load the current URL fragment. If a route succeeds with a

--- a/test/router.js
+++ b/test/router.js
@@ -630,4 +630,30 @@ $(document).ready(function() {
     });
   });
 
+  test('No hash fallback.', 0, function() {
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: {
+        pushState: function(){},
+        replaceState: function(){}
+      }
+    });
+
+    var Router = Backbone.Router.extend({
+      routes: {
+        hash: function() { ok(false); }
+      }
+    });
+    var router = new Router;
+
+    location.replace('http://example.com/');
+    Backbone.history.start({
+      pushState: true,
+      hashChange: false
+    });
+    location.replace('http://example.com/nomatch#hash');
+    Backbone.history.checkUrl();
+  });
+
 });


### PR DESCRIPTION
While doing some debugging for #2566, I ran across this [line of code](https://github.com/braddunbar/backbone/blob/61987e8debca6a80b5ac07eef8a0d774a150cda2/backbone.js#L1444).  It appears to contain a fallback so that an unsuccessful execution of `loadUrl` (matching no routes) will attempt to load the hash instead.  I'm not certain why this was originally added, though I suspect it concerns Firefox hash bugs.

All the tests pass without the fallback and it fixes the subtle bug described by the attached test case.
