### PR TITLE
History#atRoot handles params without path.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1431,7 +1431,8 @@
 
     // Are we at the app root?
     atRoot: function() {
-      return this.location.pathname.replace(/[^\/]$/, '$&/') === this.root;
+      var path = this.location.pathname.replace(/[^\/]$/, '$&/');
+      return path === this.root && !this.location.search;
     },
 
     // Gets the true hash value. Cannot use location.hash directly due to bug

--- a/test/router.js
+++ b/test/router.js
@@ -854,4 +854,17 @@
     Backbone.history.start();
   });
 
+  test("pushState to hashChange with only search params.", 1, function() {
+    Backbone.history.stop();
+    location.replace('http://example.com?a=b');
+    location.replace = function(url) {
+      strictEqual(url, '/#?a=b');
+    };
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: null
+    });
+    Backbone.history.start({pushState: true});
+  });
+
 })();


### PR DESCRIPTION
Noticed this while looking at a different issue.
