### PR TITLE
Ignore built-in object properties when using objects as hash tables

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -305,7 +305,7 @@
 
     // Get the value of an attribute.
     get: function(attr) {
-      return this.attributes[attr];
+      return property(this.attributes, attr);
     },
 
     // Get the HTML-escaped value of an attribute.
@@ -818,8 +818,8 @@
     // Get a model from the set by id.
     get: function(obj) {
       if (obj == null) return void 0;
-      var id = this.modelId(this._isModel(obj) ? obj.attributes : obj);
-      return this._byId[obj] || this._byId[id] || this._byId[obj.cid];
+      var id = this.modelId(this._isModel(obj) ? obj.attributes : obj)
+      return property(this._byId, obj) || property(this._byId, id) || property(this._byId, obj.cid);
     },
 
     // Get the model at the given index.
@@ -1680,6 +1680,13 @@
 
     return child;
   };
+
+  // Extract own properties from objects
+  var property = function (object, key) {
+    if (_.has(object, key)) {
+      return object[key];
+    }
+  }
 
   // Set up inheritance for the model, collection, router, view and history.
   Model.extend = Collection.extend = Router.extend = View.extend = History.extend = extend;

--- a/test/collection.js
+++ b/test/collection.js
@@ -1426,4 +1426,10 @@
     equal(collection.at(1), collection.get('b-1'));
   });
 
+  test('#3279: get does not return Object prototype properties', function() {
+    var collection = new Backbone.Collection;
+    strictEqual(collection.get('toString'), undefined);
+    strictEqual(collection.get(new Backbone.Model({id: 'toString'})), undefined);
+    strictEqual(collection.get({cid: 'toString'}), undefined);
+  });
 })();

--- a/test/model.js
+++ b/test/model.js
@@ -1140,4 +1140,9 @@
     model.set({a: true});
   });
 
+  test('#3279 - get does not return Object prototype properties' , function() {
+    var model = new Backbone.Model;
+    strictEqual(model.get('constructor'), undefined);
+  });
+
 })();


### PR DESCRIPTION
JavaScript object initialised via `{}` have some predefined properties such as `constructor` and `toString`. When objects are used as hashes, these properties can cause weird behaviours.

In the Collection id lookup cache, `new Collection().get('constructor')` returns `Object.prototype.constructor`. Similarly `new Model().get('toString')` returns `Object.prototype.toString`. Even worse, this causes `new Collection().push({id: 'hasOwnProperty'})` to throw an exception.

To prevent this, I've added hasOwnProperty checks to `Collection.prototype.get` and `Model.prototype.get`.
