### PR TITLE
Add scope to success and error callbacks

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -433,7 +433,7 @@
       var success = options.success;
       options.success = function(resp) {
         if (!model.set(model.parse(resp, options), options)) return false;
-        if (success) success(model, resp, options);
+        if (success) success.call(this, model, resp, options);
         model.trigger('sync', model, resp, options);
       };
       wrapError(this, options);
@@ -483,7 +483,7 @@
         if (_.isObject(serverAttrs) && !model.set(serverAttrs, options)) {
           return false;
         }
-        if (success) success(model, resp, options);
+        if (success) success.call(this, model, resp, options);
         model.trigger('sync', model, resp, options);
       };
       wrapError(this, options);
@@ -512,7 +512,7 @@
 
       options.success = function(resp) {
         if (options.wait || model.isNew()) destroy();
-        if (success) success(model, resp, options);
+        if (success) success.call(this, model, resp, options);
         if (!model.isNew()) model.trigger('sync', model, resp, options);
       };
 
@@ -863,7 +863,7 @@
       options.success = function(resp) {
         var method = options.reset ? 'reset' : 'set';
         collection[method](resp, options);
-        if (success) success(collection, resp, options);
+        if (success) success.call(this, collection, resp, options);
         collection.trigger('sync', collection, resp, options);
       };
       wrapError(this, options);
@@ -881,7 +881,7 @@
       var success = options.success;
       options.success = function(model, resp) {
         if (options.wait) collection.add(model, options);
-        if (success) success(model, resp, options);
+        if (success) success.call(this, model, resp, options);
       };
       model.save(null, options);
       return model;
@@ -1598,7 +1598,7 @@
   var wrapError = function(model, options) {
     var error = options.error;
     options.error = function(resp) {
-      if (error) error(model, resp, options);
+      if (error) error.call(this, model, resp, options);
       model.trigger('error', model, resp, options);
     };
   };

--- a/test/collection.js
+++ b/test/collection.js
@@ -1335,4 +1335,22 @@
     equal(c.models.length, 1);
   });
 
+  test("success and error scope should be consistent with $.ajax context", 4, function() {
+    var c = new Backbone.Collection();
+    
+    var opts = {
+      data: { 'a': 'b' },
+      success: function () { deepEqual(this.data, { 'a': 'b' }); },
+      error: function () { deepEqual(this.data, { 'a': 'b' }); }
+    };
+
+    Backbone.sync = function(method, model, options) { options.success(); };
+    c.fetch(opts);
+    c.create({}, opts);
+
+    Backbone.sync = function(method, model, options) { options.error(); };
+    c.fetch(opts);
+    c.create({}, opts);
+  });
+
 })();

--- a/test/model.js
+++ b/test/model.js
@@ -1127,4 +1127,24 @@
     model.set({a: true});
   });
 
+  test("success and error scope should be consistent with $.ajax context", 6, function() {
+    var m = new Backbone.Model();
+    
+    var opts = {
+      data: { 'a': 'b' },
+      success: function () { deepEqual(this.data, { 'a': 'b' }); },
+      error: function () { deepEqual(this.data, { 'a': 'b' }); }
+    };
+
+    Backbone.sync = function(method, model, options) { options.success(); };
+    m.fetch(opts);
+    m.save({}, opts);
+    m.destroy(opts);
+
+    Backbone.sync = function(method, model, options) { options.error(); };
+    m.fetch(opts);
+    m.save({}, opts);
+    m.destroy(opts);
+  });
+
 })();


### PR DESCRIPTION
"The this reference within all callbacks is the object in the context option passed to $.ajax in the settings; if context is not specified, this is a reference to the Ajax settings themselves."
- https://api.jquery.com/jQuery.ajax/

---

Currently the scope for `success` and `error` use the Window object. This PR passes the correct context of the callback through.
