### PR TITLE
Do not trigger router/history events if Router#execute returns false

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1251,7 +1251,7 @@
       var router = this;
       Backbone.history.route(route, function(fragment) {
         var args = router._extractParameters(route, fragment);
-        router.execute(callback, args);
+        if (router.execute(callback, args) === false) return;
         router.trigger.apply(router, ['route:' + name].concat(args));
         router.trigger('route', name, args);
         Backbone.history.trigger('route', router, name, args);

--- a/test/router.js
+++ b/test/router.js
@@ -331,6 +331,23 @@
     Backbone.history.checkUrl();
   });
 
+  test("does not fire event when route callback explicitly returned false", 1, function() {
+    var router = new Router({});
+    var passed = true;
+
+    router.execute = function() {
+      return false;
+    };
+
+    router.on('route', function() {
+      passed = false;
+    });
+
+    location.replace('http://example.com#route-event/x');
+    Backbone.history.checkUrl();
+    ok(passed);
+  });
+
   test("#933, #908 - leading slash", 2, function() {
     location.replace('http://example.com/root/foo');
 


### PR DESCRIPTION
This might be useful for implementation of before/after filters. E.g. when filter is not passed it explicitly returns false to Router#execute and none of router/history events will be fired in this case:

``` js

Backbone.Router.prototype.execute = function(callback, args) {
  if (!passedBeforeFilters(args)) return false; // No events triggered
  if (callback) callback.apply(this, args);
};
```
