### PR TITLE
Removing the IE8 PATCH requests fix

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1235,15 +1235,6 @@
       params.processData = false;
     }
 
-    // If we're sending a `PATCH` request, and we're in an old Internet Explorer
-    // that still has ActiveX enabled by default, override jQuery to use that
-    // for XHR instead. Remove this line when jQuery supports `PATCH` on IE8.
-    if (params.type === 'PATCH' && noXhrPatch) {
-      params.xhr = function() {
-        return new ActiveXObject("Microsoft.XMLHTTP");
-      };
-    }
-
     // Pass along `textStatus` and `errorThrown` from jQuery.
     var error = options.error;
     options.error = function(xhr, textStatus, errorThrown) {
@@ -1257,10 +1248,6 @@
     model.trigger('request', model, xhr, options);
     return xhr;
   };
-
-  var noXhrPatch =
-    typeof window !== 'undefined' && !!window.ActiveXObject &&
-      !(window.XMLHttpRequest && (new XMLHttpRequest).dispatchEvent);
 
   // Map from CRUD to HTTP for our default `Backbone.sync` implementation.
   var methodMap = {


### PR DESCRIPTION
Patch requests were not working on IE8, even with the Backbone fix (tested on XP/IE8 with modern.ie VMs).

```
Remove this line when jQuery supports `PATCH` on IE8.
```

jQuery 1.11.\* and the corresponding 2.x version now support PATCH requests (see: http://bugs.jquery.com/ticket/13240)

It now works as expected with jQuery
