### PR TITLE
Add "cid" attribute to Backbone.Collection

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -681,6 +681,8 @@
         attrs = models[i];
         if (attrs instanceof Model) {
           id = model = attrs;
+        } else if (_.isFunction(targetModel)) {
+          id = model = this._prepareModel(attrs, options);
         } else {
           id = attrs[targetModel.prototype.idAttribute];
         }


### PR DESCRIPTION
There are often times that is useful to have a unique "cid" attribute for collections, same as models and views.
