### PR TITLE
Reconsider package manager support (bower, component(1))

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,13 @@
+{
+  "name": "backbone",
+  "repo": "documentcloud/backbone",
+  "description": "Give your JS App some Backbone with Models, Views, Collections, and Events.",
+  "version": "1.0.0",
+  "keywords": ["model", "view", "controller", "router", "server", "client", "browser"],
+  "main": "backbone.js",
+  "scripts": ["backbone.js"],
+  "dependencies": {
+    "underscore": "~1.4.3"
+  },
+  "development": {}
+}

--- a/component.json
+++ b/component.json
@@ -1,0 +1,13 @@
+{
+  "name": "backbone",
+  "repo": "documentcloud/backbone",
+  "description": "Give your JS App some Backbone with Models, Views, Collections, and Events.",
+  "version": "1.0.0",
+  "keywords": ["model", "view", "controller", "router", "server", "client", "browser"],
+  "main": "backbone.js",
+  "scripts": ["backbone.js"],
+  "dependencies": {
+    "documentcloud/underscore": "~1.4.3"
+  },
+  "development": {}
+}


### PR DESCRIPTION
**edit 3 Nov 13:** since this hadn't been accepted, check out [Exoskeleton](http://exosjs.com) — my backbone fork with optional dependencies, speed optimisations AND bower / component support.

---

There is one node package manager: NPM. There are lots of client-side package managers.

Until now, all of them weren’t that popular. Now we have two really popular managers:
1. [Twitter Bower](http://bower.io) which is supported by twitter / google and is used in many projects (2.5K+).
2. [Component(1)](https://github.com/component/component/wiki/Components) which has over 1'000 components. Component(1) philosophy lies in super-simple reusable components and this is really cool.

These package managers have very distinct philosophy and are not really compatible with each other, so it makes sense to support both. Many libraries are already doing so (bootstrap, normalise.css, moment.js -- totally ~70K stars for all).

**Now, there is a problem.** We want automatic compilation of bower or component(1) packages. `bower install backbone` will simply clone git repository. Build tool won’t know what is the exact file used. This can be done by manual specification, e.g. `"main"` field of `bower.json` and `component.json`.

_What does it take to support two JSON files?_ Just bump versions on each release and that’s all (can be automated). There are a lot of folks who would gladly send pull requests and improvements for bower and component support (i’m the one). You don’t even need to mess with it.

Just add `bower.json` and `component.json`. This will really simplify our day-to-day life.

cc @visionmedia @satazor @necolas
