### PR TITLE
Don't allow initial attributes to affect previous()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -280,6 +280,7 @@
     if (options.parse) attrs = this.parse(attrs, options) || {};
     attrs = _.defaults({}, attrs, _.result(this, 'defaults'));
     this.set(attrs, options);
+    this._previousAttributes = {};
     this.changed = {};
     this.initialize.apply(this, arguments);
   };

--- a/test/model.js
+++ b/test/model.js
@@ -374,9 +374,12 @@
     equal(model.get('two'), 4);
   });
 
-  test("change, hasChanged, changedAttributes, previous, previousAttributes", 9, function() {
+  test("change, hasChanged, changedAttributes, previous, previousAttributes", 12, function() {
     var model = new Backbone.Model({name: "Tim", age: 10});
     deepEqual(model.changedAttributes(), false);
+    equal(model.hasChanged('name'), false);
+    equal(model.previous('name'), null);
+    deepEqual(model.previousAttributes(), {});
     model.on('change', function() {
       ok(model.hasChanged('name'), 'name changed');
       ok(!model.hasChanged('age'), 'age did not');


### PR DESCRIPTION
This might break existing code utilizing this "bug", though I haven't thought of a realistic use case that is negatively affected. Anyways, I thought I'd make a PR so we can discuss the issue but to my understanding this is a bug. The initial attributes for a model were being stored as `_previousAttributes` because of the `set` call in the constructor. This means calling `previous` without ever changing anything would return the initial value.

This breaks the following pseudo-view-code:

``` JS
// view for rendering other views... this is pseudocode remember
initialize: function(options) {
    //this.model.set('innerView', options.innerView);
    this.listenTo(this.model, 'change:innerView', this.renderInnerView);
    this.renderInnerView(); //render initial passed innerView
},

renderInnerView: function() {
    var newView = model.get('innerView'), 
        prevView = model.previous('innerView');
    if (prevView) { newView.destroy(); }
    newView.render();
}
```

This "bug" causes the `prevView` variable to actually be the original view passed into `options` so before we call render, we're immediately destroying the view.

The change for this is very tiny and the documentation doesn't specify what `previous` does when not called during a "change" event so this behavior is undocumented either way. The fact that `get` and `previous` return the same value though seems to contradict the function name, at least by my understanding.
