### PR TITLE
Backbone.History to trigger 'load' event when loadUrl call happens

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1478,6 +1478,10 @@
     // returns `false`.
     loadUrl: function(fragment) {
       fragment = this.fragment = this.getFragment(fragment);
+
+      // Trigger 'load' event
+      this.trigger('load', fragment);
+
       return _.any(this.handlers, function(handler) {
         if (handler.route.test(fragment)) {
           handler.callback(fragment);

--- a/test/router.js
+++ b/test/router.js
@@ -792,4 +792,24 @@
     Backbone.history.start({pushState: true});
   });
 
+  test('Backbone.history should emit "load" event with current fragment', 2, function() {
+    location.replace('http://example.com/prefix/app/action');
+    Backbone.history.stop();
+
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    Backbone.history.on('load', function(fragment) {
+      return strictEqual(fragment, 'app/action');
+    });
+    var Router = Backbone.Router.extend({
+      routes: {
+        'app/action': function() {
+          ok(true);
+        }
+      }
+    });
+    var router = new Router;
+    Backbone.history.start({pushState: true, root: '/prefix/'});
+    Backbone.history.checkUrl();
+  });
+
 })();


### PR DESCRIPTION
I am looking to make Views in my application rely on current state of URL and having 'load' event for Backbone.History will complement Backbone.History.getFragment() function.

I also see this very minimal change to allow building more flexible routers which might allow matching several different route-regexps to allow reusing smaller actions. I.e. for example if both routes /app/route1 and /app/route2 need to call function prepareApp(), this function could be added as a listener to 'load' event.
