### PR TITLE
Document listenTo's implicit 'this' context.

### DIFF
--- a/index.html
+++ b/index.html
@@ -791,7 +791,7 @@ object.off();
       Tell an <b>object</b> to listen to a particular event on an <b>other</b> object.
       The advantage of using this form, instead of <tt>other.on(event, callback)</tt>,
       is that <b>listenTo</b> allows the <b>object</b> to keep track of the events,
-      and they can be removed all at once later on. the <tt>this</tt> context for the
+      and they can be removed all at once later on. The <tt>this</tt> context for the
       callback will be set to the listening <b>object</b>.
     </p>
 


### PR DESCRIPTION
That the context to the callback in listenTo is this, is only
documented as issue discussions on github. This adds explicit
documentation of that semantic.

See Issue #1999

PS. Not sure how to submit documentation fixes, this isn't documented in CONTRIBUTING.md.
