### PR TITLE
Uses listenTo instead of on between the collection and model.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -955,13 +955,13 @@
       this._byId[model.cid] = model;
       var id = this.modelId(model.attributes);
       if (id != null) this._byId[id] = model;
-      model.on('all', this._onModelEvent, this);
+      this.listenTo(model, 'all', this._onModelEvent);
     },
 
     // Internal method to sever a model's ties to a collection.
     _removeReference: function(model, options) {
       if (this === model.collection) delete model.collection;
-      model.off('all', this._onModelEvent, this);
+      this.stopListening(model);
     },
 
     // Internal method called every time a model in the set fires an event.


### PR DESCRIPTION
This is a change to follow the best practices of using `on` vs. `listenTo`.

As far as I know, there's no functional change here within the library itself, which follows from the fact that neither models nor collections call `off` or `stopListening` in any other circumstance.

There _will_ be a functional change for those developers who are listening to other model events. In those cases, this will correctly unregister those listeners when the model is removed the collection. As it stands, the current code may present a memory leak as the collection never calls `stopListening` when a model is removed, so it should still be holding onto a reference to that model.

I can add tests for that use case...but it's 1:40AM, so, tomorrow.
