### PR TITLE
Remove argument switch/case

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -243,14 +243,8 @@
   // triggering events. Tries to keep the usual cases speedy (most internal
   // Backbone events have 3 arguments).
   var triggerEvents = function(events, args) {
-    var ev, i = -1, l = events.length, a1 = args[0], a2 = args[1], a3 = args[2];
-    switch (args.length) {
-      case 0: while (++i < l) (ev = events[i]).callback.call(ev.ctx); return;
-      case 1: while (++i < l) (ev = events[i]).callback.call(ev.ctx, a1); return;
-      case 2: while (++i < l) (ev = events[i]).callback.call(ev.ctx, a1, a2); return;
-      case 3: while (++i < l) (ev = events[i]).callback.call(ev.ctx, a1, a2, a3); return;
-      default: while (++i < l) (ev = events[i]).callback.apply(ev.ctx, args); return;
-    }
+    var ev, i = -1, l = events.length;
+    while (++i < l) (ev = events[i]).callback.apply(ev.ctx, args);
   };
 
   // Aliases for backwards compatibility.


### PR DESCRIPTION
'function.prototype.apply' will do the same job as the previous 'call' switch/case syntax. If args is length 2, then 2 arguments will be applied. 'apply' is much simpler and marginally faster.
