### PR TITLE
Allow MDN to select an appropriate localization [ci-skip]

### DIFF
--- a/index.html
+++ b/index.html
@@ -1660,7 +1660,7 @@ var spaces = new Backbone.Collection([], {
       collection. This can be used to serialize and persist the
       collection as a whole. The name of this method is a bit confusing, because
       it conforms to
-      <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON_behavior">JavaScript's JSON API</a>.
+      <a href="https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#toJSON_behavior">JavaScript's JSON API</a>.
     </p>
 
 <pre class="runnable">
@@ -1887,7 +1887,7 @@ var book = library.get(110);
       <br />
       Return a shallow copy of this collection's models, using the same options as
       native
-      <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/slice">Array#slice</a>.
+      <a href="https://developer.mozilla.org/JavaScript/Reference/Global_Objects/Array/slice">Array#slice</a>.
     </p>
 
     <p id="Collection-length">
@@ -1908,7 +1908,7 @@ var book = library.get(110);
       <a href="http://underscorejs.org/#sortBy">sortBy</a>
       (pass a function that takes a single argument),
       as a
-      <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/sort">sort</a>
+      <a href="https://developer.mozilla.org/JavaScript/Reference/Global_Objects/Array/sort">sort</a>
       (pass a comparator function that expects two arguments),
       or as a string indicating the attribute to sort by.
     </p>
@@ -4410,7 +4410,7 @@ ActiveRecord::Base.include_root_in_json = false
         A Backbone collection's <tt>comparator</tt> function may now behave
         either like a <a href="http://underscorejs.org/#sortBy">sortBy</a>
         (pass a function that takes a single argument),
-        or like a <a href="https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Array/sort">sort</a>
+        or like a <a href="https://developer.mozilla.org/JavaScript/Reference/Global_Objects/Array/sort">sort</a>
         (pass a comparator function that expects two arguments). The comparator
         function is also now bound by default to the collection &mdash; so you
         can refer to <tt>this</tt> within it.


### PR DESCRIPTION
Petty pr :) Noticed #3258, MDN redirects to the appropriate i18n page if not explicitly set.
