### PR TITLE
Fix #3448. Ensure listenToOnce splits event names.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -184,12 +184,19 @@
         for (var event in name) this.listenToOnce(obj, event, name[event]);
         return this;
       }
-      var cb = _.once(function() {
-        this.stopListening(obj, name, cb);
+      if (eventSplitter.test(name)) {
+        var names = name.split(eventSplitter);
+        for (var i = 0, length = names.length; i < length; i++) {
+          this.listenToOnce(obj, names[i], callback);
+        }
+        return this;
+      }
+      var once = _.once(function() {
+        this.stopListening(obj, name, once);
         callback.apply(this, arguments);
       });
-      cb._callback = callback;
-      return this.listenTo(obj, name, cb);
+      once._callback = callback;
+      return this.listenTo(obj, name, once);
     },
 
     // Tell this object to stop listening to either specific events ... or

--- a/test/events.js
+++ b/test/events.js
@@ -541,11 +541,12 @@
   test("#3448 - listenToOnce with space-separated events", 2, function() {
     var one = _.extend({}, Backbone.Events);
     var two = _.extend({}, Backbone.Events);
-    one.listenToOnce(two, 'x y', function() { ok(true); });
-    two.trigger('x');
-    two.trigger('x');
-    two.trigger('y');
-    two.trigger('y');
+    var count = 1;
+    one.listenToOnce(two, 'x y', function(n) { ok(n === count++); });
+    two.trigger('x', 1);
+    two.trigger('x', 1);
+    two.trigger('y', 2);
+    two.trigger('y', 2);
   });
 
 })();

--- a/test/events.js
+++ b/test/events.js
@@ -538,4 +538,14 @@
     equal(obj, obj.stopListening());
   });
 
+  test("#3448 - listenToOnce with space-separated events", 2, function() {
+    var one = _.extend({}, Backbone.Events);
+    var two = _.extend({}, Backbone.Events);
+    one.listenToOnce(two, 'x y', function() { ok(true); });
+    two.trigger('x');
+    two.trigger('x');
+    two.trigger('y');
+    two.trigger('y');
+  });
+
 })();


### PR DESCRIPTION
Calling `listenToOnce('x y', …)` should be functionally equivalent to `listenToOnce('x', …); listenToOnce('y', …)`.

I realize this isn't the most elegant fix, but it works correctly. The difference in argument order for `listenToOnce` makes it hard to implement `eventApi` for both. I'll look into simplifying though.