### PR TITLE
Fix a bunch of accessibility issues.

### DIFF
--- a/examples/todos/index.html
+++ b/examples/todos/index.html
@@ -13,6 +13,7 @@
 
     <header>
       <h1>Todos</h1>
+      <label class="sr-only" for="new-todo">What needs to be done?</label>
       <input id="new-todo" type="text" placeholder="What needs to be done?">
     </header>
 
@@ -23,14 +24,10 @@
     </section>
 
     <footer>
-      <a id="clear-completed">Clear completed</a>
+      <a href="#" id="clear-completed" role="button">Clear completed</a>
       <div id="todo-count"></div>
     </footer>
 
-  </div>
-
-  <div id="instructions">
-    Double-click to edit a todo.
   </div>
 
   <div id="credits">
@@ -51,16 +48,18 @@
 
   <script type="text/template" id="item-template">
     <div class="view">
-      <input class="toggle" type="checkbox" <%= done ? 'checked="checked"' : '' %> />
-      <label><%- title %></label>
-      <a class="destroy"></a>
+      <label>
+        <input class="toggle" type="checkbox" <%= done ? 'checked="checked"' : '' %> /><%- title %>
+      </label>
+      <a href="#" class="edit-link button" role="button">Edit</a>
+      <a href="#" class="destroy" role="button"><span class="sr-only">Delete</span></a>
     </div>
     <input class="edit" type="text" value="<%- title %>" />
   </script>
 
   <script type="text/template" id="stats-template">
     <% if (done) { %>
-      <a id="clear-completed">Clear <%= done %> completed <%= done == 1 ? 'item' : 'items' %></a>
+      <a href="#" id="clear-completed" class="button" role="button">Clear <%= done %> completed <%= done == 1 ? 'item' : 'items' %></a>
     <% } %>
     <div class="todo-count"><b><%= remaining %></b> <%= remaining == 1 ? 'item' : 'items' %> left</div>
   </script>

--- a/examples/todos/todos.css
+++ b/examples/todos/todos.css
@@ -14,6 +14,51 @@ body {
 	-webkit-font-smoothing: antialiased;
 }
 
+.sr-only {
+		position: absolute;
+		width: 1px;
+		height: 1px;
+		margin: -1px;
+		padding: 0;
+		overflow: hidden;
+		clip: rect(0,0,0,0);
+		border: 0;
+}
+
+.button {
+	line-height: 20px;
+	text-decoration: none;
+	background: rgba(0, 0, 0, 0.1);
+	color: #555555;
+	font-size: 11px;
+	padding: 0 10px 1px;
+	cursor: pointer;
+	-webkit-border-radius: 12px;
+	-moz-border-radius: 12px;
+	-ms-border-radius: 12px;
+	-o-border-radius: 12px;
+	border-radius: 12px;
+	-webkit-box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
+	-moz-box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
+	-ms-box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
+	-o-box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
+	box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
+}
+
+.button:hover {
+	background: rgba(0, 0, 0, 0.15);
+	-webkit-box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
+	-moz-box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
+	-ms-box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
+	-o-box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
+	box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
+}
+
+.button:active {
+	position: relative;
+	top: 1px;
+}
+
 #todoapp {
 	background: #fff;
 	padding: 20px;
@@ -68,7 +113,7 @@ body {
 }
 
 #todo-list li {
-	padding: 18px 20px 18px 0;
+	padding: 18px 70px 18px 0;
 	position: relative;
 	font-size: 24px;
 	border-bottom: 1px solid #cccccc;
@@ -87,19 +132,20 @@ body {
 	position: absolute;
 	right: 5px;
 	top: 20px;
-	display: none;
 	cursor: pointer;
 	width: 20px;
 	height: 20px;
 	background: url(destroy.png) no-repeat;
 }
 
-#todo-list li:hover .destroy {
-  	display: block;
+#todo-list .edit-link {
+	position: absolute;
+	right: 35px;
+	top: 20px;
 }
 
-#todo-list .destroy:hover {
-  	background-position: 0 -20px;
+#todo-list .destroy:hover, #todo-list .destroy:focus {
+		background-position: 0 -20px;
 }
 
 #todo-list li.editing {
@@ -149,54 +195,12 @@ body {
 
 #clear-completed {
 	float: right;
-	line-height: 20px;
-	text-decoration: none;
-	background: rgba(0, 0, 0, 0.1);
-	color: #555555;
-	font-size: 11px;
 	margin-top: 8px;
 	margin-bottom: 8px;
-	padding: 0 10px 1px;
-	cursor: pointer;
-	-webkit-border-radius: 12px;
-	-moz-border-radius: 12px;
-	-ms-border-radius: 12px;
-	-o-border-radius: 12px;
-	border-radius: 12px;
-	-webkit-box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
-	-moz-box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
-	-ms-box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
-	-o-box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
-	box-shadow: rgba(0, 0, 0, 0.2) 0 -1px 0 0;
-}
-
-#clear-completed:hover {
-	background: rgba(0, 0, 0, 0.15);
-	-webkit-box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
-	-moz-box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
-	-ms-box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
-	-o-box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
-	box-shadow: rgba(0, 0, 0, 0.3) 0 -1px 0 0;
-}
-
-#clear-completed:active {
-	position: relative;
-	top: 1px;
 }
 
 #todo-count span {
 	font-weight: bold;
-}
-
-#instructions {
-	margin: 10px auto;
-	color: #777777;
-	text-shadow: rgba(255, 255, 255, 0.8) 0 1px 0;
-	text-align: center;
-}
-
-#instructions a {
-	color: #336699;
 }
 
 #credits {

--- a/examples/todos/todos.js
+++ b/examples/todos/todos.js
@@ -80,11 +80,11 @@ $(function(){
 
     // The DOM events specific to an item.
     events: {
-      "click .toggle"   : "toggleDone",
-      "dblclick .view"  : "edit",
-      "click a.destroy" : "clear",
-      "keypress .edit"  : "updateOnEnter",
-      "blur .edit"      : "close"
+      "click .toggle"     : "toggleDone",
+      "click a.edit-link" : "edit",
+      "click a.destroy"   : "clear",
+      "keypress .edit"    : "updateOnEnter",
+      "blur .edit"        : "close"
     },
 
     // The TodoView listens for changes to its model, re-rendering. Since there's


### PR DESCRIPTION
* Added missing label for "What needs to be done?" text input.
* Added `href` attributes to all `<a>` tags to make them able to be focused with a keyboard.
* Replaced "double click to edit" (which can't be accessed with a keyboard [or from a touch device, for that matter]) with an edit button.
* Associated the TODO item labels with their check boxes.
* Always show the delete button. Showing it only when the parent `<li>` has mouse hover doesn't work with a keyboard (or from a touch device, for that matter).
* Apply the existing `:hover` styles to `:focus` as well. In general you always want to apply styles to both.
* Added the WAI-ARIA `role="button"` attribute to the buttons that are (probably incorrectly) marked up as `<a>` tags. They should really be marked up using `<button>`, but in the interest of treading lightly I left them as `<a>` tags. The fact that the `<a>` tags didn't have `href` attributes (and that they now have `href="#"`) is the clue that they are really buttons and not links.
* Added screen reader only "delete" text to the delete buttons, which were previously empty (with only a background image).