### PR TITLE
Changed extend function to allow access to overridden methods with: this._super()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1637,40 +1637,63 @@
   // Helpers
   // -------
 
+  var fnTest = /xyz/.test(function(){xyz;}) ? /\b_super\b/ : /.*/;
+  
   // Helper function to correctly set up the prototype chain, for subclasses.
   // Similar to `goog.inherits`, but uses a hash of prototype properties and
   // class properties to be extended.
   var extend = function(protoProps, staticProps) {
-    var parent = this;
-    var child;
 
+    var _super = this.prototype, parent = this, prototype = {}, Child;
+
+    if ( protoProps ) {
+
+       for (var name in protoProps) {
+         prototype[name] = typeof protoProps[name] == "function" && typeof _super[name] == "function" && fnTest.test(protoProps[name]) ?
+           (function(name, fn){
+             return function() {
+               var tmp = this._super;
+
+               this._super = _super[name];
+              
+               var ret = fn.apply(this, arguments);        
+               this._super = tmp;
+              
+               return ret;
+             };
+           })(name, protoProps[name]) :
+           protoProps[name];
+       }
+
+    }
+     
     // The constructor function for the new subclass is either defined by you
     // (the "constructor" property in your `extend` definition), or defaulted
     // by us to simply call the parent's constructor.
-    if (protoProps && _.has(protoProps, 'constructor')) {
-      child = protoProps.constructor;
+    if ( _.has(prototype, 'constructor') ) {
+       Child = prototype.constructor;
     } else {
-      child = function(){ return parent.apply(this, arguments); };
+       Child = function(){ return parent.apply(this, arguments) };
     }
 
     // Add static properties to the constructor function, if supplied.
-    _.extend(child, parent, staticProps);
+    _.extend(Child, parent, staticProps);
 
     // Set the prototype chain to inherit from `parent`, without calling
     // `parent`'s constructor function.
-    var Surrogate = function(){ this.constructor = child; };
+    var Surrogate = function(){ this.constructor = Child; };
     Surrogate.prototype = parent.prototype;
-    child.prototype = new Surrogate;
+    Child.prototype = new Surrogate;
 
     // Add prototype properties (instance properties) to the subclass,
     // if supplied.
-    if (protoProps) _.extend(child.prototype, protoProps);
+    if (protoProps) _.extend(Child.prototype, prototype);
 
     // Set a convenience property in case the parent's prototype is needed
     // later.
-    child.__super__ = parent.prototype;
+    Child.__super__ = parent.prototype;
 
-    return child;
+    return Child;
   };
 
   // Set up inheritance for the model, collection, router, view and history.


### PR DESCRIPTION
This is a mix of John Resig's Inheritance seen here http://ejohn.org/blog/simple-javascript-inheritance/ and what was already there.  This allows you to use this._super() to access overridden members.
