### PR TITLE
Fix for Ender + Backbone

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -15,14 +15,15 @@
       root.Backbone = factory(root, exports, _, $);
     });
 
-  // Next for Node.js or CommonJS. jQuery may not be needed as a module.
+  // Next for Node.js, CommonJS, or Ender
+  // (When not using Ender, the 4th arg will be undefined, same as if it was omitted)
   } else if (typeof exports !== 'undefined') {
     var _ = require('underscore');
-    factory(root, exports, _);
+    factory(root, exports, _, root.ender);
 
   // Finally, as a browser global.
   } else {
-    root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender || root.$));
+    root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.$));
   }
 
 }(this, function(root, Backbone, _, $) {

--- a/backbone.js
+++ b/backbone.js
@@ -15,15 +15,14 @@
       root.Backbone = factory(root, exports, _, $);
     });
 
-  // Next for Node.js, CommonJS, or Ender
-  // (When not using Ender, the 4th arg will be undefined, same as if it was omitted)
+  // Next for Node.js, CommonJS
   } else if (typeof exports !== 'undefined') {
     var _ = require('underscore');
-    factory(root, exports, _, root.ender);
+    factory(root, exports, _, (root.jQuery || root.Zepto || root.ender || root.$));
 
   // Finally, as a browser global.
   } else {
-    root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.$));
+    root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender || root.$));
   }
 
 }(this, function(root, Backbone, _, $) {


### PR DESCRIPTION
When Backbone is used as an Ender module, `exports` always exists, so
`root.ender` needs to be passed to `factory`. (When not using Ender,
the 4th arg will be undefined, same as before.)

Note that Ender 2.x no longer automatically integrates all modules into
`$`. There are two ways to use Backbone with Ender 2:

1. Assign it to its own var and use it like this:  
    `var Backbone = require('backbone');`
    `Backbone.$ = $;`
    `Backbone.View.extend({…});`

2. Integrate into `$` by adding `--integrate backbone` when building
the Ender library, then use it like this:  
    `$.View.extend({…});`