### PR TITLE
Support multiple Routers with overlapping routes

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -709,4 +709,30 @@
     Backbone.history.navigate('path?query#hash', true);
   });
 
+  test('Support multiple Routers with overlapping routes', 2, function(){
+    var FeatureRouter = Backbone.Router.extend({
+      routes: {
+        'example': 'featureCallback'
+      },
+
+      featureCallback: function(){
+        ok(true);
+      }
+    });
+
+    var GlobalRouter = Backbone.Router.extend({
+      routes: {
+        'example': 'globalCallback'
+      },
+
+      globalCallback: function(){
+        ok(true);
+      }
+    });
+
+    var router1 = new FeatureRouter;
+    var router2 = new GlobalRouter;
+    Backbone.history.navigate('example', true);
+  });
+
 })();


### PR DESCRIPTION
This modification allows each Router created to have its routes evaluated and run separate from other Routers. Originally, all routes were evaluated at the same time and quit as soon as a route was was matched. Overlapping routes defined in other Routers from wouldn't be triggered.
### Example:

In the following example, say I have a "feature" backbone app with its own `Backbone.Router`, and another "analytics" app with its own `Backbone.Router` that handles analytics tracking across all features. Ideally, they shouldn't care about each other, or get in each other's way.

``` .js
var newsRouter = Backbone.Router.extend({
  routes: {
        'news/:id': 'article'
    },

    article: function() {
        // Render the article
    }
})

var analyticsRouter = Backbone.Router.extend({
    routes: {
        'news/:id': 'trackArticleView'
    },

    trackArticleView: function() {
        // GA or Omniture event route-specific event tracking code.
    }
})
```

Before this mod, only one of these route callbacks would be fired - the first one found. Now, both routers can function independently without worrying about conflicts.
