### PR TITLE
Change how the parent constructor is called when extending objects

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1534,7 +1534,7 @@
     if (protoProps && _.has(protoProps, 'constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ return parent.apply(this, arguments); };
+      child = function(){ return parent.prototype.constructor.apply(this, arguments); };
     }
 
     // Add static properties to the constructor function, if supplied.


### PR DESCRIPTION
This is so we can monkey patch the parent's constructor later on and
still have it be called by extensions of the base object.

Here is something that is allowed due to this change:

``` javascript
var SomeView = Backbone.View.extend({});
var ctor = Backbone.View.prototype.constructor;
Backbone.View.prototype.constructor = function() {
  alert('Foo');
  ctor.apply(this, arguments);
}

new SomeView(); // Should alert 'Foo'
```
