### PR TITLE
Ensure a search test fails when appropriate.

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -775,12 +775,12 @@
     var Router = Backbone.Router.extend({
       routes: {
         path: function(params){
-          strictEqual(params, 'x=y z');
+          strictEqual(params, 'x=y%3Fz');
         }
       }
     });
     var router = new Router;
-    Backbone.history.navigate('path?x=y%20z', true);
+    Backbone.history.navigate('path?x=y%3Fz', true);
   });
 
   test('Navigate to a hash url.', function() {


### PR DESCRIPTION
Since `%20` is decoded by `decodeURI` as well as `decodeURIComponent`, this test was rendered ineffective. Using an escape only decoded by `decodeURIComponent` fixes things up.