### PR TITLE
Make it possible to decode a url containing an encodeURIComponent encode...

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -325,6 +325,13 @@
     strictEqual(router.path, 'c/d/e');
   });
 
+  test("Decode parameters containing non url legal params.", 2, function() {
+    location.replace('http://example.com#decode/a%z/c/d/e');
+    Backbone.history.checkUrl();
+    strictEqual(router.named, 'a%z');
+    strictEqual(router.path, 'c/d/e');
+  });
+
   test("fires event when router doesn't have callback on it", 1, function() {
     router.on("route:noCallback", function(){ ok(true); });
     location.replace('http://example.com#noCallback');


### PR DESCRIPTION
...d % symbol

We've been having problems with params that have been encoded as URI parts with encodeURIComponent. For example:

'http://foo.com/bar/'+encodeURIComponent('foo%/bar')

Somewhere in the router decodeURI is getting called on the URI, then it's throwing a URIError in  _extractParameters when decodeURIComponent is getting called on an already decoded % character.

This patch fixes our app by falling back on regex substitutions of URI separators not already decoded by decodeURI when a URIError is thrown. It is still necessary to perform replacements of characters decodeURI does not catch.

Confusingly, the unit test doesn't seem to call decodeURI on the url with the checkURL call, so I've left decodeURIComponent in place rather than avoiding it completely. It would break other tests to remove it and I'm not confident I know all the code paths that call _extractParameters.

Signed-off-by: Pete Setchell <pete@crittercism.com>