### PR TITLE
Allow attributes to override their json serizlization by providing `toJSON`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -277,9 +277,17 @@
     // initialization logic.
     initialize: function(){},
 
-    // Return a copy of the model's `attributes` object.
+    // Return a copy of the model's attributes.
     toJSON: function(options) {
-      return _.clone(this.attributes);
+      var result = {}, attrs = this.attributes;
+      for (var prop in attrs) {
+        if (typeof attrs[prop].toJSON === 'function') {
+          result[prop] = attrs[prop].toJSON();
+        } else {
+          result[prop] = attrs[prop];
+        }
+      }
+      return result;
     },
 
     // Proxy `Backbone.sync` by default -- but override this if you need

--- a/test/model.js
+++ b/test/model.js
@@ -1127,4 +1127,12 @@
     model.set({a: true});
   });
 
+  test("attributs can override their json serizlization by providing toJSON", function() {
+    var value = {
+      toJSON: function() {return 1337}
+    }
+    var model = new Backbone.Model({key: value});
+    deepEqual(model.toJSON(), {key: 1337});
+  });
+
 })();


### PR DESCRIPTION
The primary use case I see for this is helping serialize nested models.

For example, I work with an API that takes and returns a complete hierarchy of our data, but I need to work with each node as individual objects with their own methods. So I use collection instances as attributes to manage child nodes. When I'm ready to sync, this change does all the work of converting my data back to a hierarchy that works with our API.

It's a general enough change that there are probably other use cases.

Tests pass on
- Chrome 32 (OS X 10.9.1)
- Firefox 27 (OS X 10.9.1)
- Safari 7 (OS X 10.9.1)
- IE 8 (Windows XP)
