### PR TITLE
Ensure Collection#get does not return a false negative during the change:attr event

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -790,7 +790,7 @@
     // Get a model from the set by id.
     get: function(obj) {
       if (obj == null) return void 0;
-      return this._byId[obj.id != null ? obj.id : obj.cid || obj];
+      return this._byId[obj.id] || this._byId[obj.cid] || this._byId[obj];
     },
 
     // Get the model at the given index.

--- a/test/collection.js
+++ b/test/collection.js
@@ -87,7 +87,7 @@ $(document).ready(function() {
     equal(col2.get(model.clone()), col2.first());
   });
 
-  test("update index when id changes", 3, function() {
+  test("update index when id changes", 4, function() {
     var col = new Backbone.Collection();
     col.add([
       {id : 0, name : 'one'},
@@ -95,9 +95,10 @@ $(document).ready(function() {
     ]);
     var one = col.get(0);
     equal(one.get('name'), 'one');
-    one.set({id : 101});
+    col.on('change:name', function (model) { ok(this.get(model)); });
+    one.set({name: 'dalmatians', id : 101});
     equal(col.get(0), null);
-    equal(col.get(101).get('name'), 'one');
+    equal(col.get(101).get('name'), 'dalmatians');
   });
 
   test("at", 1, function() {


### PR DESCRIPTION
As explained by @jrreed in #2177, it's possible for `collection.get(model)` to incorrectly return `undefined` while the model's id is being set (see added test). I'm fairly certain this won't break any existing code, but please take a look before I merge.
