### PR TITLE
Clarify that listenTo() does not allow a context to be supplied

### DIFF
--- a/index.html
+++ b/index.html
@@ -815,7 +815,8 @@ object.off();
       callback, object)</tt>, is that <b>listenTo</b> allows the <b>object</b>
       to keep track of the events, and they can be removed all at once later
       on.  The <b>callback</b> will always be called with <b>object</b> as
-      context.
+      context.<br />
+      (<b>listenTo</b> does not allow supplying a <b>context</b> value for <tt>this</tt>, like you can with <b>on</b>.)
     </p>
 
 <pre>
@@ -827,7 +828,7 @@ view.listenTo(model, 'change', view.render);
       <br />
       Tell an <b>object</b> to stop listening to events. Either call
       <b>stopListening</b> with no arguments to have the <b>object</b> remove
-      all of its <a href="#Events-listenTo">registered</a> callbacks ... or be more
+      all of its <a href="#Events-listenTo">registered</a> callbacks … or be more
       precise by telling it to remove just the events it's listening to on a
       specific object, or a specific event, or just a specific callback.
     </p>


### PR DESCRIPTION
9b9046e0482ed5858c71fdda17d20dce1c0a1b57 helped, but was insufficient. Anecdotal evidence of that insufficiency below.

/cc @jessebeach

---

From https://drupal.org/comment/8299301#comment-8299301:

> >  [listenTo](http://backbonejs.org/#Events-listenTo): Tell an object to listen to a particular event on an other object...The callback will always be called with object as context.
> 
> Honestly, that quote from the docs is....damn muddled. Which object now? The object invoking `listenTo` or the one raising the event? Let's check the code in Backbone...

From http://stackoverflow.com/questions/16823746/backbone-js-listento-vs-on:

> If you provide an explicit context (the 3rd argument to `foo.on` or the 4th argument to `this.listenTo`), backbone will use that (thus this is a more robust approach)

(Now fixed since I pointed out that problem: http://stackoverflow.com/questions/16823746/backbone-js-listento-vs-on#comment31091515_16824080 .) 
