### PR TITLE
Fix #2656 - Trailing slash on root.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1480,7 +1480,7 @@
       var url = this.root + fragment;
 
       // Don't include a trailing slash on the root.
-      if (fragment === '') url = url.slice(0, -1);
+      if (fragment === '' && url !== '/') url = url.slice(0, -1);
 
       // If pushState is available, we use it to set the fragment as a real URL.
       if (this._hasPushState) {

--- a/test/router.js
+++ b/test/router.js
@@ -671,4 +671,19 @@ $(document).ready(function() {
     Backbone.history.navigate('');
   });
 
+  test('#2656 - No trailing slash on root.', 1, function() {
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: {
+        pushState: function(state, title, url){
+          strictEqual(url, '/');
+        }
+      }
+    });
+    location.replace('http://example.com/path');
+    Backbone.history.start({pushState: true});
+    Backbone.history.navigate('');
+  });
+
 });


### PR DESCRIPTION
This patch allows navigation to the root with or without a trailing slash.  One caveat is that navigating from the root without a slash to the root with a slash does not change the url because they're identical for Backbone's purposes (both yield the fragment `''`).
