### PR TITLE
change typeof <v> !== 'undefined' to <v> !== void 0

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -17,7 +17,7 @@
     });
 
   // Next for Node.js or CommonJS. jQuery may not be needed as a module.
-  } else if (typeof exports !== 'undefined') {
+  } else if (exports !== void 0) {
     var _ = require('underscore'), $;
     try { $ = require('jquery'); } catch(e) {}
     factory(root, exports, _, $);
@@ -1189,7 +1189,7 @@
   };
 
   var noXhrPatch =
-    typeof window !== 'undefined' && !!window.ActiveXObject &&
+    window !== void 0 && !!window.ActiveXObject &&
       !(window.XMLHttpRequest && (new XMLHttpRequest).dispatchEvent);
 
   // Map from CRUD to HTTP for our default `Backbone.sync` implementation.
@@ -1320,7 +1320,7 @@
     _.bindAll(this, 'checkUrl');
 
     // Ensure that `History` can be used outside of the browser.
-    if (typeof window !== 'undefined') {
+    if (window !== void 0) {
       this.location = window.location;
       this.history = window.history;
     }


### PR DESCRIPTION
This request is to modify the places in the code where "typeof <v> !== 'undefined'" to "<v> !== void 0" where <v> is a variable (in this case exports and window).

A few reasons for the request:
1)  I have seen performance improvements by going with the void 0 approach.  Supporting data: http://jsperf.com/typeof-vs-undefined-check/15
2)  It reduces the overall number of characters used to test whether the variable is undefined (an overall bandwidth improvement).
3)  Although 1 & 2 are negligible for this project due to only being used in a few places, this seems to be a best practice being used by other libraries (i.e. underscore.js) and would be good to use for continuity of best practices between projects.  

Thanks!
