### PR TITLE
Fix fetch() to properly handle HTTP 304 "Not Modified"

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -457,8 +457,8 @@
       if (options.parse === void 0) options.parse = true;
       var model = this;
       var success = options.success;
-      options.success = function(resp) {
-        if (!model.set(model.parse(resp, options), options)) return false;
+      options.success = function(resp, status) {
+        if (status !== "notmodified" && !model.set(model.parse(resp, options), options)) return false;
         if (success) success(model, resp, options);
         model.trigger('sync', model, resp, options);
       };
@@ -893,9 +893,11 @@
       if (options.parse === void 0) options.parse = true;
       var success = options.success;
       var collection = this;
-      options.success = function(resp) {
-        var method = options.reset ? 'reset' : 'set';
-        collection[method](resp, options);
+      options.success = function(resp, status) {
+        if (status !== "notmodified") {
+          var method = options.reset ? 'reset' : 'set';
+          collection[method](resp, options);
+        }
         if (success) success(collection, resp, options);
         collection.trigger('sync', collection, resp, options);
       };


### PR DESCRIPTION
jQuery.ajax allows you to pass the option ifModified: true.  Doing this means the server may return an HTTP 304 Not Modified header, and no data; and jQuery.ajax will treat the 304 return as a "success" instead of an "error".  Backbone currently sees this as a success with no data, and empties the collection - not the desired behavior.  This patch checks for this condition in the success() callback, and skips the model/collection set/reset operation.
