### PR TITLE
decode location.pathname

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1345,7 +1345,7 @@
     getFragment: function(fragment, forcePushState) {
       if (fragment == null) {
         if (this._hasPushState || !this._wantsHashChange || forcePushState) {
-          fragment = this.location.pathname;
+          fragment = decodeURI(this.location.pathname);
           var root = this.root.replace(trailingSlash, '');
           if (!fragment.indexOf(root)) fragment = fragment.slice(root.length);
         } else {


### PR DESCRIPTION
Hi! We have a problem where checkUrl function refreshes the page on Mac browsers when it should not. This happens with urls like /myyjä/ because some browsers return encoded (/myyj%C3%A4/) location.pathname. Would this be acceptable solution for this problem?
