### PR TITLE
Better documentation around the behaviour of `once` when multiple events are passed in

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -89,9 +89,10 @@
     },
 
     // Bind an event to only be triggered a single time. After the first time
-    // the callback is invoked, it will be removed. Importantly, if name references
-    // multiple events using the space separated syntax, the event will fire once
-    // per event, not once for all the events.
+    // the callback is invoked, it will be removed. When multiple events are
+    // passed in using the space separated syntax, the event will fire once for every
+    // event you passed in, not once for a combination of all events
+
     once: function(name, callback, context) {
       if (!eventsApi(this, 'once', name, [callback, context]) || !callback) return this;
       var self = this;

--- a/backbone.js
+++ b/backbone.js
@@ -89,7 +89,9 @@
     },
 
     // Bind an event to only be triggered a single time. After the first time
-    // the callback is invoked, it will be removed.
+    // the callback is invoked, it will be removed. Importantly, if name references
+    // multiple events using the space separated syntax, the event will fire once
+    // per event, not once for all the events.
     once: function(name, callback, context) {
       if (!eventsApi(this, 'once', name, [callback, context]) || !callback) return this;
       var self = this;

--- a/index.html
+++ b/index.html
@@ -806,8 +806,8 @@ object.off();
       <br />
       Just like <a href="#Events-on">on</a>, but causes the bound callback to only
       fire once before being removed. Handy for saying "the next time that X happens, do this".
-      When multiple events are passed in using the space separated syntax, the event
-      will fire once per event, not once for all the events.
+      When multiple events are passed in using the space separated syntax, the event will fire once 
+      for every event you passed in, not once for a combination of all events
     </p>
 
     <p id="Events-listenTo">

--- a/index.html
+++ b/index.html
@@ -806,6 +806,8 @@ object.off();
       <br />
       Just like <a href="#Events-on">on</a>, but causes the bound callback to only
       fire once before being removed. Handy for saying "the next time that X happens, do this".
+      When multiple events are passed in using the space separated syntax, the event
+      will fire once per event, not once for all the events.
     </p>
 
     <p id="Events-listenTo">


### PR DESCRIPTION
`EventEmitter.once` will fire once per event -- as opposed to once -- when multiple events are passed in using the space-separated syntax. This can be fairly counter-intuitive. This PR updates the documentation to make not of this.