### PR TITLE
Add jQuery as a commonjs import

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -16,9 +16,11 @@
       root.Backbone = factory(root, exports, _, $);
     });
 
-  // Next for Node.js or CommonJS.
+  // Next for Node.js or CommonJS. jQuery may not be needed as a module.
   } else if (typeof exports !== 'undefined') {
-    factory(root, exports, require('underscore'));
+    var _ = require('underscore'), $;
+    try { $ = require('jquery'); } catch(e) {};
+    factory(root, exports, _, $);
 
   // Finally, as a browser global.
   } else {


### PR DESCRIPTION
Quoting from #2857

> Sometimes you do want to use Backbone with jQuery in a commonjs environment (either in a browser with browserfy / commonjs-everywhere, in a server-side DOM implementation like jsdom, or with shared client - server templates like rendr and a jQuery mimic) without requiring the jQuery object to live on the global for Backbone to pick it up.

If jQuery isn't present in the dependency tree, the loader will simply pass `undefined` for `$`. This won't affect methods that don't rely on jQuery.
