### PR TITLE
Added `sparse` option to `set`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -332,7 +332,7 @@
     // the core primitive operation of a model, updating the data and notifying
     // anyone who needs to know about the change in state. The heart of the beast.
     set: function(key, val, options) {
-      var attr, attrs, unset, changes, silent, changing, prev, current;
+      var attr, attrs, unset, changes, silent, sparse, changing, prev, current;
       if (key == null) return this;
 
       // Handle both `"key", value` and `{key: value}` -style arguments.
@@ -351,11 +351,12 @@
       // Extract attributes and options.
       unset           = options.unset;
       silent          = options.silent;
+      sparse          = options.sparse;
       changes         = [];
       changing        = this._changing;
       this._changing  = true;
 
-      if (!changing) {
+      if (!changing || sparse) {
         this._previousAttributes = _.clone(this.attributes);
         this.changed = {};
       }

--- a/test/model.js
+++ b/test/model.js
@@ -930,6 +930,22 @@
     model.set({x: 1});
   });
 
+  test("nested `change` with sparse", 2, function() {
+    var model = new Backbone.Model();
+
+    model.once('change', function() {
+      deepEqual(this.changedAttributes(), {x: true});
+
+      model.on('change', function() {
+        deepEqual(this.changedAttributes(), {y: true});
+      });
+
+      model.set({y: true}, {sparse: true});
+    });
+
+    model.set({x: true}, {sparse: true});
+  });
+
   test("nested set multiple times", 1, function() {
     var model = new Backbone.Model();
     model.on('change:b', function() {


### PR DESCRIPTION
This option is useful for nested `change` events where Backbone would normally recursively trigger the event while collecting all the changed attributes. With `sparse` enabled, the `changedAttributes` and `hasChanged` methods will only consider the attributes that have been change by the most recent call to `set`.

Actual use case of mine: I'm writing a layout engine backed by `Backbone.Model`. Many of the attributes depend on the value of others (think `width` depends on `leftGuide` and `rightGuide`). This means if one attribute is changed, many others may have to be recomputed. This dependency chain can get multiple levels deep, as some attributes depend on other computed attributes up until at the top where there are only known or root properties (think `leftGuide` depends on `guides` and `viewportWidth`).

The way Backbone currently does the `change` event the layout engine recomputes the same values multiple times, since `changedAttributes()` will get bigger and bigger and always contain all the properties that changed since the beginning of the chain.

As you can see the diff is very simple and I was able to implement this in my subclass by overriding `set`. But I thought others might benefit from it. There's also a Stackoverflow question I created yesterday with some discussion http://stackoverflow.com/questions/26979021/backbone-model-how-to-listen-for-changes-on-multiple-attributes-only-once/26994282#26994282
