### PR TITLE
Fixes #3028 assign collection in _prepareModel

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -939,7 +939,10 @@
     // Prepare a hash of attributes (or other model) to be added to this
     // collection.
     _prepareModel: function(attrs, options) {
-      if (attrs instanceof Model) return attrs;
+      if (attrs instanceof Model) {
+        if (!attrs.collection) attrs.collection = this;
+        return attrs;
+      }
       options = options ? _.clone(options) : {};
       options.collection = this;
       var model = new this.model(attrs, options);
@@ -952,7 +955,6 @@
     _addReference: function(model, options) {
       this._byId[model.cid] = model;
       if (model.id != null) this._byId[model.id] = model;
-      if (!model.collection) model.collection = this;
       model.on('all', this._onModelEvent, this);
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -1416,4 +1416,14 @@
     ok(collection.at(1) instanceof B);
     equal(collection.at(1).id, 'b-1');
   });
+
+  test("create with wait, model instance, #3028", 1, function() {
+    var collection = new Backbone.Collection();
+    var model = new Backbone.Model({id: 1});
+    model.sync = function(){
+      equal(this.collection, collection);
+    };
+    collection.create(model, {wait: true});
+  });
+
 })();


### PR DESCRIPTION
So looking at it again, the `_addReference` is more about events and adding to the internal reference hashes than the `collection` property, so I still think this is alright... it reverts to the previous behavior for this case, but also removes `model.collection` in cases of failure with `wait:true`.

Let me know if you disagree on that second piece, but I would assume that attempting to add a model to a collection shouldn't set the "collection" attribute on the model if it's not actually added.
