### PR TITLE
Added support for arrays to `model.unset()`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -393,7 +393,14 @@
     // Remove an attribute from the model, firing `"change"`. `unset` is a noop
     // if the attribute doesn't exist.
     unset: function(attrs, options) {
-      return this.set(_.object([].concat(attrs), []), _.extend({}, options, {unset: true}));
+      var attrs = _.flatten(arguments);
+      var options = {unset: true};
+
+      if (attrs.length > 1 && typeof _.last(attrs) == "object") {
+        options = _.extend({}, attrs.pop(), {unset: true})
+      };
+
+      return this.set(_.object(attrs, []), options);
     },
 
     // Clear all attributes on the model, firing `"change"`.

--- a/test/model.js
+++ b/test/model.js
@@ -298,14 +298,21 @@
     equal(i, 2, 'Unset does not fire an event for missing attributes.');
   });
   
-  test("array support on unset", 1, function() {
+  test("array support on unset", 2, function() {
     var i = 0;
-    var counter = function(){ i++; };
-    var model = new Backbone.Model({a: 1, b: 2, c: 3});
+    var p = 0;
+    var counter = function(model, options) {
+      i++;
+
+      if (options.customProp) p++;
+    };
+    var model = new Backbone.Model({a: 1, b: 2, c: 3, d: 4, e: 5, f: 6});
     model.on("change", counter);
     model.unset('a');
     model.unset(['b', 'c']);
-    equal(i, 2, 'Unset correctly handles arrays and strings as attributes.');
+    model.unset(['d'], ['f'], { customProp: 1 });
+    equal(i, 3, 'Unset correctly handles any number of arrays or strings as attributes.');
+    equal(p, 1, 'Unset correctly handles attributes followed by an options hash.');
   });
 
   test("unset and changedAttributes", 1, function() {


### PR DESCRIPTION
I hope I kept the writing and test styles consistent.

This adds support for the `attr` argument in `model.unset()` to be an array.  It uses concat to ensure that attrs will always be an array and `_.object()` so the hash sent to `set` will be an object. Since the second argument is an empty array all values are set to `undefined`.

The contributing guide said not to update the documentation so I left the comment above the function unchanged.

Avi
