### PR TITLE
Added reverse option in the collection sort method

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -870,6 +870,10 @@
         this.models.sort(_.bind(this.comparator, this));
       }
 
+      if (options.reverse) {
+        this.models = this.models.reverse();
+      }
+
       if (!options.silent) this.trigger('sort', this, options);
       return this;
     },

--- a/test/collection.js
+++ b/test/collection.js
@@ -284,6 +284,28 @@
     equal(col.indexOf(tom), 2);
   });
 
+  test("reverse sort with a sortBy stylecomparator", function() {
+    var col = new Backbone.Collection;
+    col.comparator = function(a) {
+      return a.get('name');
+    };
+    var tom = new Backbone.Model({name: 'Tom'});
+    var rob = new Backbone.Model({name: 'Rob'});
+    var tim = new Backbone.Model({name: 'Tim'});
+    col.add(tom);
+    col.add(rob);
+    col.add(tim);
+
+    equal(col.indexOf(rob), 0);
+    equal(col.indexOf(tim), 1);
+    equal(col.indexOf(tom), 2);
+
+    col.sort({reverse: true});
+    equal(col.indexOf(tom), 0);
+    equal(col.indexOf(tim), 1);
+    equal(col.indexOf(rob), 2);
+  });
+
   test("comparator that depends on `this`", 2, function() {
     var col = new Backbone.Collection;
     col.negative = function(num) {


### PR DESCRIPTION
Added the `reverse` option to be able to sort the collection in the
inverse order specified by the comparator. Useful for one argument
comparators returning string values.

For boolean and integer comparators are easy to find the inverse
function to reverse the collection but for string comparators it's
not as easy as it seems.

I have added the reverse method after the both kind of sorts methods
 to be reused by any kind of comparator. Then you will be able to 
reverse collections without changing the comparators, and reuse them.

People is doing this kind of things to achive those results:
https://gist.github.com/malandrew/950240
