### PR TITLE
Check that model exists before trying to verify uniqueness

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -711,6 +711,7 @@
 
         // Do not add multiple models with the same `id`.
         model = existing || model;
+        if (!model) continue;
         if (order && (model.isNew() || !modelMap[model.id])) order.push(model);
         modelMap[model.id] = true;
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -1333,6 +1333,8 @@
     c.set([{id: 1}, {id: 1}]);
     equal(c.length, 1);
     equal(c.models.length, 1);
-  });
 
+    // Does not run check when model is not added
+    c.set([{id: 1}], {add: false});
+  });
 })();


### PR DESCRIPTION
When calling fetch with {add: false} and model does not exist in collection, model uniqueness check tries to access id of undefined. This verifies that model is set before checking for existing models.
