### PR TITLE
Decode the fragment before comparing.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1599,8 +1599,8 @@
 
       var url = this.root + (fragment = this.getFragment(fragment || ''));
 
-      // Strip the hash for matching.
-      fragment = fragment.replace(pathStripper, '');
+      // Strip the hash and decode for matching.
+      fragment = decodeURI(fragment.replace(pathStripper, ''));
 
       if (this.fragment === fragment) return;
       this.fragment = fragment;

--- a/test/router.js
+++ b/test/router.js
@@ -405,7 +405,7 @@
     Backbone.history.navigate('charñ', {trigger: true});
     equal(router.charType, 'UTF');
     Backbone.history.navigate('char%C3%B1', {trigger: true});
-    equal(router.charType, 'escaped');
+    equal(router.charType, 'UTF');
   });
 
   test("#1185 - Use pathname when hashChange is not wanted.", 1, function() {
@@ -768,7 +768,7 @@
     var Router = Backbone.Router.extend({
       routes: {
         path: function(params){
-          strictEqual(params, 'x=y%20z');
+          strictEqual(params, 'x=y z');
         }
       }
     });
@@ -865,6 +865,21 @@
       history: null
     });
     Backbone.history.start({pushState: true});
+  });
+
+  test("#3123 - History#navigate decodes before comparison.", 1, function() {
+    Backbone.history.stop();
+    location.replace('http://example.com/shop/search?keyword=short%20dress');
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: {
+        pushState: function(){ ok(false); },
+        replaceState: function(){ ok(false); }
+      }
+    });
+    Backbone.history.start({pushState: true});
+    Backbone.history.navigate('shop/search?keyword=short%20dress', true);
+    strictEqual(Backbone.history.fragment, 'shop/search?keyword=short dress');
   });
 
 })();


### PR DESCRIPTION
Since #getFragment decodes the fragment, #navigate should
match this behavior (using decodeURI, not decodeURIComponent).
