### PR TITLE
correcting indexOf condition in History.getFragment

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1347,7 +1347,7 @@
         if (this._hasPushState || !this._wantsHashChange || forcePushState) {
           fragment = this.location.pathname;
           var root = this.root.replace(trailingSlash, '');
-          if (!fragment.indexOf(root)) fragment = fragment.slice(root.length);
+          if (fragment.indexOf(root) < 0) fragment = fragment.slice(root.length);
         } else {
           fragment = this.getHash();
         }


### PR DESCRIPTION
https://github.com/jashkenas/backbone/blob/master/backbone.js#L1350

`if (!fragment.indexOf(root))` — this will be true if root will be on the beginning of the fragment, because indexOf returns `-1` if it doesn't find the argument string according to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/indexOf and if I understand correctly, we need to find out if root is not in the fragment, which will be `if (fragment.indexOf(root) < 0)`
