### PR TITLE
Make delegateEvents work with overwritten callback

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1063,9 +1063,18 @@
     delegateEvents: function(events) {
       if (!(events || (events = _.result(this, 'events')))) return this;
       this.undelegateEvents();
+
+      var _this = this;
+      var getMethod = function(methodName) {
+        if (!_this[methodName]) return null;
+        return function() {
+          return _this[methodName].apply(_this, arguments);
+        };
+      };
+
       for (var key in events) {
         var method = events[key];
-        if (!_.isFunction(method)) method = this[events[key]];
+        if (!_.isFunction(method)) method = getMethod(method);
         if (!method) continue;
 
         var match = key.match(delegateEventSplitter);

--- a/test/view.js
+++ b/test/view.js
@@ -82,6 +82,29 @@ $(document).ready(function() {
     equal(view.counter, 3);
   });
 
+  test("delegateEvents working with overwritten callback", 4, function() {
+    var counter = 0;
+
+    var view = new Backbone.View({el: '<p><a id="test"></a></p>'});
+    view.increment = function(){ counter += 3; };
+
+    var events = {'click #test': 'increment'};
+
+    view.delegateEvents(events);
+    view.$('#test').trigger('click');
+    equal(counter, 3);
+
+    view.increment = function(){ counter++; };
+    view.$('#test').trigger('click');
+    equal(counter, 4);
+
+    view.$('#test').trigger('click');
+    equal(counter, 5);
+
+    view.delegateEvents(events);
+    view.$('#test').trigger('click');
+    equal(counter, 6);
+  });
 
   test("delegateEvents ignore undefined methods", 0, function() {
     var view = new Backbone.View({el: '<p></p>'});


### PR DESCRIPTION
Currently, when callback function is overwritten after calling delegateEvents, overwritten callback function won't get called even though event has been triggered. This change fixes it.
