### PR TITLE
embed the talk from the conference

### DIFF
--- a/index.html
+++ b/index.html
@@ -639,6 +639,15 @@
       to execute them.
     </p>
 
+    <h3>Learn more in Jeremy Ashkenas' talk</h3>
+    <p>
+      At Backbone Conf 2014, Jeremy walked through the source code of Backbone.js in 
+      about 45 minutes. This talk gives insight into how Backbone works, explains 
+      some of the history of the project, and helps you to better understand some of 
+      the optimizations and decisions that were made over the years.
+    </p>
+    <iframe width="560" height="315" src="//www.youtube.com/embed/k4mBqcRrJ_o" frameborder="0" allowfullscreen></iframe>
+
     <h2 id="upgrading">Upgrading to 1.1</h2>
 
     <p>


### PR DESCRIPTION
This PR links to the [YouTube video by Bocoup](https://www.youtube.com/watch?v=k4mBqcRrJ_o) where Jeremy walks through the source code. I thought this should be in the documentation somewhere.

I had actually started work where this was part of the annotated source, and was inline with the code, even setting start and end times for each embed so you could hear each part explained. I thought that was overkill, but if interested, I'd be happy to submit that as well.

Screenshot:
![screenshot](http://cl.ly/image/2N1P2F3v451G/bb-conf-talk.png)
