### PR TITLE
Fix #2765 - Strip hash and query for matching.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1320,6 +1320,9 @@
   // Cached regex for removing a trailing slash.
   var trailingSlash = /\/$/;
 
+  // Cached regex for stripping urls of hash and query.
+  var pathStripper = /[?#].*$/;
+
   // Has the history handling already been started?
   History.started = false;
 
@@ -1446,8 +1449,8 @@
     // Attempt to load the current URL fragment. If a route succeeds with a
     // match, returns `true`. If no defined routes matches the fragment,
     // returns `false`.
-    loadUrl: function(fragmentOverride) {
-      var fragment = this.fragment = this.getFragment(fragmentOverride);
+    loadUrl: function(fragment) {
+      fragment = this.fragment = this.getFragment(fragment);
       return _.any(this.handlers, function(handler) {
         if (handler.route.test(fragment)) {
           handler.callback(fragment);
@@ -1467,11 +1470,13 @@
       if (!History.started) return false;
       if (!options || options === true) options = {trigger: !!options};
 
-      fragment = this.getFragment(fragment || '');
+      var url = this.root + (fragment = this.getFragment(fragment || ''));
+
+      // Strip the fragment of the query and hash for matching.
+      fragment = fragment.replace(pathStripper, '');
+
       if (this.fragment === fragment) return;
       this.fragment = fragment;
-
-      var url = this.root + fragment;
 
       // Don't include a trailing slash on the root.
       if (fragment === '' && url !== '/') url = url.slice(0, -1);

--- a/test/router.js
+++ b/test/router.js
@@ -676,7 +676,7 @@
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
-        pushState: function(state, title, url){
+        pushState: function(state, title, url) {
           strictEqual(url, '/');
         }
       }
@@ -684,6 +684,29 @@
     location.replace('http://example.com/path');
     Backbone.history.start({pushState: true});
     Backbone.history.navigate('');
+  });
+
+  test('#2765 - Fragment matching sans query/hash.', 2, function() {
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: {
+        pushState: function(state, title, url) {
+          strictEqual(url, '/path?query#hash');
+        }
+      }
+    });
+
+    var Router = Backbone.Router.extend({
+      routes: {
+        path: function() { ok(true); }
+      }
+    });
+    var router = new Router;
+
+    location.replace('http://example.com/');
+    Backbone.history.start({pushState: true});
+    Backbone.history.navigate('path?query#hash', true);
   });
 
 })();


### PR DESCRIPTION
This allows navigating to routes with a hash or query while only matching the path.  Note that it changes behavior _slightly_ because fragments cannot include `?` or `#`.  However, I don't think they ever should anyway.

/ping @tgriesser
