### PR TITLE
Add `set` event triggered once when collection models are added or removed

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -1295,4 +1295,34 @@
     equal(job.items.get(2).subItems.get(3).get('subName'), 'NewThree');
   });
 
+  test("adding multiple models triggers `set` event once", 1, function() {
+    var collection = new Backbone.Collection;
+    collection.on('set', function() { ok(true); });
+    collection.add([{id: 1}, {id: 2}, {id: 3}]);
+  });
+
+  test("removing models triggers `set` event once", 1, function() {
+    var collection = new Backbone.Collection([{id: 1}, {id: 2}, {id: 3}]);
+    collection.on('set', function() { ok(true); });
+    collection.remove([{id: 1}, {id: 2}]);
+  });
+
+  test("remove does not trigger `set` when nothing removed", 0, function() {
+    var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
+    collection.on('set', function() { ok(false); });
+    collection.remove([{id: 3}]);
+  });
+
+  test("set triggers `set` event once", 1, function() {
+    var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
+    collection.on('set', function() { ok(true); });
+    collection.set([{id: 1}, {id: 3}]);
+  });
+
+  test("set does not trigger `set` event when nothing added nor removed", 0, function() {
+    var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
+    collection.on('set', function() { ok(false); });
+    collection.set([{id: 1}, {id: 2}]);
+  });
+
 })();


### PR DESCRIPTION
Events `add` and `remove` are a great way to keep a view in sync with collection. A view can observe when collection's content changes and re-render itself. A model can be added only in the client or loaded from the server and this is transparent to the view.

However, `add` and `remove` are triggered for every single model added/removed, which results in render being called multiple times. This causes performance issues, as rendering can be a heavy operation.

I'm not the first one to encounter this problem:
* http://backbonefu.com/2013/08/handling-multiple-collection-add-models-in-a-batch/
* http://blog.pamelafox.org/2013/06/improving-backbone-app-performance.html

My suggestion is to add a new event `set` that is triggered every time models are added or removed, but just once during one operation. E.g. calling `add` with multiple models will trigger `add` event for every model and `set` event only once.