### PR TITLE
Fix listenTo memory leak

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -137,7 +137,7 @@
       var listeningTo = this._listeningTo;
       if (!listeningTo) return this;
 
-      var listeneeIds = (obj) ? [obj._listenId] : _.keys(listeningTo);
+      var listeneeIds = obj ? [obj._listenId] : _.keys(listeningTo);
       for (var i = 0, length = listeneeIds.length; i < length; i++) {
         var id = listeneeIds[i];
         var listenee = listeningTo[id];
@@ -234,23 +234,18 @@
     return obj;
   };
 
-  // Maps the normalized event callbacks into onceWrappers.
+  // Maps the normalized event callbacks into once wrappers.
   var onceMap = function(name, callback, offer) {
     return eventsApi(function(map, name, callback, offer) {
-      if (callback) map[name] = onceWrap(name, callback, offer);
+      if (callback) {
+        var once = map[name] = _.once(function() {
+          offer(name, once);
+          callback.apply(this, arguments);
+        });
+        once._callback = callback;
+      }
       return map;
     }, {}, name, callback, offer);
-  };
-
-  // Wraps an event callback, using the `offer` function to off the event
-  // once it's been called.
-  var onceWrap = function(name, callback, offer) {
-    var once = _.once(function() {
-      offer(name, once);
-      callback.apply(this, arguments);
-    });
-    once._callback = callback;
-    return once;
   };
 
   // A difficult-to-believe, but optimized internal dispatch function for

--- a/backbone.js
+++ b/backbone.js
@@ -152,12 +152,13 @@
     stopListening: function(obj, name, callback) {
       var listeningTo = this._listeningTo;
       if (!listeningTo || !listenApi(this, 'stopListening', obj, name, callback)) return this;
-      if (obj) listeningTo = _.pick(listeningTo, obj._listenId);
-      for (var id in listeningTo) {
-        var listenee = listeningTo[id];
+      var listeneeIds = (obj) ? [obj._listenId] : _.keys(listeningTo);
+      for (var i = 0, length = listeneeIds.length; i < length; i++) {
+        var listenee = listeningTo[listeneeIds[i]];
+        if (!listenee) continue;
         listenee.obj.off(name, callback, this);
         var events = offApi(listenee.events, name, callback);
-        if (!events) delete this._listeningTo[id];
+        if (!events) delete this._listeningTo[listeneeIds[i]];
       }
       if (_.isEmpty(this._listeningTo)) this._listeningTo = void 0;
       return this;

--- a/backbone.js
+++ b/backbone.js
@@ -109,7 +109,7 @@
     trigger: function(name) {
       if (!this._events) return this;
       var args = slice.call(arguments, 1);
-      eventsApi(triggerApi, this, name, void 0, args);
+      eventsApi(triggerApi, this, name, triggerApi, args);
       return this;
     },
 
@@ -223,8 +223,9 @@
     return _.isEmpty(events) ? void 0 : events;
   };
 
-  var triggerApi = function(obj, name, c, args) {
+  var triggerApi = function(obj, name, sentinel, args) {
     if (obj._events) {
+      if (sentinel !== triggerApi) args = [sentinel].concat(args);
       var events = obj._events[name];
       var allEvents = obj._events.all;
       if (events) triggerEvents(events, args);

--- a/backbone.js
+++ b/backbone.js
@@ -133,7 +133,7 @@
       var listeningTo = this._listeningTo || (this._listeningTo = {});
       listeningTo[id] || (listeningTo[id] = {obj: obj, events: {}});
       obj.on(name, callback, this);
-      listeningTo[id].events = onApi(listeningTo[id].events, name, callback, this);
+      listeningTo[id].events = onApi(listeningTo[id].events, name, callback);
       return this;
     },
 
@@ -150,16 +150,14 @@
     // Tell this object to stop listening to either specific events ... or
     // to every object it's currently listening to.
     stopListening: function(obj, name, callback) {
-      var listeningTo = this._listeningTo, events;
+      var listeningTo = this._listeningTo;
       if (!listeningTo || !listenApi(this, 'stopListening', obj, name, callback)) return this;
-      var remove = !name && !callback;
       if (obj) listeningTo = _.pick(listeningTo, obj._listenId);
       for (var id in listeningTo) {
-        obj = listeningTo[id].obj;
-        events = listeningTo[id].events;
-        obj.off(name, callback, this);
-        if (!remove) events = offApi(events, name, callback, this);
-        if (remove || !events) delete this._listeningTo[id];
+        var listenee = listeningTo[id];
+        listenee.obj.off(name, callback, this);
+        var events = offApi(listenee.events, name, callback);
+        if (!events) delete this._listeningTo[id];
       }
       if (_.isEmpty(this._listeningTo)) this._listeningTo = void 0;
       return this;

--- a/backbone.js
+++ b/backbone.js
@@ -208,7 +208,7 @@
 
       // Bail out if there are no events stored.
       var handlers = events[name];
-      if (!handlers) continue;
+      if (!handlers) break;
 
       // Find any remaining events.
       var remaining = [];

--- a/backbone.js
+++ b/backbone.js
@@ -83,8 +83,8 @@
     on: function(name, callback, context) {
       if (!eventsApi(this, 'on', name, [callback, context]) || !callback) return this;
       this._events || (this._events = {});
-      var events = this._events[name] || (this._events[name] = []);
-      events.push({callback: callback, context: context, ctx: context || this});
+      var events = this._events[name] || [];
+      this._events[name] = events.concat({callback: callback, context: context, ctx: context || this});
       return this;
     },
 

--- a/backbone.js
+++ b/backbone.js
@@ -76,127 +76,110 @@
   //     object.on('expand', function(){ alert('expanded'); });
   //     object.trigger('expand');
   //
-  var Events = Backbone.Events = {
-
-    // Bind an event to a `callback` function. Passing `"all"` will bind
-    // the callback to all events fired.
-    on: function(name, callback, context) {
-      this._events = eventsApi(onApi, this._events || {}, name, callback, context, this);
-      return this;
-    },
-
-    // Bind an event to only be triggered a single time. After the first time
-    // the callback is invoked, it will be removed.
-    once: function(name, callback, context) {
-      name = onceMap(name, callback, _.bind(this.off, this));
-      return this.on(name, callback, context);
-    },
-
-    // Remove one or many callbacks. If `context` is null, removes all
-    // callbacks with that function. If `callback` is null, removes all
-    // callbacks for the event. If `name` is null, removes all bound
-    // callbacks for all events.
-    off: function(name, callback, context) {
-      if (!this._events) return this;
-      this._events = eventsApi(offApi, this._events, name, callback, context);
-
-      var listeners = this._listeners;
-      if (listeners) {
-        var ids = context != null ? [context._listenId] : _.keys(listeners);
-        for (var i = 0, length = ids.length; i < length; i++) {
-          var listener = listeners[ids[i]];
-          if (!listener) break;
-          internalStopListening(listener, this, name, callback);
-        }
-        if (_.isEmpty(listeners)) this._listeners = void 0;
-      }
-      return this;
-    },
-
-    // Trigger one or many events, firing all bound callbacks. Callbacks are
-    // passed the same arguments as `trigger` is, apart from the event name
-    // (unless you're listening on `"all"`, which will cause your callback to
-    // receive the true name of the event as the first argument).
-    trigger: function(name) {
-      if (!this._events) return this;
-      var args = slice.call(arguments, 1);
-
-      // Use `eventsApi` to normalize `name` into the proper event names.
-      eventsApi(triggerApi, this, name, triggerSentinel, args);
-      return this;
-    },
-
-    // Inversion-of-control versions of `on` and `once`. Tell *this* object to
-    // listen to an event in another object ... keeping track of what it's
-    // listening to.
-    listenTo: function(obj, name, callback) {
-      if (!obj) return this;
-      var id = obj._listenId || (obj._listenId = _.uniqueId('l'));
-      var listeningTo = this._listeningTo || (this._listeningTo = {});
-      var listening = listeningTo[id];
-
-      if (!listening) {
-        listening = listeningTo[id] = {obj: obj, events: {}};
-        id = this._listenId || (this._listenId = _.uniqueId('l'));
-        var listeners = obj._listeners || (obj._listeners = {});
-        listeners[id] = this;
-      }
-
-      // Bind callbacks on obj, and keep track of them on listening.
-      obj.on(name, callback, this);
-      listening.events = eventsApi(onApi, listening.events, name, callback);
-      return this;
-    },
-
-    listenToOnce: function(obj, name, callback) {
-      name = onceMap(name, callback, _.bind(this.stopListening, this, obj));
-      return this.listenTo(obj, name, callback);
-    },
-
-    // Tell this object to stop listening to either specific events ... or
-    // to every object it's currently listening to.
-    stopListening: function(obj, name, callback) {
-      if (this._listeningTo) internalStopListening(this, obj, name, callback, true);
-      return this;
-    }
-
-  };
+  var Events = Backbone.Events = {};
 
   // Regular expression used to split event strings.
   var eventSplitter = /\s+/;
 
-  // Implement fancy features of the Events API such as multiple event
-  // names `"change blur"` and jQuery-style event maps `{change: action}`
-  // in terms of the existing API. Consider this just a special purpose
-  // reduce function.
-  var eventsApi = function(api, events, name, callback, context, ctx) {
+  // Iterates over the standard `event, callback` (as well as the fancy multiple
+  // space-separated events `"change blur", callback` and jQuery-style event
+  // maps `{event: callback}`), reducing them by manipulating `events`.
+  // Passes a normalized (single event name and callback), as well as the `context`
+  // and `ctx` arguments to `iteratee`.
+  var eventsApi = function(iteratee, memo, name, callback, context, ctx) {
     var i = 0, names, length;
     if (name && typeof name === 'object') {
       // Handle event maps.
       for (names = _.keys(name), length = names.length; i < length; i++) {
-        events = api(events, names[i], name[names[i]], context, ctx);
+        memo = iteratee(memo, names[i], name[names[i]], context, ctx);
       }
     } else if (name && eventSplitter.test(name)) {
       // Handle space separated event names.
       for (names = name.split(eventSplitter), length = names.length; i < length; i++) {
-        events = api(events, names[i], callback, context, ctx);
+        memo = iteratee(memo, names[i], callback, context, ctx);
       }
     } else {
-      events = api(events, name, callback, context, ctx);
+      memo = iteratee(memo, name, callback, context, ctx);
     }
-    return events;
+    return memo;
   };
 
-  // Handles actually adding the event handler.
+  // Bind an event to a `callback` function. Passing `"all"` will bind
+  // the callback to all events fired.
+  Events.on = function(name, callback, context) {
+    this._events = eventsApi(onApi, this._events || {}, name, callback, context, this);
+    return this;
+  };
+
+  // Inversion-of-control versions of `on`. Tell *this* object to listen to
+  // an event in another object... keeping track of what it's listening to.
+  Events.listenTo =  function(obj, name, callback) {
+    if (!obj) return this;
+    var id = obj._listenId || (obj._listenId = _.uniqueId('l'));
+    var listeningTo = this._listeningTo || (this._listeningTo = {});
+    var listening = listeningTo[id];
+
+    // This object is not listening to any other events on `obj` yet.
+    // Setup the necessary references to track the listening callbacks.
+    if (!listening) {
+      listening = listeningTo[id] = {obj: obj, events: {}};
+      id = this._listenId || (this._listenId = _.uniqueId('l'));
+      var listeners = obj._listeners || (obj._listeners = {});
+      listeners[id] = this;
+    }
+
+    // Bind callbacks on obj, and keep track of them on listening.
+    obj.on(name, callback, this);
+    listening.events = eventsApi(onApi, listening.events, name, callback);
+    return this;
+  };
+
+  // The reducing API that adds a callback to the `events` object.
   var onApi = function(events, name, callback, context, ctx) {
     if (callback) {
-      var handlers = events[name] || [];
-      events[name] = handlers.concat({callback: callback, context: context, ctx: context || ctx});
+      var handlers = events[name] || (events[name] = []);
+      handlers.push({callback: callback, context: context, ctx: context || ctx});
     }
     return events;
   };
 
-  // Handles removing any event handlers that are no longer wanted.
+  // Remove one or many callbacks. If `context` is null, removes all
+  // callbacks with that function. If `callback` is null, removes all
+  // callbacks for the event. If `name` is null, removes all bound
+  // callbacks for all events.
+  Events.off =  function(name, callback, context) {
+    if (!this._events) return this;
+    this._events = eventsApi(offApi, this._events, name, callback, context);
+
+    var listeners = this._listeners;
+    if (listeners) {
+      // Listeners always bind themselves as the context, so if `context`
+      // is passed, narrow down the search to just that listener.
+      var ids = context != null ? [context._listenId] : _.keys(listeners);
+
+      for (var i = 0, length = ids.length; i < length; i++) {
+        var listener = listeners[ids[i]];
+
+        // Bail out if listener isn't listening.
+        if (!listener) break;
+
+        // Tell each listener to stop, without infinitely calling `#off`.
+        internalStopListening(listener, this, name, callback);
+      }
+      if (_.isEmpty(listeners)) this._listeners = void 0;
+    }
+    return this;
+  };
+
+  // Tell this object to stop listening to either specific events ... or
+  // to every object it's currently listening to.
+  Events.stopListening =  function(obj, name, callback) {
+    // Use an internal stopListening, telling it to call off on `obj`.
+    if (this._listeningTo) internalStopListening(this, obj, name, callback, true);
+    return this;
+  };
+
+  // The reducing API that removes a callback from the `events` object.
   var offApi = function(events, name, callback, context) {
     // Remove all callbacks for all events.
     if (!events || !name && !context && !callback) return;
@@ -204,9 +187,9 @@
     var names = name ? [name] : _.keys(events);
     for (var i = 0, length = names.length; i < length; i++) {
       name = names[i];
+      var handlers = events[name];
 
       // Bail out if there are no events stored.
-      var handlers = events[name];
       if (!handlers) break;
 
       // Find any remaining events.
@@ -231,7 +214,7 @@
         delete events[name];
       }
     }
-    return _.isEmpty(events) ? void 0 : events;
+    if (!_.isEmpty(events)) return events;
   };
 
   var internalStopListening = function(listener, obj, name, callback, offEvents) {
@@ -258,27 +241,23 @@
     if (_.isEmpty(listeningTo)) listener._listeningTo = void 0;
   };
 
-  // When triggering with an `{event: value}` object, `value` should be
-  // prepended to the arguments passed onto the event callbacks.
-  var triggerSentinel = {};
+  // Bind an event to only be triggered a single time. After the first time
+  // the callback is invoked, it will be removed.
+  Events.once =  function(name, callback, context) {
+    // Map the event into a `{event: once}` object.
+    var events = onceMap(name, callback, _.bind(this.off, this));
+    return this.on(events, void 0, context);
+  };
 
-  // Handles triggering the appropriate event callbacks.
-  var triggerApi = function(obj, name, sentinel, args) {
-    if (obj._events) {
-      // Prepend `sentinel` onto args when trigger was called with
-      // an object.
-      if (sentinel !== triggerSentinel) args = [sentinel].concat(args);
-
-      var events = obj._events[name];
-      var allEvents = obj._events.all;
-      if (events) triggerEvents(events, args);
-      if (allEvents) triggerEvents(allEvents, [name].concat(args));
-    }
-    return obj;
+  // Inversion-of-control versions of `once`.
+  Events.listenToOnce =  function(obj, name, callback) {
+    // Map the event into a `{event: once}` object.
+    var events = onceMap(name, callback, _.bind(this.stopListening, this, obj));
+    return this.listenTo(obj, events);
   };
 
   // Reduces the event callbacks into a map of `{event: onceWrapper}`.
-  // `offer` is used to unbind the `onceWrapper` after it as been called.
+  // `offer` unbinds the `onceWrapper` after it as been called.
   var onceMap = function(name, callback, offer) {
     return eventsApi(function(map, name, callback, offer) {
       if (callback) {
@@ -290,6 +269,38 @@
       }
       return map;
     }, {}, name, callback, offer);
+  };
+
+  // Trigger one or many events, firing all bound callbacks. Callbacks are
+  // passed the same arguments as `trigger` is, apart from the event name
+  // (unless you're listening on `"all"`, which will cause your callback to
+  // receive the true name of the event as the first argument).
+  Events.trigger =  function(name) {
+    if (!this._events) return this;
+    var args = slice.call(arguments, 1);
+
+    // Pass `triggerSentinel` as "callback" param. If `name` is an object,
+    // it `triggerApi` will be passed the property's value instead.
+    eventsApi(triggerApi, this, name, triggerSentinel, args);
+    return this;
+  };
+
+  // A known sentinel to detect triggering with a `{event: value}` object.
+  var triggerSentinel = {};
+
+  // Handles triggering the appropriate event callbacks.
+  var triggerApi = function(obj, name, sentinel, args) {
+    if (obj._events) {
+      // If `sentinel` is not the trigger sentinel, trigger was called
+      // with a `{event: value}` object, and it is `value`.
+      if (sentinel !== triggerSentinel) args = [sentinel].concat(args);
+
+      var events = obj._events[name];
+      var allEvents = obj._events.all;
+      if (events) triggerEvents(events, args);
+      if (allEvents) triggerEvents(allEvents, [name].concat(args));
+    }
+    return obj;
   };
 
   // A difficult-to-believe, but optimized internal dispatch function for

--- a/backbone.js
+++ b/backbone.js
@@ -158,8 +158,8 @@
         obj = listeningTo[id].obj;
         events = listeningTo[id].events;
         obj.off(name, callback, this);
-        if (!remove) offApi(events, name, callback, this);
-        if (remove || _.isEmpty(events)) delete this._listeningTo[id];
+        if (!remove) events = offApi(events, name, callback, this);
+        if (remove || !events) delete this._listeningTo[id];
       }
       if (_.isEmpty(this._listeningTo)) this._listeningTo = void 0;
       return this;
@@ -269,7 +269,7 @@
           delete events[name];
         }
       }
-      return events;
+      return _.isEmpty(events) ? void 0 : events;
   };
 
   // A difficult-to-believe, but optimized internal dispatch function for

--- a/test/collection.js
+++ b/test/collection.js
@@ -1329,7 +1329,7 @@
         equal(this._byId[model.id], void 0);
         equal(this._byId[model.cid], void 0);
         equal(model.collection, void 0);
-        equal(model._events.all, void 0);
+        equal(model._events, void 0);
       }
 
     });

--- a/test/events.js
+++ b/test/events.js
@@ -341,14 +341,12 @@
   test("callback list is not altered during trigger", 2, function () {
     var counter = 0, obj = _.extend({}, Backbone.Events);
     var incr = function(){ counter++; };
-    obj.on('event', function(){ obj.on('event', incr).on('all', incr); })
-    .trigger('event');
+    var incrOn = function(){ obj.on('event', incr).on('all', incr); };
+    var incrOff = function(){ obj.off('event', incr).off('all', incr); };
+    obj.on('all', incrOn).on('event', incrOn).trigger('event');
     equal(counter, 0, 'bind does not alter callback list');
-    obj.off()
-    .on('event', function(){ obj.off('event', incr).off('all', incr); })
-    .on('event', incr)
-    .on('all', incr)
-    .trigger('event');
+    obj.off().on('all', incrOff).on('event', incrOff)
+    .on('event', incr).on('all', incr).trigger('event');
     equal(counter, 2, 'unbind does not alter callback list');
   });
 

--- a/test/events.js
+++ b/test/events.js
@@ -376,12 +376,14 @@
   test("callback list is not altered during trigger", 2, function () {
     var counter = 0, obj = _.extend({}, Backbone.Events);
     var incr = function(){ counter++; };
-    var incrOn = function(){ obj.on('event', incr).on('all', incr); };
-    var incrOff = function(){ obj.off('event', incr).off('all', incr); };
-    obj.on('all', incrOn).on('event', incrOn).trigger('event');
+    obj.on('event', function(){ obj.on('event', incr).on('all', incr); })
+    .trigger('event');
     equal(counter, 0, 'bind does not alter callback list');
-    obj.off().on('all', incrOff).on('event', incrOff)
-    .on('event', incr).on('all', incr).trigger('event');
+    obj.off()
+    .on('event', function(){ obj.off('event', incr).off('all', incr); })
+    .on('event', incr)
+    .on('all', incr)
+    .trigger('event');
     equal(counter, 2, 'unbind does not alter callback list');
   });
 

--- a/test/events.js
+++ b/test/events.js
@@ -15,33 +15,40 @@
     equal(obj.counter, 5, 'counter should be incremented five times.');
   });
 
-  test("binding and triggering multiple events", 4, function() {
+  test("binding and triggering multiple events", 9, function() {
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
+    var arg = {};
 
-    obj.on('a b c', function() { obj.counter += 1; });
+    obj.on('a b c', function(x) {
+      obj.counter += 1;
+      strictEqual(x, arg);
+    });
 
-    obj.trigger('a');
+    obj.trigger('a', arg);
     equal(obj.counter, 1);
 
-    obj.trigger('a b');
+    obj.trigger('a b', arg);
     equal(obj.counter, 3);
 
-    obj.trigger('c');
+    obj.trigger('c', arg);
     equal(obj.counter, 4);
 
     obj.off('a c');
-    obj.trigger('a b c');
+    obj.trigger('a b c', arg);
     equal(obj.counter, 5);
   });
 
-  test("binding and triggering with event maps", function() {
+  test("binding and triggering with event maps", 14, function() {
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
 
-    var increment = function() {
+    var increment = function(x, y) {
       this.counter += 1;
+      strictEqual(x, arg);
+      strictEqual(y, arg2);
     };
+    var arg = {}, arg2 = {};
 
     obj.on({
       a: increment,
@@ -49,20 +56,20 @@
       c: increment
     }, obj);
 
-    obj.trigger('a');
+    obj.trigger({ a: arg }, arg2);
     equal(obj.counter, 1);
 
-    obj.trigger('a b');
+    obj.trigger({ a: arg, b: arg }, arg2);
     equal(obj.counter, 3);
 
-    obj.trigger('c');
+    obj.trigger({ c: arg }, arg2);
     equal(obj.counter, 4);
 
     obj.off({
       a: increment,
       c: increment
     }, obj);
-    obj.trigger('a b c');
+    obj.trigger({ a: arg, b: arg, c: arg }, arg2);
     equal(obj.counter, 5);
   });
 

--- a/test/events.js
+++ b/test/events.js
@@ -172,7 +172,7 @@
     e.trigger("foo");
   });
 
-  test("stopListening cleans up references", 8, function() {
+  test("stopListening cleans up references", 12, function() {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     var fn = function() {};
@@ -180,18 +180,22 @@
     a.listenTo(b, 'event', fn).stopListening();
     equal(_.size(a._listeningTo), 0);
     equal(_.size(b._events), 1);
+    equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b);
     equal(_.size(a._listeningTo), 0);
     equal(_.size(b._events), 1);
+    equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event');
     equal(_.size(a._listeningTo), 0);
     equal(_.size(b._events), 1);
+    equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event', fn);
     equal(_.size(a._listeningTo), 0);
     equal(_.size(b._events), 1);
+    equal(_.size(b._listeners), 0);
   });
 
-  test("stopListening cleans up references from listenToOnce", 8, function() {
+  test("stopListening cleans up references from listenToOnce", 12, function() {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     var fn = function() {};
@@ -199,15 +203,37 @@
     a.listenToOnce(b, 'event', fn).stopListening();
     equal(_.size(a._listeningTo), 0);
     equal(_.size(b._events), 1);
+    equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b);
     equal(_.size(a._listeningTo), 0);
     equal(_.size(b._events), 1);
+    equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event');
     equal(_.size(a._listeningTo), 0);
     equal(_.size(b._events), 1);
+    equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event', fn);
     equal(_.size(a._listeningTo), 0);
     equal(_.size(b._events), 1);
+    equal(_.size(b._listeners), 0);
+  });
+
+  test("listenTo and off cleaning up references", 6, function() {
+    var a = _.extend({}, Backbone.Events);
+    var b = _.extend({}, Backbone.Events);
+    var fn = function() {};
+    a.listenTo(b, 'event', fn);
+    b.off('event');
+    equal(_.keys(a._listeningTo).length, 0);
+    equal(_.keys(b._listeners).length, 0);
+    a.listenTo(b, 'event', fn);
+    b.off(null, fn);
+    equal(_.keys(a._listeningTo).length, 0);
+    equal(_.keys(b._listeners).length, 0);
+    a.listenTo(b, 'event', fn);
+    b.off(null, null, a);
+    equal(_.keys(a._listeningTo).length, 0);
+    equal(_.keys(b._listeners).length, 0);
   });
 
   test("listenTo and stopListening cleaning up references", 2, function() {

--- a/test/events.js
+++ b/test/events.js
@@ -169,36 +169,38 @@
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     var fn = function() {};
+    b.on('event', fn);
     a.listenTo(b, 'event', fn).stopListening();
     equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 0);
+    equal(_.size(b._events), 1);
     a.listenTo(b, 'event', fn).stopListening(b);
     equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 0);
+    equal(_.size(b._events), 1);
     a.listenTo(b, 'event', fn).stopListening(b, 'event');
     equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 0);
+    equal(_.size(b._events), 1);
     a.listenTo(b, 'event', fn).stopListening(b, 'event', fn);
     equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 0);
+    equal(_.size(b._events), 1);
   });
 
   test("stopListening cleans up references from listenToOnce", 8, function() {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     var fn = function() {};
+    b.on('event', fn);
     a.listenToOnce(b, 'event', fn).stopListening();
     equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 0);
+    equal(_.size(b._events), 1);
     a.listenToOnce(b, 'event', fn).stopListening(b);
     equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 0);
+    equal(_.size(b._events), 1);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event');
     equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 0);
+    equal(_.size(b._events), 1);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event', fn);
     equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 0);
+    equal(_.size(b._events), 1);
   });
 
   test("listenTo and stopListening cleaning up references", 2, function() {


### PR DESCRIPTION
Fixes https://github.com/jashkenas/backbone/issues/3453, and competes with https://github.com/jashkenas/backbone/pull/3049.

I think this aligns more closely with what's currently implemented. :smile:

It also implements `listenApi`, which is `eventsApi` translated to the `listenTo` / `stopListening` method signatures.