### PR TITLE
Improve events performance in some cases by 20x.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -115,7 +115,7 @@
       var retain, ev, events, names, i, l, j, k;
       if (!this._events || !eventsApi(this, 'off', name, [callback, context])) return this;
       if (!name && !callback && !context) {
-        this._events = {};
+        this._events = void 0;
         return this;
       }
       names = name ? [name] : _.keys(this._events);


### PR DESCRIPTION
Things like [Chaplin](http://chaplinjs.org) are using advanced memory management heavily. This includes unbinding of all events too.

Events are getting unbound all the time. When other objects may still try to trigger events, this will increase performance by 20x.

Initially taken from my Backbone fork with optional dependencies — [Exoskeleton](http://exosjs.com).

Proof of 20x speed: http://jsperf.com/exoskeleton-events-vs-backbone-events
