### PR TITLE
Only test node 0.10.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - 0.8
   - '0.10'
 notifications:
   email: false


### PR DESCRIPTION
Since we only use node to drive phantomjs it
doesn't really matter what version we use.
