### PR TITLE
Fix AMD tests

### DIFF
--- a/test/test-amd.html
+++ b/test/test-amd.html
@@ -5,7 +5,6 @@
   <link rel="stylesheet" href="vendor/qunit.css" type="text/css" media="screen" />
   <script type="text/javascript" src="vendor/json2.js"></script>
   <script type="text/javascript" src="vendor/qunit.js"></script>
-  <script type="text/javascript" src="vendor/jslitmus.js"></script>
   <script type="text/javascript" src="vendor/require.js"></script>
   <script>
     // Tests are loaded async, so wait for them
@@ -17,12 +16,6 @@
         'jquery': 'vendor/jquery',
         'underscore': 'vendor/underscore',
         'backbone': '../backbone'
-      },
-      // jQuery is old, so shim.
-      shim: {
-        jquery: {
-          exports: 'jQuery'
-        }
       }
     });
 
@@ -30,6 +23,7 @@
 
     require(['backbone'], function(Backbone) {
       require([
+        'environment',
         'noconflict',
         'events',
         'model',


### PR DESCRIPTION
Vendored jQuery already supports AMD so no need for a shim. Remove JSLitmus import, and add in stubbed xhr environment file
