### PR TITLE
workaround for a bug in the android browser.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1610,6 +1610,9 @@
 
       // If pushState is available, we use it to set the fragment as a real URL.
       if (this._hasPushState) {
+        //you can't trust Backbone.history.history when running in the Android browser.
+        this.history=window.history;
+        
         this.history[options.replace ? 'replaceState' : 'pushState']({}, document.title, url);
 
       // If hash changes haven't been explicitly disabled, update the hash


### PR DESCRIPTION
When leaving a backbone app, and returning via the back button,
Android's browser fails to properly restore the value of
Backbone.history.history, turning it into a dangerous pointer into
apparently freed memory.
This addition patches the one part of Backbone most likely to run afoul
of this bug while hopefully not harming other browsers.