### PR TITLE
Updated pathStripper

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1502,7 +1502,7 @@
       var url = this.root + (fragment = this.getFragment(fragment || ''));
 
       // Strip the hash for matching.
-      if (this.pathStripperEnable = true) fragment = fragment.replace(pathStripper, '');
+      if (this.pathStripperEnable == true) fragment = fragment.replace(pathStripper, '');
 
       if (this.fragment === fragment) return;
       this.fragment = fragment;


### PR DESCRIPTION
Updated pathStripper
Define if router'll remove queryString
Usage: Backbone.history.pathStripperEnable = [true/false]
If defined as false, router'll accept querystring with the url 
Ex: /myurl?para=1 will be differente from /myurl?para=2
