### PR TITLE
Declare module name on AMD setup

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -9,7 +9,7 @@
 
   // Set up Backbone appropriately for the environment. Start with AMD.
   if (typeof define === 'function' && define.amd) {
-    define(['underscore', 'jquery', 'exports'], function(_, $, exports) {
+    define('backbone', ['underscore', 'jquery', 'exports'], function(_, $, exports) {
       // Export global even in AMD case in case this script is loaded with
       // others that may still expect a global Backbone.
       root.Backbone = factory(root, exports, _, $);


### PR DESCRIPTION
Missing the name will give a "MISMATCHED ANONYMOUS DEFINE() MODULES ..." error when loading backbone.js and require.js through script tags.

This is also following how underscore.js works, which declares the module name in the define() call.
