### PR TITLE
add bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "backbone",
+  "main": "backbone.js",
+  "version": "1.1.0",
+  "dependencies"  : {
+    "underscore"  : ">=1.4.3"
+  },
+  "devDependencies": {
+    "phantomjs": "1.9.0-1",
+    "docco": "0.6.1",
+    "coffee-script": "1.6.1"
+  },
+  "ignore": [
+    "test/",
+    "Rakefile",
+    "docs/",
+    "raw/",
+    "examples/",
+    "index.html",
+    ".jshintrc"
+  ]
+}


### PR DESCRIPTION
While I know it is a pain to manage yet another file during releases, the backbone entry in bower is already coming from this repo, and so it would be great to use a few of the features of the bower.json file to make it's use a bit more pleasurable. 

Most notably, include the `main` attribute to list `backbone.js` as the main file, and
the `ignore` property to not include the things being ignored in `.npmignore`.
