### PR TITLE
Proposal: View.prototype._createElement to allow for overrideable DOM element creation

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1145,6 +1145,11 @@
       this.$el.off(eventName + '.delegateEvents' + this.cid, selector, listener);
     },
 
+    // Produces a DOM element according to the `tagName` parameter.
+    _createElement: function(tagName) {
+      return document.createElement(tagName);
+    },
+
     // Ensure that the View has a DOM element to render into.
     // If `this.el` is a string, pass it through `$()`, take the first
     // matching element, and re-assign it to `el`. Otherwise, create
@@ -1154,7 +1159,7 @@
         var attrs = _.extend({}, _.result(this, 'attributes'));
         if (this.id) attrs.id = _.result(this, 'id');
         if (this.className) attrs['class'] = _.result(this, 'className');
-        this.setElement(document.createElement(_.result(this, 'tagName')));
+        this.setElement(this._createElement(_.result(this, 'tagName')));
         this._setAttributes(attrs);
       } else {
         this.setElement(_.result(this, 'el'));

--- a/test/view.js
+++ b/test/view.js
@@ -176,6 +176,14 @@
     view.$el.trigger('click');
   });
 
+  test("_createElement produces the correct DOM el", 1, function() {
+    var View = Backbone.View.extend({
+      tagName: 'span'
+    });
+
+    equal(new View().el.tagName, 'SPAN');
+  });
+
   test("_ensureElement with DOM node el", 1, function() {
     var View = Backbone.View.extend({
       el: document.body


### PR DESCRIPTION
Fantastic work happened in #3003, I'm amazed out how quickly you can [extend Backbone to work with node](https://gist.github.com/nhunzaker/9676031)

However I had a hard time finding any discussion of adding the ability to directly change how the element associated with a view is actually produced. Right now this is a `document.create` call in `_ensureElement`

It seems like being able to override this specific behavior would be particularly useful for working with libraries such as [cheerio](http://matthewmueller.github.io/cheerio/). Making it easier to just change the _idea_ of a DOM element, leaving `_ensureElement` otherwise intact.

Of course, it isn't terribly difficult to just do something like:

``` javascript
Backbone.View.prototype._ensureElement = function() {
    if (!this.el) {
        var attrs = _.extend({}, _.result(this, 'attributes'));
        if (this.id) attrs.id = _.result(this, 'id');
        if (this.className) attrs['class'] = _.result(this, 'className');

        this.setElement(cheerio.load('<' + _.result(this, 'tagName') + '>'));

        this._setAttributes(attrs);
    } else {
        this.setElement(_.result(this, 'el'));
    }
};
```

However I think being able to easily slice out that one line would be pretty neat.
