### PR TITLE
Optionally let collection.set keep unsynced models

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -706,7 +706,12 @@
       // Remove nonexistent models if appropriate.
       if (remove) {
         for (i = 0, l = this.length; i < l; ++i) {
-          if (!modelMap[(model = this.models[i]).cid]) toRemove.push(model);
+          model = this.models[i];
+          if (options.keepnew && model.isNew()) {
+            order && order.push(model);
+            continue;
+          }
+          if (!modelMap[model.cid]) toRemove.push(model);
         }
         if (toRemove.length) this.remove(toRemove, options);
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -912,6 +912,10 @@ $(document).ready(function() {
     strictEqual(c.length, 2);
     strictEqual(m2.get('a'), 1);
 
+    // keepnew: true doesn't remove models that aren't saved to the server yet
+    c.set([m2], {keepnew: true});
+    strictEqual(c.length, 2);
+
     // Test removing models not passing an argument
     c.off('remove').on('remove', function(model) {
       ok(model === m2 || model === m3);


### PR DESCRIPTION
I would like to optionally specify that collection.set should not remove models that have not finished saving to the server.
Specifically calling fetch and updating the client with any changes that exist on the server, will cause any models that are in the process of being saved to be removed on the client.
