### PR TITLE
Decode unicode escapes without decoding `%25`.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1440,7 +1440,9 @@
       return path === this.root && !this.getSearch();
     },
 
-    // Decode unicode escapes without decoding `%25`.
+    // Unicode characters in `location.pathname` are percent encoded so they're
+    // decoded for comparison. `%25` should not be decoded since it may be part
+    // of an encoded parameter.
     decodeFragment: function(fragment) {
       return decodeURI(fragment.replace(/%25/g, '%2525'));
     },

--- a/backbone.js
+++ b/backbone.js
@@ -1440,6 +1440,11 @@
       return path === this.root && !this.getSearch();
     },
 
+    // Decode unicode escapes without decoding `%25`.
+    decodeFragment: function(fragment) {
+      return decodeURI(fragment.replace(/%25/g, '%2525'));
+    },
+
     // In IE6, the hash fragment and search params are incorrect if the
     // fragment contains `?`.
     getSearch: function() {
@@ -1456,7 +1461,9 @@
 
     // Get the pathname and search params, without the root.
     getPath: function() {
-      var path = decodeURI(this.location.pathname + this.getSearch());
+      var path = this.decodeFragment(
+        this.location.pathname + this.getSearch()
+      );
       var root = this.root.slice(0, -1);
       if (!path.indexOf(root)) path = path.slice(root.length);
       return path.charAt(0) === '/' ? path.slice(1) : path;
@@ -1629,7 +1636,7 @@
       var url = root + fragment;
 
       // Strip the hash and decode for matching.
-      fragment = decodeURI(fragment.replace(pathStripper, ''));
+      fragment = this.decodeFragment(fragment.replace(pathStripper, ''));
 
       if (this.fragment === fragment) return;
       this.fragment = fragment;

--- a/test/router.js
+++ b/test/router.js
@@ -829,6 +829,21 @@
     Backbone.history.start({pushState: true});
   });
 
+  test('unicode pathname with % in a parameter', 1, function() {
+    location.replace('http://example.com/myyjä/foo%20%25%3F%2f%40%25%20bar');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    var Router = Backbone.Router.extend({
+      routes: {
+        'myyjä/:query': function(query) {
+          strictEqual(query, 'foo %?/@% bar');
+        }
+      }
+    });
+    new Router;
+    Backbone.history.start({pushState: true});
+  });
+
   test('newline in route', 1, function() {
     location.replace('http://example.com/stuff%0Anonsense?param=foo%0Abar');
     Backbone.history.stop();


### PR DESCRIPTION
Fixes #3426.

### The Problem

By using `decodeURI` to decode unicode escapes, `%25` is also decoded. When included in a url parameter, this creates an invalid escape sequence and causes `decodeURIComponent` to throw.

*Sidebar: Should invalid sequences cause the router to throw in the first place? What else can it do?*

### The Solution

Double escape `%25` as `%2525` before using `decodeURI`.

### Is this another step down a crazy rabbit hole of URI escaping?

Maybe? I'm pretty happy with the outcome though. I like that we can continue to remove escapes if we come across more problems of this nature. Further, adding it as `History#decodeFragment` means users can customize it to patch things easily when needed.

I'm going to do a bit more research and try to figure out why the browser escapes unicode in the first place. It effectively prevents us from knowing what was escaped by the user and what was escaped by the browser. :confused: