### PR TITLE
backbone.js , Provide current change key during trigger phase

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -371,7 +371,7 @@
       if (!silent) {
         if (changes.length) this._pending = options;
         for (var i = 0, length = changes.length; i < length; i++) {
-          this.trigger('change:' + changes[i], this, current[changes[i]], options);
+          this.trigger('change:' + changes[i], this, current[changes[i]], changes[i] , options);
         }
       }
 


### PR DESCRIPTION
This change provide the key during the loop which trigger the event.
We have the value but the key was never provided.
This change have passed the test, and no regression or break have been made (really ???) .
When you use : 

``` javascript
    mymodel.on('change:a change:b change:c' , function(model , value , key , options){
        // here you know the current key without having to loop again
        // over changedAttributes previousAttributes etc...
        doWhatYouWant( key ); 
    });
```

Before you can't know which one trigger the event, and now you can !
yes we can !
? really ?
