### PR TITLE
Update documentation for Backbone.Router

### DIFF
--- a/index.html
+++ b/index.html
@@ -2156,7 +2156,7 @@ var othello = nypl.create({
 
     <p>
       During page load, after your application has finished creating all of its routers,
-      be sure to call <tt>Backbone.history.start()</tt>, or
+      be sure to call <tt>Backbone.history.start()</tt> or
       <tt>Backbone.history.start({pushState: true})</tt> to route the initial URL.
     </p>
 


### PR DESCRIPTION
The old documentation makes it look `Backbone.history.start()` starts listening for new hash changes and you have to call `Backbone.history.start({pushState: true})` to route the current URL too. This does not match the behavior in the code.

I removed the `,` from the Backbone.Router documentation to clarify this.