### PR TITLE
Fixed a bug where navigate to /?someparam=somevalue will get url truncated

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1599,7 +1599,7 @@
       this.fragment = fragment;
 
       // Don't include a trailing slash on the root.
-      if (fragment === '' && url !== '/') url = url.slice(0, -1);
+      if (fragment === '' && url.length > 1 && url[url.length - 1] === '/') url = url.slice(0, -1);
 
       // If pushState is available, we use it to set the fragment as a real URL.
       if (this._hasPushState) {


### PR DESCRIPTION
The line I edited was supposed to removed an unnecessary trailing slash in the URL, so what I did is to check if the trailing character is actually a slash, which I guess should make sense.

We ran into an issue where we are navigating to home(/) page with some params, and the last character gets removed.

Thanks.
