### PR TITLE
Add a serialize method to Model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -542,6 +542,13 @@
     parse: function(resp, options) {
       return resp;
     },
+    
+    // **serialize** converts a model's attributes into data suitable for saving
+    // to a server. The default implementation renders a JSON string from the
+    // model's attributes object.
+    serialize: function(options) {
+      return JSON.stringify(options.attrs || this.toJSON(options));
+    },
 
     // Create a new model with identical attributes to this one.
     clone: function() {
@@ -1147,7 +1154,7 @@
     // Ensure that we have the appropriate request data.
     if (options.data == null && model && (method === 'create' || method === 'update' || method === 'patch')) {
       params.contentType = 'application/json';
-      params.data = JSON.stringify(options.attrs || model.toJSON(options));
+      params.data = model.serialize(options);
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.

--- a/test/model.js
+++ b/test/model.js
@@ -455,6 +455,27 @@ $(document).ready(function() {
     equal(this.ajaxSettings.data, "{\"b\":2,\"d\":4}");
   });
 
+  test("save as XML", function() {
+    doc.serialize = function(options) {
+      var i = 0, xml = '<?xml version="1.0"?><items>', key,
+          keys = _.keys(doc.attributes).sort();
+          
+      for (i = 0; i < keys.length; i++) {
+        key = keys[i];
+        xml += '<item><key>' + key + '</key><value>' + doc.get(key) + '</value></item>';
+      }
+      xml += '</items>';
+      
+      options.contentType || (options.contentType = 'application/xml');
+      return xml;
+    };
+    
+    doc.clear().set({a: 1, b: 2});
+    doc.save();
+    equal(this.ajaxSettings.data, '<?xml version="1.0"?><items><item><key>a</key><value>1</value></item><item><key>b</key><value>2</value></item></items>');
+    equal(this.ajaxSettings.contentType, 'application/xml');
+  });
+
   test("save in positional style", 1, function() {
     var model = new Backbone.Model();
     model.sync = function(method, model, options) {


### PR DESCRIPTION
This pull request adds a `serialize` method to the `Model` class, and calls the model's `serialize` method during `sync`. This way, `serialize` can be overridden when server wants something other than a JSON representation of the attributes. This allows developer to avoid having to override the `sync` method. It should be considered the inverse of the `parse` method.
