### PR TITLE
Fix #2850 - Use `hashChange: false` where appropriate.

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -684,7 +684,7 @@
       }
     });
     location.replace('http://example.com/root/path');
-    Backbone.history.start({pushState: true, root: 'root'});
+    Backbone.history.start({pushState: true, hashChange: false, root: 'root'});
     Backbone.history.navigate('');
   });
 
@@ -699,7 +699,7 @@
       }
     });
     location.replace('http://example.com/path');
-    Backbone.history.start({pushState: true});
+    Backbone.history.start({pushState: true, hashChange: false});
     Backbone.history.navigate('');
   });
 
@@ -722,7 +722,7 @@
     var router = new Router;
 
     location.replace('http://example.com/');
-    Backbone.history.start({pushState: true});
+    Backbone.history.start({pushState: true, hashChange: false});
     Backbone.history.navigate('path?query#hash', true);
   });
 


### PR DESCRIPTION
I should've checked when I wrote these tests.  :blush:
