### PR TITLE
Add an optional argument 'trailingSlashIsSignificant' to Backbone.Router...

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1285,6 +1285,9 @@
   var Router = Backbone.Router = function(options) {
     options || (options = {});
     if (options.routes) this.routes = options.routes;
+    if ('trailingSlashIsSignificant' in options) {
+        routeTrailingSlashPattern = options.trailingSlashIsSignificant ? '' : '[/]?';
+    }
     this._bindRoutes();
     this.initialize.apply(this, arguments);
   };
@@ -1295,6 +1298,7 @@
   var namedParam    = /(\(\?)?:\w+/g;
   var splatParam    = /\*\w+/g;
   var escapeRegExp  = /[\-{}\[\]+?.,\\\^$|#\s]/g;
+  var routeTrailingSlashPattern = '';
 
   // Set up all inheritable **Backbone.Router** properties and methods.
   _.extend(Router.prototype, Events, {
@@ -1361,7 +1365,8 @@
                      return optional ? match : '([^/?]+)';
                    })
                    .replace(splatParam, '([^?]*?)');
-      return new RegExp('^' + route + '(?:\\?([\\s\\S]*))?$');
+
+      return new RegExp('^' + route + '(?:\\?([\\s\\S]*))?' + routeTrailingSlashPattern + '$');
     },
 
     // Given a route, and a URL fragment that it matches, return the array of

--- a/test/router.js
+++ b/test/router.js
@@ -189,6 +189,29 @@
     equal(lastArgs[0], 'news');
   });
 
+  test("routes (simple, trailing slash is significant)", 4, function() {
+    location.replace('http://example.com#search/news/');
+    Backbone.history.checkUrl();
+    equal(typeof router.query, 'function');
+    equal(router.page, void 0);
+    equal(lastRoute, 'anything');
+    equal(lastArgs[0], 'search/news/');
+  });
+
+  test("routes (simple, trailing slash is insignificant)", 4, function() {
+    location.replace('http://example.com#search/news/');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    var route = new Router({ trailingSlashIsSignificant : false });
+    Backbone.history.on('route', onRoute);
+    Backbone.history.start();
+    Backbone.history.checkUrl();
+    equal(route.query, 'news');
+    equal(route.page, void 0);
+    equal(lastRoute, 'search');
+    equal(lastArgs[0], 'news');
+  });
+
   test("routes (simple, but unicode)", 4, function() {
     location.replace('http://example.com#search/тест');
     Backbone.history.checkUrl();


### PR DESCRIPTION
... so application authors can determine whether their applications treats URIs with a trailing slash as a different resource than URIs without a trailing slash. Defaults to true. This option causes Router to set the 'routeTrailingSlashPattern' variable, which is added to the overall URIs matching regex. #848
