### PR TITLE
Fix double parse on Collection#create

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -877,6 +877,7 @@
       if (!options.wait) this.add(model, options);
       var collection = this;
       var success = options.success;
+      if (options.parse === void 0) options.parse = false;
       options.success = function(model, resp) {
         if (options.wait) collection.add(model, options);
         if (success) success(model, resp, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -487,6 +487,19 @@
     equal(model.collection, collection);
   });
 
+  test("ensure create doesn't parse", 1, function() {
+    var collection = new Backbone.Collection;
+    var counter = 0;
+    collection.parse = function(models) {
+      counter++;
+      return models;
+    };
+    collection.url = '/test';
+    collection.create({});
+    this.syncArgs.options.success();
+    equal(counter, 0);
+  });
+
   test("create with validate:true enforces validation", 3, function() {
     var ValidatingModel = Backbone.Model.extend({
       validate: function(attrs) {


### PR DESCRIPTION
Fixes the issue demonstrated here: http://jsbin.com/IgeWIpo/2/edit

Basically, `Model#save` sets `options.parse` to `true` automatically and that gets passed to `Collection#add` and then `Collection#set` which causes the already created model to be parsed as a server response.
