### PR TITLE
Add Collection cid

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -600,6 +600,7 @@
     options || (options = {});
     if (options.model) this.model = options.model;
     if (options.comparator !== void 0) this.comparator = options.comparator;
+    this.cid = _.uniqueId('c');
     this._reset();
     this.initialize.apply(this, arguments);
     if (models) this.reset(models, _.extend({silent: true}, options));


### PR DESCRIPTION
Cid's are a useful field for keeping track of class instances. The `cid` field in this case is modeled after Model's `cid` field and prepends the 'c' to the unique id.

I'm curious to see what opinions you have. We're discussing adding cids to our classes in marionette so that it is easy to track references while debugging. Cids are also useful when building inspector tools that want a unique reference to primary class instances in the system. [marionette discussion](https://github.com/marionettejs/backbone.marionette/issues/2059).
