### PR TITLE
Prevent initialize when instantiating temporary merge model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -257,7 +257,9 @@
     }
     this.set(attrs, options);
     this.changed = {};
-    this.initialize.apply(this, arguments);
+    if (!options._preventInitialize) {
+      this.initialize.apply(this, arguments);
+    }
   };
 
   // Attach all inheritable methods to the Model prototype.
@@ -691,6 +693,7 @@
 
         // This is a new model, push it to the `toAdd` list.
         } else if (add) {
+          model.initialize();
           toAdd.push(model);
 
           // Listen to added models' events, and index models for lookup by
@@ -910,7 +913,7 @@
         if (!attrs.collection) attrs.collection = this;
         return attrs;
       }
-      options || (options = {});
+      _.extend(options || {}, {_preventInitialize: true});
       options.collection = this;
       var model = new this.model(attrs, options);
       if (!model._validate(attrs, options)) {


### PR DESCRIPTION
When a collection fetches updates on its models it uses the _prepareModel method to set up a new model with the fetched attributes. Either this model becomes a new model in the collection or it is used to merge with an existing model.

A problem can occur when it instantiates a new model and the initialize method runs. The initialize method is often customized by the developer and can contain some harmful, or at least totally unnecessary code for merging purposes. 

Specifically I run into a scenario where my model listened to events in the initialize method, causing the temporary merge-model to never stop listening after the merge.

But this is just one scenario. I think it is a good principle to not trigger the initialize-method since Backbone tries to do its own thing and triggering initilize can cause all sorts of havoc.

Instead the initialize method is run right before it is added to the collection, so the only delay is the check for "merge".

I do see an issue if you have manipulated the attributes in the initialize method, but manipulating attributes on instantiation should be done with a parse method.
