### PR TITLE
Switch from double to single quotes

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1447,7 +1447,7 @@
     // Start the hash change handling, returning `true` if the current URL matches
     // an existing route, and `false` otherwise.
     start: function(options) {
-      if (History.started) throw new Error("Backbone.history has already been started");
+      if (History.started) throw new Error('Backbone.history has already been started');
       History.started = true;
 
       // Figure out the initial configuration. Do we need an iframe?


### PR DESCRIPTION
Switch from double to single quotes for consistency with rest of file

BEFORE:
      if (History.started) throw new Error("Backbone.history has already been started");

AFTER:
      if (History.started) throw new Error('Backbone.history has already been started');
