### PR TITLE
Triggering the sort event now only depends on the sort variable

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -734,7 +734,7 @@
       }
 
       // Trigger `sort` if the collection was sorted.
-      if (sort || (order && order.length)) this.trigger('sort', this, options);
+      if (sort) this.trigger('sort', this, options);
       return this;
     },
 


### PR DESCRIPTION
It looks like whether you sort a collection during `set` depends only on the `sort` variable. So triggering the `sort` event now also depends only on the `sort` variable.

Signed-off-by: Adriaan Labuschagne adriaanlabuschagne@gmail.com
