### PR TITLE
Fixed typo with `model.isValid()` in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -1404,7 +1404,7 @@ one.save({
     </p>
 
     <p id="Model-isValid">
-      <b class="header">isValid</b><code>model.isValid</code>
+      <b class="header">isValid</b><code>model.isValid()</code>
       <br />
       Run <a href="#Model-validate">validate</a> to check the model state.
     </p>


### PR DESCRIPTION
`model.isValid()` is a function and was missing trailing parenthesis in the docs.

Cheers :beers:!
