### PR TITLE
Adding the functionality to have a OR operated find.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -811,11 +811,19 @@
 
     // Return models with matching attributes. Useful for simple cases of
     // `filter`.
-    where: function(attrs, first) {
+    where: function (attrs, first) {
       if (_.isEmpty(attrs)) return first ? void 0 : [];
-      return this[first ? 'find' : 'filter'](function(model) {
+      return this[first ? 'find' : 'filter'](function (model) {
         for (var key in attrs) {
-          if (attrs[key] !== model.get(key)) return false;
+          var needles = [];
+          if (!_.isArray(attrs[key])) {
+            needles.push(attrs[key]);
+          } else {
+            needles = attrs[key];
+          }
+          if (!_.contains(needles, model.get(key))) {
+            return false;
+          }
         }
         return true;
       });

--- a/test/collection.js
+++ b/test/collection.js
@@ -533,7 +533,7 @@
     equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });
 
-  test("where and findWhere", 8, function() {
+  test("where and findWhere", 11, function() {
     var model = new Backbone.Model({a: 1});
     var coll = new Backbone.Collection([
       model,
@@ -547,6 +547,9 @@
     equal(coll.where({a: 3}).length, 1);
     equal(coll.where({b: 1}).length, 0);
     equal(coll.where({b: 2}).length, 2);
+    equal(coll.where({a: 1}).length, 3);
+    equal(coll.where({a: [1,2]}).length, 4);
+    equal(coll.where({a: [2,3]}).length, 2);
     equal(coll.where({a: 1, b: 2}).length, 1);
     equal(coll.findWhere({a: 1}), model);
     equal(coll.findWhere({a: 4}), void 0);


### PR DESCRIPTION
E.g.
collection.where({key:value); will still return the collections where key equals value. I have added the option:
collection.where({key:[value1,value2]}) now it will return all models where key has either value1 or value2.

I've added this because I needed it for a faceted search project.
