### PR TITLE
Added splice to collections

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -826,6 +826,15 @@
       return slice.apply(this.models, arguments);
     },
 
+    // Splice removes a number of models and optionally replace them
+    splice: function(index, howMany /* [, replaceModel1[, ... replaceModelN]] */) {
+      var toAdd = slice.call(arguments, 2);
+      var removed = slice.call(this.models, index, index + howMany);
+      this.remove(removed);
+      if (toAdd.length > 0) this.add(toAdd, {at: index});
+      return removed;
+    },
+
     // Get a model from the set by id.
     get: function(obj) {
       if (obj == null) return void 0;

--- a/test/collection.js
+++ b/test/collection.js
@@ -364,6 +364,14 @@
     equal(array[0].get('b'), 'b');
   });
 
+  test("splice", 3, function() {
+    var col = new Backbone.Collection([{a: 'a'}, {b: 'b'}, {c: 'c'}]);
+    var removed = col.splice(1, 2, {d: 'd'}, {e: 'e'});
+    equal(removed.length, 2);
+    equal(removed[0].get('b'), 'b');
+    equal(col.at(2).get('e'), 'e');
+  });
+
   test("events are unbound on remove", 3, function() {
     var counter = 0;
     var dj = new Backbone.Model();


### PR DESCRIPTION
Adding `splice` to collections which is just a wrapper for slicing and then removing. Optionally also allows you to replace models just like `Array.prototype.splice`. Like `slice` it has the same arguments as `Array.prototype.splice`.

The only problem I see with this is that we don't have a good place to put `options`. We can't really just shove it on the end since we couldn't distinguish someone not passing options from someone passing an object that should be added. We could put it after `howMany` but that would break the format from being the same as `Array.prototype.splice`. I didn't put it anywhere for now, I thought I'd wait for others to weigh in.
