### PR TITLE
Make backbone-min.js available for bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,5 +5,5 @@
   "dependencies"  : {
     "underscore"  : ">=1.5.0"
   },
-  "ignore"        : ["backbone-min.js", "docs", "examples", "test", "*.yml", "*.map", "*.html", "*.ico", "*.md", "CNAME"]
+  "ignore"        : ["docs", "examples", "test", "*.yml", "*.html", "*.ico", "*.md", "CNAME"]
 }


### PR DESCRIPTION
After "bower install" missing backbone-min.js and backbone-min.map. To make it available - we just need to remove it from bower.json ignore.
