### PR TITLE
test node 0.10.x version on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - 0.8
+  - '0.10'
 notifications:
   email: false


### PR DESCRIPTION
Test result

```
$ npm test

> backbone@1.1.2 test /home/git/backbone
> phantomjs test/vendor/runner.js test/index.html?noglobals=true && coffee test/model.coffee

Took 2823ms to run 865 tests. 865 passed, 0 failed.
passed 4 tests

$ node -v
v0.10.26

$ npm -v
1.4.3
```
