### PR TITLE
Failing test for #3017

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -1426,4 +1426,15 @@
     collection.create(model, {wait: true});
   });
 
+  test("#3017 - create with an error response triggers an error event", 1, function () {
+    var collection = new Backbone.Collection();
+    var model = new Backbone.Model();
+    collection.url = '/test';
+    collection.on('error', function () {
+      ok(true);
+    });
+    collection.sync = function (method, model, options) { options.error(); };
+    collection.create(model);
+  });
+
 })();


### PR DESCRIPTION
#3017 Was closed previously due to a lack of a failing test so I'm providing one here. If this is not the desired behavior the documentation should be updated accordingly. Looking at the [Catalog of Built-in Events](http://backbonejs.org/#Events-catalog) section it seems to imply that an error event will be triggered:

> when model's or collection's request to remote server has failed
