### PR TITLE
wrapError shadows original results of options.error callback

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1574,8 +1574,12 @@
   var wrapError = function(model, options) {
     var error = options.error;
     options.error = function(resp) {
-      if (error) error(model, resp, options);
+      var result = undefined;
+      if (error) {
+        result = error(model, resp, options);
+      }
       model.trigger('error', model, resp, options);
+      return result;
     };
   };
 


### PR DESCRIPTION
Hi.

Now I'm troubled with `wrapError` behavior because it shadows original results of `options.error` callback. I want to setup default error callbacks at `Backbone.sync` and join `options.error` callback at `Backbone.View` to the default callbacks. And for stopping callback propagation, I want to returns the results of the callback.

For example:

``` coffeescript
# Backbone.sync overrides
forbiddenHandler = (xhr, status, e) ->
  if xhr and xhr.status is 403
    EventBus.publish Messages.FORBIDDEN, response: xhr
    false

sync = Backbone.sync
Backbone.sync = (method, model, options) ->
  options.error = Util.join options.error, forbiddenHandler # Util.join stops callbacks when its function returns false
  sync method, model, options
```

``` coffeescript
# LoginView
login: (e) ->
  e.preventDefault()
  @model.save
    success: _.bind @_successHandler, @
    error: _.bind @_errorHandler, @

_errorHandler: (model, response, options) ->
  if response and response.status is 403
    res = @parse response
    if res.subStatus
      @_handleAccountLockedError model if res.subStatus is 12
      @_handlePasswordExpiredError model if res.subStatus is 17
      false
    else
      throw new Error "unexpected 403 subStatus: #{res}"
```

In this case, I want to stop error handler at the callback of `LoginView` and don't want to call `forbiddenHandler`.

Could you consider to merge this PR ?
