### PR TITLE
Add __parent__ property inside extend

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1557,6 +1557,7 @@
 
     // Set a convenience property in case the parent's prototype is needed
     // later.
+    child.__parent__ = parent;
     child.__super__ = parent.prototype;
 
     return child;


### PR DESCRIPTION
### Overview

I'd like to update `extend`, so that the child has a refernce to its parent's constructor (`__parent__ = parent`). The main motivation is that I'd like to check to see if model B is a subclass of model A without instanciating it and using `instanceof`. 

As a disclaimer, `__parent__` would be used in a small ancestor-esque util, not product code.
### Relevant issues / tests

I checked #787, #1348, #342 and I don't think this solution addressed. I looked for relevant tests and could not find any. 
### Sample Code

Here's some throw-away code that could be written if `__parent__` were availble.

``` js
Model.childOf = function(objB) {
    var objA = this;
    while ((objA = objA.__parent__) !== undefined) {
        if (objA === objB) {
            return true;
        }
    }

    return false;
}

Model.ancestors = function() {
    var ancestors = [],
        ancestor = this;
    while ((ancestor = ancestor.__parent__) !== undefined) {
        ancestors.push(ancestor)
    }

    return ancestors;
}

var A = Backbone.Model.extend({}),
    B = A.extend({}),
    C = B.extend({}),
    D = C.extend({});

console.log('D, A', D.childOf(B));          // => true
console.log('A, B', A.childOf(B));          // => false
console.log('A, A', A.childOf(A));          // => false
console.log('Bs ancestors', B.ancestors()); // => [A, Backbone.Model]
```
