### PR TITLE
Mix in sortedIndex from Underscore to Collection

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -954,7 +954,7 @@
     'reject', 'every', 'all', 'some', 'any', 'include', 'contains', 'invoke',
     'max', 'min', 'toArray', 'size', 'first', 'head', 'take', 'initial', 'rest',
     'tail', 'drop', 'last', 'without', 'difference', 'indexOf', 'shuffle',
-    'lastIndexOf', 'isEmpty', 'chain', 'sample'];
+    'lastIndexOf', 'isEmpty', 'chain', 'sample', 'sortedIndex'];
 
   // Mix in each Underscore method as a proxy to `Collection#models`.
   _.each(methods, function(method) {


### PR DESCRIPTION
Backbone's version of this was removed in #2629 but wasn't being mixed in by Underscore, breaking code that relied on it.
