### PR TITLE
Allow multiple callbacks per event

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1051,7 +1051,7 @@
     //
     //     {
     //       'mousedown .title':  'edit',
-    //       'click .button':     'save'
+    //       'click .button':     'save',
     //       'click .open':       function(e) { ... }
     //     }
     //
@@ -1064,19 +1064,21 @@
       if (!(events || (events = _.result(this, 'events')))) return this;
       this.undelegateEvents();
       for (var key in events) {
-        var method = events[key];
-        if (!_.isFunction(method)) method = this[events[key]];
-        if (!method) continue;
+        var methods = _.isArray(events[key]) ? events[key] : [events[key]];
+        _.each(methods, _.bind(function(method) {
+          if (!_.isFunction(method)) method = this[method];
+          if (!method) return;
 
-        var match = key.match(delegateEventSplitter);
-        var eventName = match[1], selector = match[2];
-        method = _.bind(method, this);
-        eventName += '.delegateEvents' + this.cid;
-        if (selector === '') {
-          this.$el.on(eventName, method);
-        } else {
-          this.$el.on(eventName, selector, method);
-        }
+          var match = key.match(delegateEventSplitter);
+          var eventName = match[1], selector = match[2];
+          method = _.bind(method, this);
+          eventName += '.delegateEvents' + this.cid;
+          if (selector === '') {
+            this.$el.on(eventName, method);
+          } else {
+            this.$el.on(eventName, selector, method);
+          }
+        }, this));
       }
       return this;
     },


### PR DESCRIPTION
Current version cannot do the following (in a View)

``` javascript
events: {
  'click .button': 'foo',
  'click .button': 'bar'
}
```

This is because the key cannot be duplicated.

---

This change allows the following

``` javascript
events: {
  'click .button': ['foo', 'bar']
}
```
