### PR TITLE
Add willBeValid to Model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -558,6 +558,15 @@
       return this._validate({}, _.extend(options || {}, { validate: true }));
     },
 
+    // Validate attrs before setting them.
+    // It does not effect both events and validationError.
+    willBeValid: function(attrs, options) {
+      options || (options = {});
+      if (!this.validate) return true;
+      attrs = _.extend({}, this.attributes, attrs);
+      return !this.validate(attrs, _.extend(options, {validate:true}));
+    },
+
     // Run validation against the next complete set of model attributes,
     // returning `true` if all is well. Otherwise, fire an `"invalid"` event.
     _validate: function(attrs, options) {

--- a/test/model.js
+++ b/test/model.js
@@ -1107,4 +1107,16 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test("willBeValid", function() {
+    var model = new Backbone.Model({validA: true, validB: true});
+    model.validate = function(attrs) {
+      if (!(attrs.validA && attrs.validB)) return "invalid";
+    };
+    equal(model.willBeValid(), true);
+    equal(model.willBeValid({validA:false}), false);
+    model.set({validB:false});
+    equal(model.willBeValid(), false);
+    equal(model.willBeValid({validB:true}), true);
+  });
+
 });


### PR DESCRIPTION
This method validates attrs without both raising events and changing validationError.

Similar isValid is no good in my app like the following case:
- Can't pass attrs before setting them
- Always raises "invalid" event, if I don't want it

Please consider if you like!
