### PR TITLE
Specify npm included files explictly in package.json

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,7 +1,0 @@
-test/
-Rakefile
-docs/
-raw/
-examples/
-index.html
-.jshintrc

--- a/index.js
+++ b/index.js
@@ -1,1 +1,0 @@
-module.exports = require('./backbone');

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "docco": "0.6.3",
     "coffee-script": "1.7.1"
   },
+  "main": "backbone.js",
   "scripts": {
     "test": "phantomjs test/vendor/runner.js test/index.html?noglobals=true && coffee test/model.coffee",
     "build": "uglifyjs backbone.js --mangle --source-map backbone-min.map -o backbone-min.js",
@@ -24,5 +25,8 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/jashkenas/backbone.git"
-  }
+  },
+  "files": [
+    "backbone.js", "backbone-min.js", "backbone-min.map", "LICENSE"
+  ]
 }


### PR DESCRIPTION
This just bugged me a little, figured we could save our selves a couple files (and seeing we're currently the 17th most downloaded package, a tiny bit of bandwidth xD)

``` sh
$ ls node_modules/backbone/
backbone.js       bower.json      CONTRIBUTING.md  LICENSE
backbone-min.js   CNAME           favicon.ico      package.json
backbone-min.map  component.json  index.js         README.md
```

I also dropped the `index.js` in favour of a `main` param, useful mainly for browserify
