### PR TITLE
Added {unshift: true} option to Collection.unshift

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -775,7 +775,7 @@
 
     // Add a model to the beginning of the collection.
     unshift: function(model, options) {
-      this.add(model, _.extend({at: 0}, options));
+      this.add(model, _.extend({at: 0, unshift: true}, options));
       return model;
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -1220,4 +1220,16 @@
     equal(job.items.get(2).subItems.get(3).get('subName'), 'NewThree');
   });
 
+  test("unshift trigger an 'add' event with unshift option", function(){
+    var colE = new Backbone.Collection();
+    var e = new Backbone.Model({id: 10, label : 'e'});
+    e.on('add', function (model, collection, options) {
+      equal(options.unshift, true);
+    });
+    colE.on('add', function (model, collection, options) {
+      equal(options.unshift, true);
+    });
+    colE.unshift(e);
+  });
+
 })();


### PR DESCRIPTION
This is a proposal. I'd like to add a default option {unshift: true} to Collection.unshift. 
This provides more flexibility on handling "add" event. Specifically, there are scenarios, for example, if "add" event triggered by Collection.add, ｊQuery append should be executed, and if triggered by Collection.unshift, ｊQuery prepend should be executed.
Maybe, firing a different event "unshift" would be a more appropriate. But, it seems a little painful for Backbone 1.

Of course, I know we can pass these options as Collection.unshift arguments. But I think the standard way to handle "unshift" event should be defined.
