### PR TITLE
QUnit 1.12.0

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -2,11 +2,9 @@ $(document).ready(function() {
 
   var a, b, c, d, e, col, otherCol;
 
-  module("Backbone.Collection", _.extend(new Environment, {
+  module("Backbone.Collection", {
 
     setup: function() {
-      Environment.prototype.setup.apply(this, arguments);
-
       a         = new Backbone.Model({id: 3, label: 'a'});
       b         = new Backbone.Model({id: 2, label: 'b'});
       c         = new Backbone.Model({id: 1, label: 'c'});
@@ -16,7 +14,7 @@ $(document).ready(function() {
       otherCol  = new Backbone.Collection();
     }
 
-  }));
+  });
 
   test("new and sort", 9, function() {
     var counter = 0;

--- a/test/environment.js
+++ b/test/environment.js
@@ -1,45 +1,35 @@
 (function() {
 
-  var Environment = this.Environment = function(){};
+  var sync = Backbone.sync;
+  var ajax = Backbone.ajax;
+  var emulateHTTP = Backbone.emulateHTTP;
+  var emulateJSON = Backbone.emulateJSON;
 
-  _.extend(Environment.prototype, {
+  QUnit.testStart(function() {
+    var env = this.config.current.testEnvironment;
 
-    ajax: Backbone.ajax,
+    // Capture ajax settings for comparison.
+    Backbone.ajax = function(settings) {
+      env.ajaxSettings = settings;
+    };
 
-    sync: Backbone.sync,
-
-    emulateHTTP: Backbone.emulateHTTP,
-
-    emulateJSON: Backbone.emulateJSON,
-
-    setup: function() {
-      var env = this;
-
-      // Capture ajax settings for comparison.
-      Backbone.ajax = function(settings) {
-        env.ajaxSettings = settings;
+    // Capture the arguments to Backbone.sync for comparison.
+    Backbone.sync = function(method, model, options) {
+      env.syncArgs = {
+        method: method,
+        model: model,
+        options: options
       };
+      sync.apply(this, arguments);
+    };
 
-      // Capture the arguments to Backbone.sync for comparison.
-      Backbone.sync = function(method, model, options) {
-        env.syncArgs = {
-          method: method,
-          model: model,
-          options: options
-        };
-        env.sync.apply(this, arguments);
-      };
-    },
+  });
 
-    teardown: function() {
-      this.syncArgs = null;
-      this.ajaxSettings = null;
-      Backbone.sync = this.sync;
-      Backbone.ajax = this.ajax;
-      Backbone.emulateHTTP = this.emulateHTTP;
-      Backbone.emulateJSON = this.emulateJSON;
-    }
-
+  QUnit.testDone(function() {
+    Backbone.sync = sync;
+    Backbone.ajax = ajax;
+    Backbone.emulateHTTP = emulateHTTP;
+    Backbone.emulateJSON = emulateJSON;
   });
 
 })();

--- a/test/model.js
+++ b/test/model.js
@@ -6,10 +6,9 @@ $(document).ready(function() {
   });
   var doc, collection;
 
-  module("Backbone.Model", _.extend(new Environment, {
+  module("Backbone.Model", {
 
     setup: function() {
-      Environment.prototype.setup.apply(this, arguments);
       doc = new proxy({
         id     : '1-the-tempest',
         title  : "The Tempest",
@@ -20,7 +19,7 @@ $(document).ready(function() {
       collection.add(doc);
     }
 
-  }));
+  });
 
   test("initialize", 3, function() {
     var Model = Backbone.Model.extend({

--- a/test/sync.js
+++ b/test/sync.js
@@ -11,20 +11,18 @@ $(document).ready(function() {
     length : 123
   };
 
-  module("Backbone.sync", _.extend(new Environment, {
+  module("Backbone.sync", {
 
     setup : function() {
-      Environment.prototype.setup.apply(this, arguments);
       library = new Library;
       library.create(attrs, {wait: false});
     },
 
     teardown: function() {
-      Environment.prototype.teardown.apply(this, arguments);
       Backbone.emulateHTTP = false;
     }
 
-  }));
+  });
 
   test("read", 4, function() {
     library.fetch();

--- a/test/vendor/qunit.css
+++ b/test/vendor/qunit.css
@@ -1,5 +1,5 @@
 /**
- * QUnit v1.11.0 - A JavaScript Unit Testing Framework
+ * QUnit v1.12.0 - A JavaScript Unit Testing Framework
  *
  * http://qunitjs.com
  *


### PR DESCRIPTION
QUnit 1.12.0 introduces a change or two that break the test suite.  In particular, only own properties are copied from the module test environment to each particular test.  I've modified the suite to use QUnit hooks instead and I think it turned out a little nicer than it was before.
