### PR TITLE
Call the success callback with context

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -464,7 +464,7 @@
       var success = options.success;
       options.success = function(resp) {
         if (!model.set(model.parse(resp, options), options)) return false;
-        if (success) success(model, resp, options);
+        if (success) success.call(options.context, model, resp, options);
         model.trigger('sync', model, resp, options);
       };
       wrapError(this, options);
@@ -514,7 +514,7 @@
         if (_.isObject(serverAttrs) && !model.set(serverAttrs, options)) {
           return false;
         }
-        if (success) success(model, resp, options);
+        if (success) success.call(options.context, model, resp, options);
         model.trigger('sync', model, resp, options);
       };
       wrapError(this, options);
@@ -544,7 +544,7 @@
 
       options.success = function(resp) {
         if (options.wait || model.isNew()) destroy();
-        if (success) success(model, resp, options);
+        if (success) success.call(options.context, model, resp, options);
         if (!model.isNew()) model.trigger('sync', model, resp, options);
       };
 
@@ -901,7 +901,7 @@
       options.success = function(resp) {
         var method = options.reset ? 'reset' : 'set';
         collection[method](resp, options);
-        if (success) success(collection, resp, options);
+        if (success) success.call(options.context, collection, resp, options);
         collection.trigger('sync', collection, resp, options);
       };
       wrapError(this, options);
@@ -919,7 +919,7 @@
       var success = options.success;
       options.success = function(model, resp) {
         if (options.wait) collection.add(model, options);
-        if (success) success(model, resp, options);
+        if (success) success.call(options.context, model, resp, options);
       };
       model.save(null, options);
       return model;
@@ -1271,7 +1271,7 @@
     options.error = function(xhr, textStatus, errorThrown) {
       options.textStatus = textStatus;
       options.errorThrown = errorThrown;
-      if (error) error.apply(this, arguments);
+      if (error) error.call(options.context, xhr, textStatus, errorThrown);
     };
 
     // Make the request, allowing the user to override any Ajax options.
@@ -1726,7 +1726,7 @@
   var wrapError = function(model, options) {
     var error = options.error;
     options.error = function(resp) {
-      if (error) error(model, resp, options);
+      if (error) error.call(options.context, model, resp, options);
       model.trigger('error', model, resp, options);
     };
   };

--- a/test/collection.js
+++ b/test/collection.js
@@ -475,6 +475,21 @@
     collection.fetch();
   });
 
+  test("#3283 - fetch with an error response calls error with context", 1, function () {
+    var collection = new Backbone.Collection();
+    var obj = {};
+    var options = {
+      context: obj,
+      error: function() {
+        equal(this, obj);
+      }
+    };
+    collection.sync = function (method, model, options) {
+      options.error.call(options.context);
+    };
+    collection.fetch(options);
+  });
+
   test("ensure fetch only parses once", 1, function() {
     var collection = new Backbone.Collection;
     var counter = 0;
@@ -811,6 +826,24 @@
     });
     collection.create({id: 1});
     collection.off();
+  });
+
+  test("#3283 - fetch, create calls success with context", 2, function() {
+    var collection = new Backbone.Collection;
+    collection.url = '/test';
+    Backbone.ajax = function(settings) {
+      settings.success.call(settings.context);
+    };
+    var obj = {};
+    var options = {
+      context: obj,
+      success: function() {
+        equal(this, obj);
+      }
+    };
+
+    collection.fetch(options);
+    collection.create({id: 1}, options);
   });
 
   test("#1447 - create with wait adds model.", 1, function() {

--- a/test/model.js
+++ b/test/model.js
@@ -478,6 +478,40 @@
     model.destroy();
   });
 
+  test("#3283 - save, fetch, destroy calls success with context", 3, function () {
+    var model = new Backbone.Model();
+    var obj = {};
+    var options = {
+      context: obj,
+      success: function() {
+        equal(this, obj);
+      }
+    };
+    model.sync = function (method, model, options) {
+      options.success.call(options.context);
+    };
+    model.save({data: 2, id: 1}, options);
+    model.fetch(options);
+    model.destroy(options);
+  });
+
+  test("#3283 - save, fetch, destroy calls error with context", 3, function () {
+    var model = new Backbone.Model();
+    var obj = {};
+    var options = {
+      context: obj,
+      error: function() {
+        equal(this, obj);
+      }
+    };
+    model.sync = function (method, model, options) {
+      options.error.call(options.context);
+    };
+    model.save({data: 2, id: 1}, options);
+    model.fetch(options);
+    model.destroy(options);
+  });
+
   test("save with PATCH", function() {
     doc.clear().set({id: 1, a: 1, b: 2, c: 3, d: 4});
     doc.save();


### PR DESCRIPTION
Fixes https://github.com/jashkenas/backbone/issues/3283. The only niggle is `Model#destroy` when `isNew`, since it doesn't go through the usual ajax process.