### PR TITLE
Allow user defined view options to be assigned onto the view

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1030,7 +1030,7 @@
   var View = Backbone.View = function(options) {
     this.cid = _.uniqueId('view');
     options || (options = {});
-    _.extend(this, _.pick(options, _.extend([], defaultViewOptions, this.viewOptions)));
+    _.extend(this, _.pick(options, defaultViewOptions.concat(this.viewOptions || [])));
     this._ensureElement();
     this.initialize.apply(this, arguments);
   };

--- a/test/view.js
+++ b/test/view.js
@@ -387,7 +387,7 @@
     equal(counter, 2);
   });
 
-  test("merge specified view options", 2, function () {
+  test("merge specified view options", 3, function () {
     var objectToAssign = {};
 
     var View = Backbone.View.extend({
@@ -395,10 +395,12 @@
     });
 
     var view = new View({
-      foo: objectToAssign
+      foo: objectToAssign,
+      bar: objectToAssign
     });
 
     strictEqual(view.foo, objectToAssign);
+    strictEqual(view.bar, undefined);
 
     // ensure Backbone.View works as expected
     var view2 = new Backbone.View({


### PR DESCRIPTION
I'm aware that this has been proposed numerous times, but I've got a slightly different reasoning for this from what I've read in the other pull requests/issues threads. I'm interested in people's thoughts more than I am about getting this merged.

(this ended up longer than expected, so the TL;DR is: I want to promote the use of domain-specific language in applications, and relying on `model` and `collection` 'keywords' makes that hard)

Firstly, since the `view.options` property was removed (which is a very good move, IMO) a little bit of convenience has been lost, but removal of an anti-pattern has been gained. This pull request gets that convenience back.  Yes, you can write the one-liner in your initiliaze/constructor method, but then you have to know which one to do it in, and what the differences between the two are. 

My main reason for proposing this is that using the generic terms 'model' and 'collection' across all views is bad practise, in my opinion. Once you get to an application with a certain level of complexity, the model and collection properties become meaningless and unclear. You're much better off using more semantic terms, such as `view.person` for a PersonView.

I would have suggested that the current set of `viewOptions` should be reduced to only those that are actually required in order for Backbone to work, and not just to provide convenience. This would have involved removing the `model` and `collection` properties from that list (and probably some others) but that would of course cause lots of problems for Backbone's dependents.

So it seems like Backbone is attempting to not only provide some convenience, but also to help people write better, more semantic code along the way. With that in mind, I think that encouraging people to move away from using `.model` and `.collection` all over the place, and making that as easy as possible is desirable. I've seen a lot of misunderstanding of the M part of MV\* over the last few years, mainly around thinking that a model is some specialised entity, rather than just 'whatever stuff you are trying to represent'. The other big one is about multiple models for a view, as if somehow that isn't allowed, and you must combine multiple models into a single object containing those objects. I think that elevating `model` and `collection` almost to the status of keywords in Backbone promotes this kind of thinking.

---

Just a bit of background. I'm currently working in a distributed team with I think more than 25 developers across three continents writing a very large Backbone application. Clarity of intent across the codebase has been harmed by overuse of generic terms (yes this is our fault, not Backbone's, but I figured it could have been prevented if Backbone's generic terms were more easily avoided)
