### PR TITLE
Add reset opt-out feature to Collection.initialize

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -621,8 +621,8 @@
     if (options.model) this.model = options.model;
     if (options.comparator !== void 0) this.comparator = options.comparator;
     this._reset();
-    this.initialize.apply(this, arguments);
-    if (models) this.reset(models, _.extend({silent: true}, options));
+    var reset = this.initialize.apply(this, arguments);
+    if (reset !== false && models) this.reset(models, _.extend({silent: true}, options));
   };
 
   // Default options for `Collection#set`.

--- a/test/collection.js
+++ b/test/collection.js
@@ -543,6 +543,27 @@
     equal(coll.one, 1);
   });
 
+  test("opt-out of reset", function() {
+    var NormalCollection = Backbone.Collection.extend({
+      initialize: function(items) {
+        this.add(_.take(items, 1)); //this will be removed
+      }
+    });
+
+    var OptOutCollection = Backbone.Collection.extend({
+      initialize: function(items) {
+        this.add(_.take(items, 1));
+        return false;
+      }
+    });
+
+    var ncol = new NormalCollection([{a: 1}, {b: 2}]);
+    var ocol = new OptOutCollection([{a: 1}, {b: 2}]);
+
+    equal(ncol.length, 2, "resets anything done in initialize by default");
+    equal(ocol.length, 1, "returning false from initialize does not reset the collection");
+  });
+
   test("toJSON", 1, function() {
     equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });


### PR DESCRIPTION
Currently if we want our `initialize` constructor to take `models` and also add models to the collection it will need to do some dirty stuff:
- modify the `models` array if we can assume its an array (e.g. change the array of models as we desire)
- monkey-patch reset
- change the `initialize` for models which change `collection.models` to the form `initialize(falsy, options, models, *args)`

This patch allows it to be nicer, instead `initialize(models, options, *args)`. If `initialize` returns `false`, we simply won't call `reset` and `initialize` will be responsible for adding the `models`.
