### PR TITLE
Backbone learns 'sync:fetch', 'sync:save', and 'sync:destroy' triggers

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -435,7 +435,7 @@
       options.success = function(resp) {
         if (!model.set(model.parse(resp, options), options)) return false;
         if (success) success(model, resp, options);
-        model.trigger('sync', model, resp, options);
+        model.trigger('sync sync:fetch', model, resp, options);
       };
       wrapError(this, options);
       return this.sync('read', this, options);
@@ -485,7 +485,7 @@
           return false;
         }
         if (success) success(model, resp, options);
-        model.trigger('sync', model, resp, options);
+        model.trigger('sync sync:save', model, resp, options);
       };
       wrapError(this, options);
 
@@ -514,7 +514,7 @@
       options.success = function(resp) {
         if (options.wait || model.isNew()) destroy();
         if (success) success(model, resp, options);
-        if (!model.isNew()) model.trigger('sync', model, resp, options);
+        if (!model.isNew()) model.trigger('sync sync:destroy', model, resp, options);
       };
 
       if (this.isNew()) {
@@ -861,7 +861,7 @@
         var method = options.reset ? 'reset' : 'set';
         collection[method](resp, options);
         if (success) success(collection, resp, options);
-        collection.trigger('sync', collection, resp, options);
+        collection.trigger('sync sync:fetch', collection, resp, options);
       };
       wrapError(this, options);
       return this.sync('read', this, options);

--- a/test/model.js
+++ b/test/model.js
@@ -938,10 +938,13 @@ $(document).ready(function() {
     model.destroy(opts);
   });
 
-  test("#1412 - Trigger 'sync' event.", 3, function() {
+  test("#1412 - Trigger 'sync' event.", 6, function() {
     var model = new Backbone.Model({id: 1});
     model.sync = function (method, model, options) { options.success(); };
     model.on('sync', function(){ ok(true); });
+    model.on('sync:fetch', function(){ ok(true); });
+    model.on('sync:save', function(){ ok(true); });
+    model.on('sync:destroy', function(){ ok(true); });
     model.fetch();
     model.save();
     model.destroy();
@@ -949,6 +952,7 @@ $(document).ready(function() {
 
   test("#1365 - Destroy: New models execute success callback.", 2, function() {
     new Backbone.Model()
+    .on('sync:destroy', function() { ok(false); })
     .on('sync', function() { ok(false); })
     .on('destroy', function(){ ok(true); })
     .destroy({ success: function(){ ok(true); }});


### PR DESCRIPTION
On occasion, one would like to get notifications for save w/o getting triggers for fetch or destroy. 

I've gone ahead and created this change that adds all three types of sync changes to model/collection (where applicable). It should cover other people's use cases and won't break anyone's existing functionality (Unless of course they already use sync:fetch, sync:save, or sync:destroy as custom triggers on their models..).
