### PR TITLE
Add note to view.attributes docs re: `id` and `className` precedence.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2643,8 +2643,8 @@ listView.$el.append(itemView.el);
       <b class="header">attributes</b><code>view.attributes</code>
       <br />
       A hash of attributes that will be set as HTML DOM element attributes on the
-      view's <tt>el</tt> (id, class, data-properties, etc.), or a function that
-      returns such a hash.
+      view's <tt>el</tt> (<tt>id</tt>, <tt>class</tt>, data-properties, etc.), or a function that
+      returns such a hash. If <tt>view.id</tt> or <tt>view.className</tt> are set they will supersede <tt>id</tt> and <tt>class</tt> attributes, respectively.
     </p>
 
     <p id="View-dollar">


### PR DESCRIPTION
Document how `view.attributes.class` and `view.attributes.id` are affected (superseded) by `view.className` and `view.id`, respectively.

Are you trying to maintain a particular line-length limit in this file?
