### PR TITLE
Can now pass optional keys to omit when cloning a model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -542,9 +542,13 @@
       return resp;
     },
 
-    // Create a new model with identical attributes to this one.
-    clone: function() {
-      return new this.constructor(this.attributes);
+    // Create a new model with identical attributes to this one. If `omit: keys`
+    // is passed, these attributes will not be cloned. `keys` can be a `string`
+    // or an `array` of `string`
+    clone: function(options) {
+      options || (options = {});
+      console.log(_.omit(this.attributes, options.omit));
+      return new this.constructor(_.omit(this.attributes, options.omit));
     },
 
     // A model is new if it has never been saved to the server, and lacks an id.

--- a/test/model.js
+++ b/test/model.js
@@ -140,6 +140,22 @@
     equal(bar.get('p'), undefined);
   });
 
+  test("clone omitting one key", 3, function() {
+    var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
+    var b = a.clone({omit: 'foo'});
+    equal(b.get('foo'), undefined);
+    equal(b.get('bar'), a.get('bar'));
+    equal(b.get('baz'), a.get('baz'));
+  });
+
+  test("clone omitting an array of keys", 3, function() {
+    var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
+    var b = a.clone({omit: ['foo', 'bar']});
+    equal(b.get('foo'), undefined);
+    equal(b.get('bar'), undefined);
+    equal(b.get('baz'), a.get('baz'));
+  });
+
   test("isNew", 6, function() {
     var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
     ok(a.isNew(), "it should be new");


### PR DESCRIPTION
Can now do:

```
model.clone({omit: "id"})
```

or

```
model.clone({omit: ["name", "firstname"]})
```

There might be other ways to do that but I find it comfortable.

I chose `omit` instead of `except` so it stays consitent with underscore method's name.
Having an `only` option could also be useful.
