### PR TITLE
Added binary search for collections

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -891,11 +891,11 @@
           return true;
         });
       } else if (first) {
-        return [this.search(attrs[this.comparator], {getMin: true})];
+        return this.search(attrs[this.comparator], {getMin: true});
       } else {
         var minIndex = this.search(attrs[this.comparator], {returnIndex: true, getMin: true});
         var maxIndex = this.search(attrs[this.comparator], {returnIndex: true, getMax: true});
-        return !minIndex ? [] : this.models.slice(minIndex, maxIndex + 1);
+        return minIndex == null ? [] : this.models.slice(minIndex, maxIndex + 1);
       }
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -611,14 +611,14 @@
     var col2 = new Backbone.Collection(models, {
       comparator: 'a'
     });
-    equal(coll.where({a: 1}).length, 3);
-    equal(coll.where({a: 2}).length, 1);
-    equal(coll.where({a: 3}).length, 1);
-    equal(coll.where({b: 1}).length, 0);
-    equal(coll.where({b: 2}).length, 2);
-    equal(coll.where({a: 1, b: 2}).length, 1);
-    equal(coll.findWhere({a: 1}), model);
-    equal(coll.findWhere({a: 4}), void 0);
+    equal(col2.where({a: 1}).length, 3);
+    equal(col2.where({a: 2}).length, 1);
+    equal(col2.where({a: 3}).length, 1);
+    equal(col2.where({b: 1}).length, 0);
+    equal(col2.where({b: 2}).length, 2);
+    equal(col2.where({a: 1, b: 2}).length, 1);
+    equal(col2.findWhere({a: 1}), model);
+    equal(col2.findWhere({a: 4}), void 0);
   });
 
   test("Underscore methods", 16, function() {


### PR DESCRIPTION
Added `search` method to collection prototype as per #3169. This is automatically used by `where` and `findWhere` when it is possible to do so to provide speedups without user needing to do anything.

For `toFind`, the user may provide:
- a comparison function which compares takes one value and returns 1 if the sought value has higher index, -1 if its lower and 0 if the value matches (`comparator` unused)
- a value to search for (the value of the `model[comparator]` sought - requires `comparator` to be a string)
- a model to search for (where `comparator` is a function)

Users may also request that it is the index of the model that is returned or that the model of highest/lowest index which matches the comparison is sought.

When no match is found, `undefined` is returned, or if `returnIndex` is true then `-1` is returned instead.

One point that may need to be considered is that the behaviour when a model is input as `toFind` but the `comparator` is a string is different from that when `comparator` is a function. Furthermore, the name of this method may also need some more thought to emphasise that it is for _binary_ searches or that it only works on sorted collections so `binarySearch` or the more user-friendly `sortedSearched` might be preferable.
