### PR TITLE
Resolve returned xhr(promise) with model.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1183,7 +1183,10 @@
     // Make the request, allowing the user to override any Ajax options.
     var xhr = options.xhr = Backbone.ajax(_.extend(params, options));
     model.trigger('request', model, xhr, options);
-    return xhr;
+    //return promise that will be resolved with model
+    return xhr && xhr.then ? xhr.then(function(){
+      return model;
+    }) : xhr;
   };
 
   var noXhrPatch = typeof window !== 'undefined' && !!window.ActiveXObject && !(window.XMLHttpRequest && (new XMLHttpRequest).dispatchEvent);


### PR DESCRIPTION
Hi,

I have faced the need to use Promises with Backbone methods, or `Backbone.sync` in general.
I would really like to use model, as first argument of fulfill function.

I read problems related to #1774, #2489, and #2345.
I come with a simple idea: instead of trying to introduce Promises into entire Backbone flow, we can tune those given by jQuery (if any).

Simply, if we have Promise available, we will use it to resolve with `model`, otherwise we will return xhr as we did before.

Thanks to that, old non-promise apps and flows will still work, but we could use [jQuery.Deferreds](http://api.jquery.com/jQuery.Deferred/), [Q](https://github.com/kriskowal/q), etc. to do what we want. 

``` javascript
function doSmthWithModel( model ){
    console.log(model);
    //..
}
//jQuery.Deferred
model.save().then( doSmthWithModel );
```

to work around `false` returned by Model#save

``` javascript
$.when( model.save() ).then( doSmthWithModel )
```

or use Q, which also solves `false` issue

``` javascript
Q( model.save() ).then( doSmthWithModel )
```

if we need a rejection even nicer `( model.save() || Q.reject(model))`

So it will be tiny step towards Promises in Backbone.

I have also made it work for jQuery>1.6 with `.pipe` if we need @50c8cf49ac62ef8fa9a0a4169fa6f3dba89bd7d4.
