### PR TITLE
Improve readability of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@
     (_.———————————————————————————————————————————————————————————————————————————————._)
 
 
-Backbone supplies structure to JavaScript-heavy applications by providing models key-value binding and custom events, collections with a rich API of enumerable functions, views with declarative event handling, and connects it all to your existing application over a RESTful JSON interface.
+Backbone supplies structure to JavaScript-heavy applications by providing:
+ - Models key-value binding and custom events,
+ - Collections with a rich API of enumerable functions.
+ - Views with declarative event handling.
+Plus it connects it all to your existing application over a RESTful JSON interface.
 
 For Docs, License, Tests, pre-packed downloads, and everything else, really, see:
 http://backbonejs.org


### PR DESCRIPTION
The previous first long sentence of README.md has been split into a short unordered list which is much easier to read and places emphasis on the main features. No wording has been changed. No source code has been changed,
