### PR TITLE
Fix #2719 - Check Collection.add will only merge or delete existing Back...

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -681,7 +681,8 @@
 
         // If a duplicate is found, prevent it from being added and
         // optionally merge it into the existing model.
-        if (existing = this.get(model)) {
+        existing = this.get(model);
+        if (existing && existing.cid) {
           if (remove) modelMap[existing.cid] = true;
           if (merge) {
             attrs = attrs === model ? model.attributes : options._attrs;

--- a/test/collection.js
+++ b/test/collection.js
@@ -237,6 +237,30 @@ $(document).ready(function() {
     equal(collection.first().get('name'), 'Alf');
   });
 
+  test("Issue #2719 - add with merge does not error on non-Backbone Models", function() {
+    var collection = new Backbone.Collection();
+
+    collection._byId.something = {
+      data: 'something has messed with the Collection cache'
+    };
+
+    collection.add({id: 'something', name: 'Real user data'}, {merge: true});
+    equal(collection.get('something').get('name'), 'Real user data');
+  });
+
+  test("Issue #2719 - add with merge does not error on prototype methods", function() {
+    var collection = new Backbone.Collection();
+
+    // Firefox has a Object.prototype.watch() method, other browsers do not so fake it out
+    if(!Object.prototype.watch){
+      collection._byId.watch = function watch(){};
+    }
+
+    collection.add({id: 'watch', name: 'Watch'}, {merge: true});
+    equal(collection.get('watch').get('name'), 'Watch');
+  });
+
+
   test("add model to collection with sort()-style comparator", 3, function() {
     var col = new Backbone.Collection;
     col.comparator = function(a, b) {


### PR DESCRIPTION
...bone Models in its cache

Mitigated now Collection.add default behaviour has been changed since v1.0.0 to {merge: false}, a Collection does not check that it gets an actual Backbone Model from the cache before attempting to merge.
