### PR TITLE
Fix Outdated Copyright Year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2014 Jeremy Ashkenas, DocumentCloud
+Copyright (c) 2010-2015 Jeremy Ashkenas, DocumentCloud
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
Fix outdated copyright year (update to 2015)
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2015.