### PR TITLE
Allow customization of parsing id.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -680,6 +680,10 @@
       return singular ? models[0] : models;
     },
 
+    parseId: function(attrs) {
+      return attrs[this.model.prototype.idAttribute || 'id'];
+    },
+
     // Update a collection by `set`-ing a new list of models, adding new ones,
     // removing models that are no longer present, and merging models that
     // already exist in the collection, as necessary. Similar to **Model#set**,
@@ -704,7 +708,7 @@
         if (attrs instanceof Model) {
           id = model = attrs;
         } else {
-          id = attrs[this.model.prototype.idAttribute || 'id'];
+          id = this.parseId(attrs);
         }
 
         // If a duplicate is found, prevent it from being added and


### PR DESCRIPTION
An alternative to #2985.

Rather than handling composite ids specifically, I think it best that we just allow customizing the method by which the id is parsed.  Then you can do the same in `Model#parse` and set up whatever change handlers you need on your own, thus leaving `_onModelChange` to worry about one change event, the already existing `change:id`.

``` js
var Collection = Backbone.Collection.extend({
  model: Backbone.Model.extend({
    parse: function(attrs) {
      attrs.id = attrs.one + attrs.two;
      return attrs;
    }
  }),
  parseId: function(attrs) {
    return attrs.one + attrs.two;
  }
});
```
