### PR TITLE
Remove wrapError calls, fixes #3346

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1243,18 +1243,8 @@
       params.processData = false;
     }
 
-    // Pass along `textStatus` and `errorThrown` from jQuery, and trigger model.
-    var error = options.error;
-    options.error = function(xhr, textStatus, errorThrown) {
-      options.textStatus = textStatus;
-      options.errorThrown = errorThrown;
-      model.trigger('error', model, xhr, options);
-
-      if (error) error.apply(this, arguments);
-    };
-
     // Make the request, allowing the user to override any Ajax options.
-    var xhr = options.xhr = Backbone.ajax(_.extend(params, options));
+    var xhr = options.xhr = Backbone.ajax(_.extend(params, options), model);
     model.trigger('request', model, xhr, options);
     return xhr;
   };
@@ -1270,8 +1260,18 @@
 
   // Set the default implementation of `Backbone.ajax` to proxy through to `$`.
   // Override this if you'd like to use a different library.
-  Backbone.ajax = function() {
-    return Backbone.$.ajax.apply(Backbone.$, arguments);
+  Backbone.ajax = function(options, model) {
+    // Pass along `textStatus` and `errorThrown` from jQuery, and trigger model.
+    var error = options.error;
+    options.error = function(xhr, textStatus, errorThrown) {
+      options.textStatus = textStatus;
+      options.errorThrown = errorThrown;
+      model.trigger('error', model, xhr, options);
+
+      if (error) error.apply(this, arguments);
+    };
+
+    return Backbone.$.ajax.call(Backbone.$, options);
   };
 
   // Backbone.Router

--- a/test/collection.js
+++ b/test/collection.js
@@ -474,7 +474,7 @@
     collection.on('error', function () {
       ok(true);
     });
-    Backbone.ajax = function(options) {
+    Backbone.$.ajax = function(options) {
         options.error();
     };
     collection.fetch({url: "test"});

--- a/test/environment.js
+++ b/test/environment.js
@@ -15,7 +15,7 @@
     history.pushState = history.replaceState = function(){};
 
     // Capture ajax settings for comparison.
-    Backbone.ajax = function(settings) {
+    Backbone.$.ajax = function(settings) {
       env.ajaxSettings = settings;
     };
 

--- a/test/model.js
+++ b/test/model.js
@@ -457,7 +457,7 @@
     model.on('error', function () {
       ok(true);
     });
-    Backbone.ajax = function(options) {
+    Backbone.$.ajax = function(options) {
         options.error();
     };
     model.save({data: 2, id: 1}, {url: "test"});


### PR DESCRIPTION
Ref: issue #3346 

Currently wrapError is always called before Backbone.sync. If wrapError is removed and its functionality is moved within Backbone.sync, it will provide these added benefits:
1. When users override Backbone.sync themselves, they can check to see if an error parameter was explicitly defined in their code
2. No unnecessary pre-emptive checks to see if options.error is specified on every ajax call
