### PR TITLE
Fix «request», «sync» and «error» events documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -863,9 +863,9 @@ view.stopListening(model);
       <li><b>"change"</b> (model, options) &mdash; when a model's attributes have changed. </li>
       <li><b>"change:[attribute]"</b> (model, value, options) &mdash; when a specific attribute has been updated. </li>
       <li><b>"destroy"</b> (model, collection, options) &mdash; when a model is <a href="#Model-destroy">destroyed</a>. </li>
-      <li><b>"request"</b> (model, collection, xhr, options) &mdash; when a model or collection has started a request to the server. </li>
-      <li><b>"sync"</b> (model, collection, resp, options) &mdash; when a model or collection has been successfully synced with the server. </li>
-      <li><b>"error"</b> (model, collection, resp, options) &mdash; when a model's <a href="#Model-save">save</a> call fails on the server. </li>
+      <li><b>"request"</b> (model_or_collection, xhr, options) &mdash; when a model or collection has started a request to the server. </li>
+      <li><b>"sync"</b> (model_or_collection, resp, options) &mdash; when a model or collection has been successfully synced with the server.</li>
+      <li><b>"error"</b> (model_or_collection, resp, options) &mdash; when model's or collection's request to remote server has failed. </li>
       <li><b>"invalid"</b> (model, error, options) &mdash; when a model's <a href="#Model-validate">validation</a> fails on the client. </li>
       <li><b>"route:[name]"</b> (params) &mdash; Fired by the router when a specific route is matched.</li>
       <li><b>"route"</b> (route, params) &mdash; Fired by the router when <i>any</i> route has been matched.</li>


### PR DESCRIPTION
- signatures had wrong number of parameters;
- it was not documented that «error» is fired by fetch, sync and destroy methods. There are unit tests for this behavior in Backbone repo. 

I named first parameter using_underscores because modelOrCollection is quite unreadable IMHO, and Backbone docs already uses similar names (e.g. `this.model.get("viewer_url")`). Another option was to call it 'object' and write "first argument is a model or a collection", but it is quite verbose and require reader to read events' descriptions carefully to check if they are same or not.
