### PR TITLE
Added toggle method for Backbone.Model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -558,6 +558,12 @@
       return this._validate({}, _.extend(options || {}, { validate: true }));
     },
 
+    // Toggle the value of an attribute, firing `"change"`.
+    toggle: function(attr, options) {
+      options = options ? _.clone(options) : {}
+      return this.set(attr, !this.get(attr), options)
+    },
+
     // Run validation against the next complete set of model attributes,
     // returning `true` if all is well. Otherwise, fire an `"invalid"` event.
     _validate: function(attrs, options) {

--- a/test/model.js
+++ b/test/model.js
@@ -1108,4 +1108,12 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test("toggle", function() {
+    var model = new Backbone.Model({foo: true, bar: false})
+    model.toggle('foo')
+    equal(model.get('foo'), false)
+    model.toggle('bar')
+    equal(model.get('bar'), true)
+  });
+
 });


### PR DESCRIPTION
This PR adds a simple `toggle` method to `Backbone.Model`. It will toggle the value of any attribute passed in and then trigger a `"change"`.

``` javascript
var book = new Backbone.Model({
  available: true
});

book.toggle('available') // Sets available to false
```
