### PR TITLE
Switch url check order for the model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -558,8 +558,8 @@
     // that will be called.
     url: function() {
       var base =
-        _.result(this, 'urlRoot') ||
         _.result(this.collection, 'url') ||
+        _.result(this, 'urlRoot') ||
         urlError();
       if (this.isNew()) return base;
       return base.replace(/([^\/])$/, '$1/') + encodeURIComponent(this.id);


### PR DESCRIPTION
So while looking around at things for #3028, this stuck out as something I never really understood, and I expected that a bunch of tests would break when I tried this, but surprisingly none did...

So I thought I'd just put it out there... doesn't it seem more intuitive that a model would only use the `urlRoot` as a fallback, for cases where it lives outside of a collection, rather than the default (once it lives inside the collection, it would presumably use that collection's url and then fallback to `urlRoot` if none is defined).

I can add some tests and such, but first I wanted to check if there was something really obvious I was missing here first on why the check exists the way it does.
