### PR TITLE
Prevent memory leak by `stopListening` on Backbone.Model `destroy`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -524,6 +524,7 @@
       var success = options.success;
 
       var destroy = function() {
+        model.stopListening();
         model.trigger('destroy', model, model.collection, options);
       };
 


### PR DESCRIPTION
Models may frequently be listening to events in other models, collections, or global messaging objects. When Models were `destroy`ed they would still be listening to these events.

This fiddle demonstrates the behavior: http://jsfiddle.net/E3hDA/

While programmers certainly can do this action themselves on a "destroy" callback, it is both extremely easy to overlook and `destroy` semantically implies that references will be cleaned up as best as possible.
