### PR TITLE
Dependency injection for views

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -993,6 +993,7 @@
     this.cid = _.uniqueId('view');
     options || (options = {});
     _.extend(this, _.pick(options, viewOptions));
+    this._injectDependencies(options);
     this._ensureElement();
     this.initialize.apply(this, arguments);
     this.delegateEvents();
@@ -1006,6 +1007,10 @@
 
   // Set up all inheritable **Backbone.View** properties and methods.
   _.extend(View.prototype, Events, {
+
+    // A list of dependencies to inject into `this`.
+    // Expects an array of strings.
+    dependencies: [],
 
     // The default `tagName` of a View's element is `"div"`.
     tagName: 'div',
@@ -1102,6 +1107,19 @@
         this.setElement($el, false);
       } else {
         this.setElement(_.result(this, 'el'), false);
+      }
+    },
+
+    // Injects the dependencies onto `this`.
+    // Throws an error if the dependencies are not met.
+    _injectDependencies: function(options) {
+      var missingDependencies = _.filter(this.dependencies, function(dependency) {
+        return !_.has(options, dependency);
+      });
+      if (_.some(missingDependencies)) {
+        throw new Error("One or more dependencies were expected but were undefined: " + missingDependencies.join(', '));
+      } else {
+        _.extend(this, _.pick(options, this.dependencies));
       }
     }
 

--- a/test/view.js
+++ b/test/view.js
@@ -35,6 +35,32 @@ $(document).ready(function() {
 
     strictEqual(new View().one, 1);
   });
+  
+  test("dependency injection", 4, function() {
+    var View = Backbone.View.extend({
+      dependencies: ['foo','bar','baz']
+    });
+    
+    view = new View({
+      foo: 1,
+      bar: 2,
+      baz: 3
+    });
+    
+    strictEqual(view.foo, 1);
+    strictEqual(view.bar, 2);
+    strictEqual(view.baz, 3);
+    
+    throws(
+      function() {
+        view = new View({
+          foo: 1
+        })
+      },
+      /One or more dependencies were expected but were undefined: bar, baz/,
+      "raised an error containing the undefined dependencies"
+    );
+  });
 
   test("delegateEvents", 6, function() {
     var counter1 = 0, counter2 = 0;


### PR DESCRIPTION
Since the merging of options in views was removed in https://github.com/jashkenas/backbone/pull/2461 the views are missing certain functionality such as the ability to include multiple models/collections or required arguments.

The only way I can think of that would allow such functionality in the current state of backbone.js is to create a nested model with the required objects as attributes eg:

```
new ProductsView({
  model : new Backbone.Model({
    products : new Products,
    session  : new Session
  })
});
```

This is less than ideal since the above example is instantiating a model with the single purpose of including more than one object to the view.

This pull request adds the ability to define expected dependencies and have them injected onto the instance:

```
ProductsView = Backbone.View.extend({
  dependencies : ['session']
});

new ProductsView({
  model   : new Products,
  session : new Session
});
```

This is loosely based off an idea @wookiehangover gave my co-developers, I believe he also gave a talk about this subject recently too.
