### PR TITLE
Fixes potential issues with comparator and bindAll

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -833,7 +833,7 @@
       options || (options = {});
 
       // Run sort based on type of `comparator`.
-      if (_.isString(this.comparator) || (this.comparatorLength || this.comparator.length) === 1) {
+      if (_.isString(this.comparator) || (this.comparator.length || this.comparatorLength) === 1) {
         this.models = this.sortBy(this.comparator, this);
       } else {
         this.models.sort(_.bind(this.comparator, this));


### PR DESCRIPTION
In the event that a comparator function declared at instantiation is bound, these bindings can cause sort to work incorrectly. These errors can occur in IE < 9, PhantomJS, & Safari 5, or when using alternative libraries such as Lo-Dash.

In particular, this occurs if _.bindAll(this) is called in the constructor. While not good practice (and subsequently not an option in Underscore 1.5.0), it has been a prevalent anti-pattern.

This pull request increases Backbone resiliency (and compatibility with other libraries) by storing the original comparator's length during instantiation. In the event that comparator is manually updated, will default to using this.comparator.length first. Only in the event that this is falsy will this.comparatorLength be used.
