### PR TITLE
Update devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "underscore"  : ">=1.5.0"
   },
   "devDependencies": {
-    "phantomjs": "1.9.0-1",
-    "docco": "0.6.1",
-    "coffee-script": "1.6.1"
+    "phantomjs": "1.9.7-1",
+    "docco": "0.6.3",
+    "coffee-script": "1.7.1"
   },
   "scripts": {
     "test": "phantomjs test/vendor/runner.js test/index.html?noglobals=true && coffee test/model.coffee",


### PR DESCRIPTION
PhantomJS fixed the really annoying "CoreText performance note:" message in
1.9.3 or so.
