### PR TITLE
Send correct 'at' when firing 'add' event

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -760,8 +760,10 @@
 
       // Unless silenced, it's time to fire all appropriate add/sort events.
       if (!options.silent) {
+        var addOpts = at != null ? _.clone(options) : options;
         for (var i = 0, length = toAdd.length; i < length; i++) {
-          (model = toAdd[i]).trigger('add', model, this, options);
+          if (at != null) addOpts.index = at + i;
+          (model = toAdd[i]).trigger('add', model, this, addOpts);
         }
         if (sort || (order && order.length)) this.trigger('sort', this, options);
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -1426,4 +1426,20 @@
     equal(collection.at(1), collection.get('b-1'));
   });
 
+  test("#3039: adding at index fires with correct at", 3, function() {
+    var col = new Backbone.Collection([{at: 0}, {at: 4}]);
+    col.on('add', function(model, col, options) {
+        equal(model.get('at'), options.index);
+    });
+    col.add([{at: 1}, {at: 2}, {at: 3}], {at: 1});
+  });
+
+  test("#3039: index is not sent when at is not specified", 2, function() {
+    var col = new Backbone.Collection([{at: 0}]);
+    col.on('add', function(model, col, options) {
+        equal(undefined, options.index);
+    });
+    col.add([{at: 1}, {at: 2}]);
+  });
+
 })();


### PR DESCRIPTION
If you add an array of models to a collection and specify `at` in options when the add event is fired on the collection for each model the `at` sent in the options is incorrect for that specific model.

The `extend` is only necessary when the `at` is not undefined, otherwise we're not modifying it.

Downside of the `extend` is if someone was wrongly modifying options object in an add event and expecting to get those changes in other events, that is now broken. I had considered changing the original `options` but that generally doesn't seem to be what any other functions are doing.
