### PR TITLE
Add settings attr to options on Backbone.sync

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1185,7 +1185,9 @@
     }
 
     // Make the request, allowing the user to override any Ajax options.
-    var xhr = options.xhr = Backbone.ajax(_.extend(params, options));
+    var settings = _.extend(params, options);
+    var xhr = options.xhr = Backbone.ajax(settings);
+    options.settings = settings;
     model.trigger('request', model, xhr, options);
     return xhr;
   };

--- a/test/sync.js
+++ b/test/sync.js
@@ -207,4 +207,15 @@
     strictEqual(this.ajaxSettings.beforeSend(xhr), false);
   });
 
+  test("Attach ajax settings to options argument", 1, function() {
+    var model = new Backbone.Model();
+    model.url = '/test';
+
+    model.on('request', function (model, xhr, options) {
+      ok(options.settings);
+    });
+
+    model.sync('create', model);
+  });
+
 })();


### PR DESCRIPTION
A alternative solution for obtaining the ajax settings within success and error callbacks (#3008).

**example usage**:

```
model.fetch({
  error: function (model, resp, options) {
    if (options.xhr.statusText == 'timeout') { Backbone.ajax(options.settings); }
  }
});
```
