### PR TITLE
Fix up the `repo` key and relax underscore's version requirement

### DIFF
--- a/component.json
+++ b/component.json
@@ -3,9 +3,9 @@
   "version"       : "1.1.0",
   "description"   : "Give your JS App some Backbone with Models, Views, Collections, and Events.",
   "keywords"      : ["model", "view", "controller", "router", "server", "client", "browser"],
-  "repository"    : "jashkenas/backbone",
+  "repo"          : "jashkenas/backbone",
   "dependencies"  : {
-    "jashkenas/underscore"  : ">=1.4.3"
+    "jashkenas/underscore"  : "*"
   },
   "main"          : "backbone.js",
   "scripts"       : ["backbone.js"],


### PR DESCRIPTION
Changed `repository` to `repo` per the component spec and depend on underscore master because component doesn't support version range and the 1.5.2 tag doesn't have a component.json file.

I just tested this from my branch and this change shoudl finally make `component install jashkenas/backbone` work without error.
