### PR TITLE
Nested attribute selector

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -288,9 +288,14 @@
       return Backbone.sync.apply(this, arguments);
     },
 
-    // Get the value of an attribute.
-    get: function(attr) {
-      return this.attributes[attr];
+    // Get the value of a (nested) attribute
+    get: function(attrs) {
+      attrs = attrs.split(".");
+      var cast = _.clone(this.attributes);
+      for (var i = 0; i < attrs.length; i++) {
+        cast = cast[attrs[i]];
+      }
+      return cast;
     },
 
     // Get the HTML-escaped value of an attribute.


### PR DESCRIPTION
Ran into the problem, that it's quite ugly to get a value which is nested within an attribute. Momentarily this is done like this: model.get("address").street_name. With my addition it is done like the the following: model.get("address.street_name"), off course model.get("address") also still works.
