### PR TITLE
Fix #2470 Do not mutate options in _prepareModel

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -909,7 +909,7 @@
         if (!attrs.collection) attrs.collection = this;
         return attrs;
       }
-      options || (options = {});
+      options = options ? _.clone(options) : {};
       options.collection = this;
       var model = new this.model(attrs, options);
       if (!model.validationError) return model;


### PR DESCRIPTION
Now that Tim's changes have been merged, we no longer need to mutate the options object in `_prepareModel`. Using a PR for a sanity check @jashkenas @tgriesser @braddunbar
