### PR TITLE
_addReference, to mirror _removeReference

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -1284,4 +1284,39 @@
     equal(job.items.get(2).subItems.get(3).get('subName'), 'NewThree');
   });
 
+  test('_addReference binds all collection events & adds to the lookup hashes', 9, function() {
+
+    var calls = {add: 0, remove: 0};
+
+    var Collection = Backbone.Collection.extend({
+
+      _addReference: function(model) {
+        Backbone.Collection.prototype._addReference.apply(this, arguments);
+        calls.add++;
+        equal(model, this._byId[model.id]);
+        equal(model, this._byId[model.cid]);
+        equal(model._events.all.length, 1);
+      },
+
+      _removeReference: function(model) {
+        Backbone.Collection.prototype._removeReference.apply(this, arguments);
+        calls.remove++;
+        equal(this._byId[model.id], void 0);
+        equal(this._byId[model.cid], void 0);
+        equal(model.collection, void 0);
+        equal(model._events.all, void 0);
+      }
+
+    });
+
+    var collection = new Collection();
+    var model = collection.add({id: 1});
+    collection.remove(model);
+
+    equal(calls.add, 1);
+    equal(calls.remove, 1);
+
+  });
+
+
 })();


### PR DESCRIPTION
I've been working with modifying some collection internals for a few ideas I've had, and things are much easier to extend if there's an central point for both adding & removing the collection reference on the model. It'd make `collection.set` less of a black box, and gives a bit of symmetry between adding & removing the model internally.

It also passes along the `options` object, as is common elsewhere in the library, if (for example) you'd like to be able to set some flags in the `options` object to determine what events should be bound on the model.
