### PR TITLE
fixing minor inconsistency in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -864,7 +864,7 @@ view.stopListening(model);
 
     <p>
       Generally speaking, when calling a function that emits an event
-      (<tt>model.set()</tt>, <tt>collection.add</tt>, and so on...),
+      (<tt>model.set</tt>, <tt>collection.add</tt>, and so on...),
       if you'd like to prevent the event from being triggered, you may pass
       <tt>{silent: true}</tt> as an option. Note that this is <i>rarely</i>,
       perhaps even never, a good idea. Passing through a specific flag


### PR DESCRIPTION
should be consistent about parens (having it on both, or neither) after `model.set` and `collection.add`
