### PR TITLE
Collection.add accepts negative indexes for the `at` option

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -700,6 +700,7 @@
       models = singular ? (models ? [models] : []) : models.slice();
       var id, model, attrs, existing, sort;
       var at = options.at;
+      if (at < 0) at += this.length + 1;
       var sortable = this.comparator && (at == null) && options.sort !== false;
       var sortAttr = _.isString(this.comparator) ? this.comparator : null;
       var toAdd = [], toRemove = [], modelMap = {};

--- a/test/collection.js
+++ b/test/collection.js
@@ -1482,4 +1482,11 @@
     collection.set([{id: 1}, {id: 2}, {id: 3}]);
   });
 
+  test("add supports negative indexes", 1, function() {
+    var collection = new Backbone.Collection([{id: 1}]);
+    collection.add([{id: 2}, {id: 3}], {at: -1});
+    collection.add([{id: 2.5}], {at: -2});
+    equal(collection.pluck('id').join(','), "1,2,2.5,3");
+  });
+
 })();


### PR DESCRIPTION
https://github.com/jashkenas/backbone/pull/3281 added support to `at` for negative indexes but it seems useful to add to `add` (pun not intended) as well. Adding a model to the end of a collection would be as easy as:

``` JS
collection.add(model, {at: -1});
```

With the simplicity of the change and since without this patch passing `-1` would actually add to the beginning of the collection (the opposite of the user's expectation) I think it's worth accepting.
