### PR TITLE
Remove this.options from History

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1477,12 +1477,12 @@
 
       // Figure out the initial configuration. Do we need an iframe?
       // Is pushState desired ... is it available?
-      this.options          = _.extend({root: '/'}, this.options, options);
-      this.root             = this.options.root;
-      this._wantsHashChange = this.options.hashChange !== false;
+      options               = _.extend({root: '/'}, options);
+      this.root             = options.root;
+      this._wantsHashChange = options.hashChange !== false;
       this._hasHashChange   = 'onhashchange' in window;
-      this._wantsPushState  = !!this.options.pushState;
-      this._hasPushState    = !!(this.options.pushState && this.history && this.history.pushState);
+      this._wantsPushState  = !!options.pushState;
+      this._hasPushState    = !!(options.pushState && this.history && this.history.pushState);
       this.fragment         = this.getFragment();
 
       // Add a cross-platform `addEventListener` shim for older browsers.
@@ -1536,7 +1536,7 @@
 
       }
 
-      if (!this.options.silent) return this.loadUrl();
+      if (!options.silent) return this.loadUrl();
     },
 
     // Disable Backbone.history, perhaps temporarily. Not useful in a real app,


### PR DESCRIPTION
Is there ever a time where you'd want to make `Backbone.history`'s `this.options` part of its public interface? In my experience the only time these properties are set is from the options to `history.start`.

The only case I can think of that you might need `this.options` is if you for some reason subclassed `Backbone.History`, but even then, in the vein of #2461, it'd make sense for these to be properties of the instance, not options. (Surprisingly, this change doesn't even break any tests.)

<!--
As an aside, Backbone History is an odd case because although it's almost required to use history as a singleton (you can't have two started Histories on the same page), we've exposed the constructor function for creating new instances like all the other classes. It'd seem to me that the singleton instance should just be a plain object; there should be no need to expose the constructor. 
-->
