### PR TITLE
Removed wrapping when emulateJSON is true, can't see a reason for it.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1143,7 +1143,11 @@
     // Ensure that we have the appropriate request data.
     if (options.data == null && model && (method === 'create' || method === 'update' || method === 'patch')) {
       params.contentType = 'application/json';
-      params.data = JSON.stringify(options.attrs || model.toJSON(options));
+      if (options.emulateJSON) {
+        params.data = options.attrs || model.toJSON(options);
+      } else {
+        params.data = JSON.stringify(options.attrs || model.toJSON(options));
+      }
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.

--- a/test/sync.js
+++ b/test/sync.js
@@ -70,7 +70,7 @@
     equal(this.ajaxSettings.type, 'POST');
     equal(this.ajaxSettings.dataType, 'json');
     equal(this.ajaxSettings.data._method, 'PUT');
-    var data = JSON.parse(this.ajaxSettings.data);
+    var data = this.ajaxSettings.data;
     equal(data.id, '2-the-tempest');
     equal(data.author, 'Tim Shakespeare');
     equal(data.length, 123);
@@ -96,7 +96,7 @@
     equal(this.ajaxSettings.url, '/library/2-the-tempest');
     equal(this.ajaxSettings.type, 'PUT');
     equal(this.ajaxSettings.contentType, 'application/x-www-form-urlencoded');
-    var data = JSON.parse(this.ajaxSettings.data);
+    var data = this.ajaxSettings.data;
     equal(data.id, '2-the-tempest');
     equal(data.author, 'Tim Shakespeare');
     equal(data.length, 123);


### PR DESCRIPTION
Hi,

When setting emulateJSON to true the model's values get wrapped in `{model: …}`. This is the commit that where was introduced, and it seems to have been kept ever since:

> 302c0d5 John Wright Thu Oct 28 20:21:59 2010 -0600
>  Added Backbone.emulateJSON to enable the current behavior of syncing
>   and made sending the body as application/json without a wrapping model
>   param, the default

I haven't been able to find any reasoning/justification for the difference. It's not _only_ emulating JSON if it wraps the data in the new keys, in my opinion, so I removed it.

Regards,
Iain
