### PR TITLE
fix spelling error in documentation

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1011,7 +1011,7 @@
     tagName: 'div',
 
     // jQuery delegate for element lookup, scoped to DOM elements within the
-    // current view. This should be prefered to global lookups where possible.
+    // current view. This should be preferred to global lookups where possible.
     $: function(selector) {
       return this.$el.find(selector);
     },


### PR DESCRIPTION
Just a quick fix for correct spelling in `preferred`. Saw this while reading through documentation. Everything else looks good.
