### PR TITLE
Handle incorrect hash/search values in IE6.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1422,8 +1422,10 @@
       return path === this.root && !this.getSearch();
     },
 
+    // In IE6, the hash fragment and search params are incorrect if the
+    // fragment contains `?`.
     getSearch: function() {
-      var match = this.location.href.replace(/#.*$/, '').match(/\?.+$/);
+      var match = this.location.href.replace(/#.*/, '').match(/\?.+/);
       return match ? match[0] : '';
     },
 


### PR DESCRIPTION
In IE6, the hash/search value will not be correct when the hash
fragment contains '?'.

Thanks for pointing out the failure @jdalton!
