### PR TITLE
Allow filtering of incoming data

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -221,9 +221,9 @@ $(document).ready(function() {
   });
 
   test("loadUrl is not called for identical routes.", 0, function() {
+    Backbone.history.loadUrl = function(){ ok(false); };
     location.replace('http://example.com#route');
     Backbone.history.navigate('route');
-    Backbone.history.loadUrl = function(){ ok(false); };
     Backbone.history.navigate('/route');
     Backbone.history.navigate('/route');
   });


### PR DESCRIPTION
Hi,

I'd like to be able to filter incoming data to a collection before display. There doesn't seem to be any functionality to allow me to do this easily, so I've patched backbone to allow me to do this.  My collection now has the following additional method:

``` javascript
var Feed = Backbone.Collection.extend({

        ...

        filter: function(model) {
            var node = model.get('node')
            return (node.substr(-6) == '/posts')
        }
})
```

This isn't a full pull request (i.e. no tests) as I wanted to gauge whether there was actually a way to do this (I can't find any) and whether there is a good reason there isn't something like this in place already. 

If its given the thumbs up then I'll throw in some UTs and then push into this PR to be added.

Thanks, Lloyd.
