### PR TITLE
Make isNew use the has function

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -555,7 +555,7 @@
 
     // A model is new if it has never been saved to the server, and lacks an id.
     isNew: function() {
-      return this.id == null;
+      return !this.has(this.idAttribute);
     },
 
     // Check if the model is currently in a valid state.


### PR DESCRIPTION
I found myself recently overriding the `has` functionality (model is only strings and an empty string should be false), however I also had to override the `isNew` function with this little snippet.
