### PR TITLE
Update comparator example in the docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1815,9 +1815,7 @@ var book = Library.get(110);
 var Chapter  = Backbone.Model;
 var chapters = new Backbone.Collection;
 
-chapters.comparator = function(chapter) {
-  return chapter.get("page");
-};
+chapters.comparator = 'page';
 
 chapters.add(new Chapter({page: 9, title: "The End"}));
 chapters.add(new Chapter({page: 5, title: "The Middle"}));


### PR DESCRIPTION
Promote the shorter string form of Collection#comparator for simple attribute sorting (really just sugar for the current form given in the example).

It might also be helpful to include an example of a comparator function, if not in the docs (for the interest of space) then maybe in some one-liners page on the wiki.

``` javascript
var deck = new Backbone.Collection;
deck.comparator = function() {
  return _.random(0, this.length);
};
_(52).times(function(n) {
  deck.add({id: n, suit: Math.ceil(n / 13), value: n % 13});
});

alert(deck.pluck('id').join(', '));
```
