### PR TITLE
Transition from hash-based route: check it's really a route (and not an ...

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1417,7 +1417,9 @@
         // in a browser where it could be `pushState`-based instead...
         } else if (this._hasPushState && atRoot && loc.hash) {
           this.fragment = this.getHash().replace(routeStripper, '');
-          this.history.replaceState({}, document.title, this.root + this.fragment + loc.search);
+          if (this.loadUrl(this.fragment)) {
+            this.history.replaceState({}, document.title, this.root + this.fragment + loc.search); 
+          }
         }
 
       }


### PR DESCRIPTION
...anchor)
## Issue

On `http://mysuperapp.com` (with a pushState-enabled browser) suppose we have a `<a href="#top">Go to top</a>` link. After having clicked on it, location is now `http://mysuperapp.com/#top`.

When refreshing the page (F5), Backbone history converts it to `http://mysuperapp.com/top` which is wrong because `'top'` is not a route...
## Proposed solution

Just check the fragment `'top'` is **really** a route. This allows usage of anchors in pushState-enabled browsers.
