### PR TITLE
in extend function,the keyword "return" is unnecessary.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1539,7 +1539,7 @@
     if (protoProps && _.has(protoProps, 'constructor')) {
       child = protoProps.constructor;
     } else {
-      child = function(){ return parent.apply(this, arguments); };
+      child = function(){  parent.apply(this, arguments); };
     }
 
     // Add static properties to the constructor function, if supplied.

--- a/test/model.js
+++ b/test/model.js
@@ -1107,4 +1107,12 @@ $(document).ready(function() {
     model.set({a: true});
   });
 
+  test("extend", 3, function() {
+    var Child = Backbone.Model.extend();
+    var childObj=new Child;
+    equal(Child.__super__,Backbone.Model.prototype);
+    equal(Child.prototype.constructor,Child);
+    equal(childObj.constructor,Child);
+  });
+
 });


### PR DESCRIPTION
in extend function,the keyword "return" is unnecessary.
