### PR TITLE
Change the reference to rails in the 'sync' docs to reflect Rails 4

### DIFF
--- a/index.html
+++ b/index.html
@@ -2454,16 +2454,14 @@ $(function(){
     </ul>
 
     <p>
-      As an example, a Rails handler responding to an <tt>"update"</tt> call from
-      <tt>Backbone</tt> might look like this: <i>(In real code, never use
-      </i><tt>update_attributes</tt><i> blindly, and always whitelist the attributes
-      you allow to be changed.)</i>
+      As an example, a Rails 4 handler responding to an <tt>"update"</tt> call from
+      <tt>Backbone</tt> might look like this:
     </p>
 
 <pre>
 def update
   account = Account.find params[:id]
-  account.update_attributes params
+  account.update_attributes params.require(:account).permit(:name, :otherparam)
   render :json => account
 end
 </pre>


### PR DESCRIPTION
Hello,

This is just a small update to the docs to make the example Rails update handler in the sync docs reflect the current style of rails controllers.  In essence params can no longer be passed to update_attributes directly, it causes an error.
