### PR TITLE
History's root

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1464,7 +1464,7 @@
     // Get the cross-browser normalized URL fragment from the path or hash.
     getFragment: function(fragment) {
       if (fragment == null) {
-        if (this._hasPushState || !this._wantsHashChange) {
+        if (this._usePushState || !this._wantsHashChange) {
           fragment = this.getPath();
         } else {
           fragment = this.getHash();
@@ -1486,7 +1486,8 @@
       this._wantsHashChange = this.options.hashChange !== false;
       this._hasHashChange   = 'onhashchange' in window;
       this._wantsPushState  = !!this.options.pushState;
-      this._hasPushState    = !!(this.options.pushState && this.history && this.history.pushState);
+      this._hasPushState    = !!(this.history && this.history.pushState);
+      this._usePushState    = this._wantsPushState && this._hasPushState;
       this.fragment         = this.getFragment();
 
       // Normalize root to always include a leading slash.
@@ -1514,7 +1515,7 @@
       // Proxy an iframe to handle location events if the browser doesn't
       // support the `hashchange` event, HTML5 history, or the user wants
       // `hashChange` but not `pushState`.
-      if (!this._hasHashChange && this._wantsHashChange && (!this._wantsPushState || !this._hasPushState)) {
+      if (!this._hasHashChange && this._wantsHashChange && !this._usePushState) {
         var iframe = document.createElement('iframe');
         iframe.src = 'javascript:0';
         iframe.style.display = 'none';
@@ -1533,7 +1534,7 @@
 
       // Depending on whether we're using pushState or hashes, and whether
       // 'onhashchange' is supported, determine how we check the URL state.
-      if (this._hasPushState) {
+      if (this._usePushState) {
         addEventListener('popstate', this.checkUrl, false);
       } else if (this._wantsHashChange && this._hasHashChange && !this.iframe) {
         addEventListener('hashchange', this.checkUrl, false);
@@ -1553,7 +1554,7 @@
       };
 
       // Remove window listeners.
-      if (this._hasPushState) {
+      if (this._usePushState) {
         removeEventListener('popstate', this.checkUrl, false);
       } else if (this._wantsHashChange && this._hasHashChange && !this.iframe) {
         removeEventListener('hashchange', this.checkUrl, false);
@@ -1621,7 +1622,7 @@
 
       // Append a trailing slash if needed.
       var root = this.root;
-      if (fragment && this._hasPushState) {
+      if (fragment && this._usePushState) {
         if (root.charAt(root.length - 1) !== '/' && fragment.charAt(0) !== '?') root += '/';
       }
 
@@ -1634,7 +1635,7 @@
       this.fragment = fragment;
 
       // If pushState is available, we use it to set the fragment as a real URL.
-      if (this._hasPushState) {
+      if (this._usePushState) {
         this.history[options.replace ? 'replaceState' : 'pushState']({}, document.title, url);
 
       // If hash changes haven't been explicitly disabled, update the hash

--- a/backbone.js
+++ b/backbone.js
@@ -1433,7 +1433,9 @@
 
     // Are we at the app root?
     atRoot: function() {
-      return this.location.pathname === this.root && !this.getSearch();
+      var path = this.location.pathname;
+      if (this.root.charAt(this.root.length - 1) === '/') path = path.replace(/[^\/]$/, '$&/');
+      return path === this.root && !this.getSearch();
     },
 
     // In IE6, the hash fragment and search params are incorrect if the

--- a/backbone.js
+++ b/backbone.js
@@ -1418,9 +1418,6 @@
   // Cached regex for stripping a leading hash/slash and trailing space.
   var routeStripper = /^[#\/]|\s+$/g;
 
-  // Cached regex for stripping leading and trailing slashes.
-  var rootStripper = /^\/+|\/+$/g;
-
   // Cached regex for stripping urls of hash.
   var pathStripper = /#.*$/;
 
@@ -1491,7 +1488,7 @@
       this.fragment         = this.getFragment();
 
       // Normalize root to always include a leading slash.
-      this.root = (this.root || '/').replace(/^[^\/]/, '/$&');
+      if (this.root.charAt(0) !== '/') this.root = '/' + this.root;
 
       // Transition from hashChange to pushState or vice versa if both are
       // requested.

--- a/backbone.js
+++ b/backbone.js
@@ -1436,8 +1436,7 @@
 
     // Are we at the app root?
     atRoot: function() {
-      var path = this.location.pathname.replace(/[^\/]$/, '$&/');
-      return path === this.root && !this.getSearch();
+      return this.location.pathname === this.root && !this.getSearch();
     },
 
     // In IE6, the hash fragment and search params are incorrect if the
@@ -1457,7 +1456,7 @@
     // Get the pathname and search params, without the root.
     getPath: function() {
       var path = decodeURI(this.location.pathname + this.getSearch());
-      var root = this.root.slice(0, -1);
+      var root = this.root;
       if (!path.indexOf(root)) path = path.slice(root.length);
       return path.charAt(0) === '/' ? path.slice(1) : path;
     },
@@ -1490,8 +1489,8 @@
       this._hasPushState    = !!(this.options.pushState && this.history && this.history.pushState);
       this.fragment         = this.getFragment();
 
-      // Normalize root to always include a leading and trailing slash.
-      this.root = ('/' + this.root + '/').replace(rootStripper, '/');
+      // Normalize root to always include a leading slash.
+      this.root = (this.root || '/').replace(/^[^\/]/, '/$&');
 
       // Transition from hashChange to pushState or vice versa if both are
       // requested.
@@ -1500,8 +1499,7 @@
         // If we've started off with a route from a `pushState`-enabled
         // browser, but we're currently in a browser that doesn't support it...
         if (!this._hasPushState && !this.atRoot()) {
-          var root = this.root.slice(0, -1) || '/';
-          this.location.replace(root + '#' + this.getPath());
+          this.location.replace(this.root + '#' + this.getPath());
           // Return immediately as browser will do redirect to new url
           return true;
 
@@ -1621,11 +1619,12 @@
       // Normalize the fragment.
       fragment = this.getFragment(fragment || '');
 
-      // Don't include a trailing slash on the root.
+      // Append a trailing slash if needed.
       var root = this.root;
-      if (fragment === '' || fragment.charAt(0) === '?') {
-        root = root.slice(0, -1) || '/';
+      if (fragment && this._hasPushState) {
+        if (root.charAt(root.length - 1) !== '/' && fragment.charAt(0) !== '?') root += '/';
       }
+
       var url = root + fragment;
 
       // Strip the hash and decode for matching.

--- a/test/router.js
+++ b/test/router.js
@@ -748,6 +748,21 @@
     Backbone.history.navigate('?x=1');
   });
 
+  test('Trailing slash on root.', 1, function() {
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: {
+        pushState: function(state, title, url){
+          strictEqual(url, '/root/');
+        }
+      }
+    });
+    location.replace('http://example.com/root/path');
+    Backbone.history.start({pushState: true, root: '/root/'});
+    Backbone.history.navigate('');
+  });
+
   test('#2765 - Fragment matching sans query/hash.', 2, function() {
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {

--- a/test/router.js
+++ b/test/router.js
@@ -580,6 +580,23 @@
     });
   });
 
+  test("Transition from pushState to hashChange with trailing slash.", 0, function() {
+    Backbone.history.stop();
+    location.replace('http://example.com/root');
+    location.replace = function() { ok(false); };
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: {
+        pushState: null,
+        replaceState: null
+      }
+    });
+    Backbone.history.start({
+      root: '/root/',
+      pushState: true
+    });
+  });
+
   test("#1695 - hashChange to pushState with search.", 1, function() {
     Backbone.history.stop();
     location.replace('http://example.com/root#x/y?a=b');

--- a/test/router.js
+++ b/test/router.js
@@ -424,7 +424,7 @@
     Backbone.history.stop();
     location.replace('http://example.com/root');
     Backbone.history = _.extend(new Backbone.History, {location: location});
-    Backbone.history.start({hashChange: false, root: '/root/', silent: true});
+    Backbone.history.start({hashChange: false, root: '/root', silent: true});
     strictEqual(Backbone.history.getFragment(), '');
   });
 
@@ -507,7 +507,7 @@
       }
     });
     Backbone.history.start({root: 'root'});
-    strictEqual(Backbone.history.root, '/root/');
+    strictEqual(Backbone.history.root, '/root');
   });
 
   test("Transition from hashChange to pushState.", 1, function() {


### PR DESCRIPTION
This is another take on https://github.com/jashkenas/backbone/issues/2656 to allow an optional trailing `/` for root. Instead of normalizing the root to always include the trailing and the baggage that comes with it (all the `slice`s and having to normalize `location.pathname` to include it), it instead only adds the slash when necessary.

I've kept the following:

```javascript
Backbone.history.start({ root: '/root' });
Backbone.history.navigate('?a=b');
console.log(location.href); `.../root?a=b`
```

But it does not apply when a mandatory trailing slash is added:
```javascript
Backbone.history.start({ root: '/root/' });
Backbone.history.navigate('?a=b');
console.log(location.href); `.../root/?a=b`
```
