### PR TITLE
Fix #2719 - check that the return from Collection.get is an Object

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -790,7 +790,12 @@
     // Get a model from the set by id.
     get: function(obj) {
       if (obj == null) return void 0;
-      return this._byId[obj.id] || this._byId[obj.cid] || this._byId[obj];
+      obj = this._byId[obj.id] || this._byId[obj.cid] || this._byId[obj];
+      if(typeof obj === "object"){
+        return obj;
+      } else {
+        return void 0;
+      }
     },
 
     // Get the model at the given index.

--- a/test/collection.js
+++ b/test/collection.js
@@ -1151,4 +1151,34 @@ $(document).ready(function() {
     this.ajaxSettings.success('response');
   });
 
+  test("#2719 - Collection#set does not think Object.prototype.methods are existing Models", 1, function() {
+    // Firefox has a Object.prototype.watch() method, other browsers do not
+    var collection = new Backbone.Collection,
+        data = {
+          id: 'watch'
+        },
+        model;
+
+    model = collection.set(data);
+    model = collection.get(data);
+    ok(typeof model !== 'function', 'returned a function()');
+  });
+
+  test("#2719 - Collection#get does not return Object.prototype.methods as Models", 2, function() {
+    // Firefox has a Object.prototype.watch() method, other browsers do not
+    var collection = new Backbone.Collection,
+        data = {
+          id: 'watch'
+        },
+        model;
+
+    model = collection.get(data);
+    ok(typeof model !== 'function', 'returned a function()');
+
+    collection.add(data);
+    model = collection.get(data);
+    ok(typeof model !== 'function', 'returned a function()');
+  });
+
+
 });


### PR DESCRIPTION
This stops the mistaken return of Object.prototype methods that match Model id's, e.g. 'watch'
