### PR TITLE
spelling: change "overriden" to "overridden" in two places. #2325 redux.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2443,7 +2443,7 @@ $(function(){
     </p>
 
     <p>
-      The <b>sync</b> function may be overriden globally as <tt>Backbone.sync</tt>,
+      The <b>sync</b> function may be overridden globally as <tt>Backbone.sync</tt>,
       or at a finer-grained level, by adding a <tt>sync</tt> function to a Backbone
       collection or to an individual model.
     </p>
@@ -3070,7 +3070,7 @@ inbox.messages.fetch({reset: true});
       extend and enhance it in the ways you see fit &mdash; the entire source
       code is <a href="docs/backbone.html">annotated</a> to make this easier
       for you. You'll find that there's very little there apart from core
-      functions, and most of those can be overriden or augmented should you find
+      functions, and most of those can be overridden or augmented should you find
       the need. If you catch yourself adding methods to <tt>Backbone.Model.prototype</tt>,
       or creating your own base subclass, don't worry &mdash; that's how things are
       supposed to work.


### PR DESCRIPTION
It looks like this issue was raised and resolved in 2013 (issue #2325), but the misspelling somehow persisted.  "Overridden" is misspelled as "overriden" in two places in index.html; this pull request fixes that.
