### PR TITLE
fix flawed test

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -1189,15 +1189,15 @@
   });
 
   test("Attach options to collection.", 2, function() {
-    var model = new Backbone.Model;
+    var Model = Backbone.Model;
     var comparator = function(){};
 
     var collection = new Backbone.Collection([], {
-      model: model,
+      model: Model,
       comparator: comparator
     });
 
-    ok(collection.model === model);
+    ok(collection.model === Model);
     ok(collection.comparator === comparator);
   });
 


### PR DESCRIPTION
This test's `sync` stub uses the wrong options.success api. The test is wrong though it does not produce any error. Yet I was adding custom features to my fork when this piece of code generated a bug. It will likely produce a bug in upstream backbone too if it is not fixed now.

The problem is `options.success` takes `(model, response, options)` when dealing with save, sync and co. However it takes `(response)` when in `Backbone.sync` and _this is not documented_.

I suggest adding an entry in the doc to avoid this kind of problems in the future.
