### PR TITLE
remove null options guard

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -565,7 +565,7 @@
       attrs = _.extend({}, this.attributes, attrs);
       var error = this.validationError = this.validate(attrs, options) || null;
       if (!error) return true;
-      this.trigger('invalid', this, error, _.extend(options || {}, {validationError: error}));
+      this.trigger('invalid', this, error, _.extend(options, {validationError: error}));
       return false;
     }
 


### PR DESCRIPTION
no need to check for null options here as the first line of the
function already assumes an options object.
