### PR TITLE
Force navigation, even if the URL isn't changing.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1579,7 +1579,7 @@
       // Strip the hash and decode for matching.
       fragment = decodeURI(fragment.replace(pathStripper, ''));
 
-      if (this.fragment === fragment) return;
+      if (this.fragment === fragment && !options.trigger) return;
       this.fragment = fragment;
 
       // Don't include a trailing slash on the root.


### PR DESCRIPTION
Make `Backbone.History.navigate('route', {trigger: true})` to call `.loadUrl`, even if the route isn't changing.

This bit me because I had assumed that `{trigger: true}` would cause my routing methods to be called in every scenario, but that was not the case when the URL wasn't actually changing.
