### PR TITLE
Extend Backbone.View#delegate to listen to models

### DIFF
--- a/test/view.js
+++ b/test/view.js
@@ -72,6 +72,31 @@
     equal(counter2, 3);
   });
 
+  test("delegateEvents can listen for events on the model", 1, function() {
+    var counter = 0;
+
+    var model = new Backbone.Model
+    var view = new Backbone.View({el: '#testElement', model: model});
+    view.increment = function(){ counter++ };
+
+    var events = {'@model change': 'increment'}
+
+    view.delegateEvents(events);
+    model.trigger('change');
+    equal(counter, 1);
+  });
+
+  test("delegate listens for model events", 1, function() {
+    var model = new Backbone.Model();
+    var view = new Backbone.View({ el: '#testElement', model: model});
+
+    view.delegate('@model change', '', function() {
+      ok(true);
+    }, model);
+
+    model.trigger('change');
+  });
+
   test("delegate", 2, function() {
     var view = new Backbone.View({el: '#testElement'});
     view.delegate('click', 'h1', function() {
@@ -135,6 +160,24 @@
     view.$('h1').trigger('click');
     equal(counter1, 2);
     equal(counter2, 3);
+  });
+
+  test("undelegateEvents removes model events", 2, function() {
+    var counter = 0;
+
+    var model = new Backbone.Model();
+    var view = new Backbone.View({ model: model, el: '#testElement' });
+    view.increment = function(){ counter++ };
+
+    var events = { '@model customEvent': 'increment' }
+
+    view.delegateEvents(events);
+    model.trigger('customEvent');
+    equal(counter, 1);
+
+    view.undelegateEvents();
+    model.trigger('customEvent');
+    equal(counter, 1);
   });
 
   test("undelegate", 0, function() {


### PR DESCRIPTION
A lot of times Backbone views will have the responsibility of listening and responding to events happening on it's model. This yields code that looks like the following:

``` js
var ExampleView = Backbone.View.extend({
  events: {
    'click': 'handleClick'
  },
  initialize: function() {
    this.listenTo(this.model, 'change', this.render);
  },
  render: function() {};
});
```

Backbone views currently provide a convenience syntax for listening to events on it's element. This commit extends that functionality to give you convenience syntax for the model.

``` js
var ExampleView = Backbone.View.extend({
  events: {
    'click': 'handleClick',
    '@model change': 'render'
  },
  render: function() {
    console.log('triggered because of the model!');
  };
});

var model = new Backbone.Model()
new ExampleView(model: model);

model.trigger('change');
//=> 'triggered because of the model!'
```

`Backbone.View#undelegateEvents` has also been modified to stop listening to all model events that were set via the events hash, `delegateEvents` or `delegate`.
