### PR TITLE
Allow multiple events per delegated trigger

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1069,14 +1069,16 @@
         if (!method) continue;
 
         var match = key.match(delegateEventSplitter);
-        var eventName = match[1], selector = match[2];
+        var eventNames = match[1].split(','), selector = match[2];
         method = _.bind(method, this);
-        eventName += '.delegateEvents' + this.cid;
-        if (selector === '') {
-          this.$el.on(eventName, method);
-        } else {
-          this.$el.on(eventName, selector, method);
-        }
+  			for(var i in eventNames){
+					eventNames[i] += '.delegateEvents' + this.cid;
+					if (selector === '') {
+						this.$el.on(eventNames[i], method);
+					} else {
+						this.$el.on(eventNames[i], selector, method);
+					}
+				}
       }
       return this;
     },


### PR DESCRIPTION
Consider the following event delegation (in a view)

``` javascript
events: {
  'blur #myInput': 'doSomething',
  'keyup #myInput': 'doSomething'
}
```

This change allows the following

``` javascript
events: {
  'blur,keyup #myInput': 'doSomething'
}
```

mh
