### PR TITLE
Change Documented Method Signature of "new Collection" and "new Model"

### DIFF
--- a/index.html
+++ b/index.html
@@ -975,7 +975,7 @@ var Note = Backbone.Model.extend({
 </pre>
 
     <p id="Model-constructor">
-      <b class="header">constructor / initialize</b><code>new Model([attributes], [options])</code>
+      <b class="header">constructor / initialize</b><code>new Model(attributes, [options])</code>
       <br />
       When creating an instance of a model, you can pass in the initial values
       of the <b>attributes</b>, which will be <a href="#Model-set">set</a> on the
@@ -1628,7 +1628,7 @@ var Library = Backbone.Collection.extend({
 </pre>
 
     <p id="Collection-constructor">
-      <b class="header">constructor / initialize</b><code>new Backbone.Collection([models], [options])</code>
+      <b class="header">constructor / initialize</b><code>new Backbone.Collection(models, [options])</code>
       <br />
       When creating a Collection, you may choose to pass in the initial array
       of <b>models</b>.  The collection's <a href="#Collection-comparator">comparator</a>


### PR DESCRIPTION
According to the source code, supplying models and attributes for
"new Backbone.Collection" and "new Backbone.Model", respectively,
are NOT optional. If "models"/"attributes" is omitted and "options"
supplied "options" will be used as if it were a model or an array
of models.
