### PR TITLE
Use QUnit `raises` instead of `throws`

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -305,7 +305,7 @@
 
   test("if callback is truthy but not a function, `on` should throw an error just like jQuery", 1, function() {
     var view = _.extend({}, Backbone.Events).on('test', 'noop');
-    throws(function() {
+    raises(function() {
       view.trigger('test');
     });
   });


### PR DESCRIPTION
`throws` is a future reserved word (http://www.ecma-international.org/publications/files/ECMA-ST-ARCH/ECMA-262,%203rd%20edition,%20December%201999.pdf), and using it causes problems with Closure Compiler and (reportedly) NarwhalJS (https://github.com/jquery/qunit/pull/323).

QUnit has `raises` as an alias.
