### PR TITLE
Don't revalidate in Collection#_prepareModel

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -565,7 +565,7 @@
       attrs = _.extend({}, this.attributes, attrs);
       var error = this.validationError = this.validate(attrs, options) || null;
       if (!error) return true;
-      this.trigger('invalid', this, error, _.extend(options || {}, {validationError: error}));
+      this.trigger('invalid', this, error, options || {});
       return false;
     }
 
@@ -914,7 +914,7 @@
       options.collection = this;
       var model = new this.model(attrs, options);
       if (!model.validationError) return model;
-      this.trigger('invalid', this, attrs, options);
+      this.trigger('invalid', attrs, model.validationError, options);
       return false;
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -448,8 +448,8 @@ $(document).ready(function() {
       model: ValidatingModel
     });
     var col = new ValidatingCollection();
-    col.on('invalid', function (collection, attrs, options) {
-      equal(options.validationError, 'fail');
+    col.on('invalid', function (attrs, error, options) {
+      equal(error, 'fail');
     });
     equal(col.create({"foo":"bar"}, {validate:true}), false);
   });


### PR DESCRIPTION
As pointed out by @kuzemchik, a second `_validate` call is really unnecessary here. Also, I've changed the arguments in the event to match those passed in `_validate`.
