### PR TITLE
add `shallowApi` and `shallowUrl` to support shallow apis

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -548,11 +548,27 @@
     // using Backbone's restful methods, override this to change the endpoint
     // that will be called.
     url: function() {
+      if (this.shallowApi) return this.shallowUrl();
       var base =
         _.result(this, 'urlRoot') ||
         _.result(this.collection, 'url') ||
         urlError();
       if (this.isNew()) return base;
+      return base.replace(/([^\/])$/, '$1/') + encodeURIComponent(this.id);
+    },
+
+    // Shallow URL given the models location on the server is nested. If
+    // endpoints are nested shallow, set `shallowApi: true`. To have the
+    // url calculated by collection for CREATE and INDEX actions and by
+    // the model for member actions.
+    shallowUrl: function () {
+      if (this.isNew()) {
+        return _.result(this.collection, 'url');
+      }
+      var base =
+        _.result(this, 'urlRoot') ||
+        _.result(this.collection, 'url') ||
+        urlError();
       return base.replace(/([^\/])$/, '$1/') + encodeURIComponent(this.id);
     },
 

--- a/test/model.js
+++ b/test/model.js
@@ -110,6 +110,20 @@
     equal(model.url(), '/nested/1/collection/2');
   });
 
+  test("url when using shallowApi property to determine url at runtime", 2, function() {
+    var Model = Backbone.Model.extend({
+      shallowApi: true,
+      urlRoot: '/collection'
+    });
+
+    var model = new Model();
+    model.collection = new klass();
+    model.collection.url = '/nested/2/collection';
+    equal(model.url(), '/nested/2/collection');
+    model.set({id: 7});
+    equal(model.url(), '/collection/7');
+  });
+
   test("underscore methods", 5, function() {
     var model = new Backbone.Model({ 'foo': 'a', 'bar': 'b', 'baz': 'c' });
     var model2 = model.clone();


### PR DESCRIPTION
Allows the model to set a property of shallowApi to true, then will default to collection url if new, or model url if going to a member route.

Probably could use better naming. This was primarily to start the discussion about supporting urls of shallow apis better.
