### PR TITLE
Switch model/collection on an existing view

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1028,6 +1028,8 @@
     options || (options = {});
     _.extend(this, _.pick(options, viewOptions));
     this._ensureElement();
+    this.setModel(options.model);
+    this.setCollection(options.collection);
     this.initialize.apply(this, arguments);
   };
 
@@ -1035,7 +1037,7 @@
   var delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
   // List of view options to be merged as properties.
-  var viewOptions = ['model', 'collection', 'el', 'id', 'attributes', 'className', 'tagName', 'events'];
+  var viewOptions = ['el', 'id', 'attributes', 'className', 'tagName', 'events', 'modelEvents', 'collectionEvents'];
 
   // Set up all inheritable **Backbone.View** properties and methods.
   _.extend(View.prototype, Events, {

--- a/test/view.js
+++ b/test/view.js
@@ -403,7 +403,7 @@
   });
 
 
-  test("setModel", 3, function() {
+  test("setModel", 4, function() {
 
     var ChildView = Backbone.View.extend({
       modelEvents: {
@@ -425,6 +425,8 @@
 
     view.render();
     equal(view.$el.text(), 'bar');
+    m1.set('foo', 'babar');
+    equal(view.$el.text(), 'babar');
     view.setModel(m2);
     view.render();
     equal(view.$el.text(), 'baz');
@@ -433,7 +435,7 @@
 
   });
 
-  test("setCollection", 3, function() {
+  test("setCollection", 4, function() {
 
     var ChildView = Backbone.View.extend({
       collectionEvents: {
@@ -458,6 +460,8 @@
 
     view.render();
     equal(view.$el.text(), '1,2,3,4,5');
+    c1.add({id:6});
+    equal(view.$el.text(), '1,2,3,4,5,6');
     view.setCollection(c2);
     view.render();
     equal(view.$el.text(), '1,2,3,4,5,6,7,8,9,10');


### PR DESCRIPTION
If I have a view and would like to display several models successively, the easiest way to do this is to destroy the view then create a new one.
Sometimes I think it could be interesting to keep the same instance.

`View.setElement` is really smart because:
it binds view's method on DOM events based on the `events` options
it allows you to manipulate your view and attach (or move) in the DOM and you don’t have to take care about event binding/unbinding.
it provides an accessor on the view's DOM element which can be overriden for any reason

I think `View.setModel` and `View.setCollection` could be very nice because it could do the same job as `setElement` but on the model/collection.
It binds view's methods on model/collection events based on options ( `modelEvents` / `collectionEvents` ?)
It allows you to create a view without model and attach a model later or switch from a model to another one without removing all listeners.
It provides an accessor on the model/collection which can be overriden for any reason.

for example 

``` js
//on intialize
//view will start to listen to `initialModel` for change, request and sync events.
var view = new Backbone.View({
  modelEvents: {
    'change':'render',
    'request':'displayLoader',
    'sync':'hideLoader'
  }
  model: initialModel
});
//later, you can replace `initialModel` by `anOtherModel`
// all the events will be unbind on initialModel an bind on anOtherModel automatically  
view.setModel(anOtherModel);
//and another time...
view.setModel(lastModel);
```

and of course same concept with collection via `View.setCollection`
