### PR TITLE
Update JavaScript toJSON API documentation URL

### DIFF
--- a/index.html
+++ b/index.html
@@ -1660,7 +1660,7 @@ var spaces = new Backbone.Collection([], {
       collection. This can be used to serialize and persist the
       collection as a whole. The name of this method is a bit confusing, because
       it conforms to
-      <a href="https://developer.mozilla.org/en/JSON#toJSON()_method">JavaScript's JSON API</a>.
+      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON_behavior">JavaScript's JSON API</a>.
     </p>
 
 <pre class="runnable">


### PR DESCRIPTION
The previous link to MDN had rotted, this seems to be the closest correct URL.
