### PR TITLE
Propagate events of subviews

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1091,6 +1091,22 @@
       return this;
     },
 
+    propagateEvents: function (view, events) {
+      if (!_.isArray(events) && !_.isString("string")) return this;
+      if (_.isArray(events)) {
+        _.each(events, function (eventName) {
+          view.on(eventName, function () {
+            this.trigger.apply(this, [eventName].concat(Array.prototype.slice.call(arguments)));
+          }, this);
+        }, this);
+      } else {
+        view.on(events, function () {
+          this.trigger.apply(this, [events].concat(Array.prototype.slice.call(arguments)));
+        }, this);
+      }
+      return this;
+    },
+
     // Ensure that the View has a DOM element to render into.
     // If `this.el` is a string, pass it through `$()`, take the first
     // matching element, and re-assign it to `el`. Otherwise, create

--- a/test/view.js
+++ b/test/view.js
@@ -114,6 +114,34 @@ $(document).ready(function() {
     equal(counter2, 3);
   });
 
+  test("propagateEvents single event", 1, function () {
+    var parentView = new Backbone.View({el: '<div id="test"><div id="subview"></div></div>'});
+    var subView = new Backbone.View({});
+
+    subView.setElement(parentView.$('#subview'));
+    parentView.propagateEvents(subView, 'event1');
+    parentView.on('event1', function () {
+      ok(true);
+    });
+    subView.trigger("event1");
+  });
+
+  test("propagateEvents events array", 2, function () {
+    var parentView = new Backbone.View({el: '<div id="test"><div id="subview"></div></div>'});
+
+    var subView = new Backbone.View({});
+    subView.setElement(parentView.$('#subview'));
+
+    parentView.propagateEvents(subView, ['event1', 'event2']);
+    parentView.on('event1', function () {
+      ok(true);
+    }).on("event2", function () {
+      ok(true);
+    });
+
+    subView.trigger("event1").trigger("event2");
+  });
+
   test("_ensureElement with DOM node el", 1, function() {
     var View = Backbone.View.extend({
       el: document.body
@@ -326,5 +354,4 @@ $(document).ready(function() {
     view2.$('#test').trigger('click');
     equal(counter, 4);
   });
-
 });


### PR DESCRIPTION
This method came in handy when writing a large application
nesting Backbone views. Specifically, this was needed
when handling navigation events with two different controllers based
on whether the application was rendering on a mobile device
or in a desktop browser.
