### PR TITLE
Add this.options to every View

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -993,6 +993,7 @@
     this.cid = _.uniqueId('view');
     options || (options = {});
     _.extend(this, _.pick(options, viewOptions));
+    this.options = options;
     this._ensureElement();
     this.initialize.apply(this, arguments);
     this.delegateEvents();


### PR DESCRIPTION
The Backbone docs (http://backbonejs.org/#View-constructor) says that the options are merged into "`this.options` for future reference". But in BB 1.0.0 that functionality is broken. This commit unbreaks it. 
