### PR TITLE
Fix #2976 Do not add multiple models with same `id`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -710,7 +710,11 @@
           toAdd.push(model);
           this._addReference(model, options);
         }
-        if (order) order.push(existing || model);
+
+        // Do not add multiple models with the same `id`.
+        model = existing || model;
+        if (order && (model.isNew() || !modelMap[model.id])) order.push(model);
+        modelMap[model.id] = true;
       }
 
       // Remove nonexistent models if appropriate.

--- a/test/collection.js
+++ b/test/collection.js
@@ -1323,5 +1323,16 @@
 
   });
 
+  test('Do not allow duplicate models to be `add`ed or `set`', function() {
+    var c = new Backbone.Collection();
+
+    c.add([{id: 1}, {id: 1}]);
+    equal(c.length, 1);
+    equal(c.models.length, 1);
+
+    c.set([{id: 1}, {id: 1}]);
+    equal(c.length, 1);
+    equal(c.models.length, 1);
+  });
 
 })();


### PR DESCRIPTION
`add` is protected from this, but when using the `order` array to reorder models, we need to make sure multiple models with the same `id` aren't both pushed onto `order`.
