### PR TITLE
Docs: Add validation error example, and note changed behavior for model validation in changelog.

### DIFF
--- a/index.html
+++ b/index.html
@@ -686,6 +686,11 @@
         <tt>set</tt>, <tt>push</tt>, and <tt>shift</tt> now return the model
         (or models) added or removed from the collection.
       </li>
+      <li>
+        In 1.1, models created using Collection's <tt>add</tt> or <tt>create</tt> and the
+        <tt>{validate: true}</tt> option are no longer validated again after they have been
+        initialized. They are now only validated once, before being initialized.
+      </li>
     </ul>
 
     <h2 id="Events">Backbone.Events</h2>
@@ -4038,6 +4043,11 @@ ActiveRecord::Base.include_root_in_json = false
         <tt>remove</tt>, and <tt>reset</tt> more useful. Instead of returning
         <tt>this</tt>, they now return the changed (added, removed or updated)
         model or list of models.
+      </li>
+      <li>
+        Models created using Collection's <tt>add</tt> or <tt>create</tt> and the
+        <tt>{validate: true}</tt> option are no longer validated again after they have been
+        initialized. They are now only validated once, before being initialized.
       </li>
       <li>
         Backbone Views no longer automatically attach options passed to the constructor as


### PR DESCRIPTION
As per issue #2839, this pull request adds an example to the docs for how a model.validationError might be used, and notes a small change in behavior (1.0.0 to 1.1.0) related to validating models that are created using `collection.add()` or `collection.create()` methods.
