### PR TITLE
Ensure listenToOnce without a callback noops

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -191,6 +191,7 @@
         }
         return this;
       }
+      if (!callback) return this;
       var once = _.once(function() {
         this.stopListening(obj, name, once);
         callback.apply(this, arguments);

--- a/test/events.js
+++ b/test/events.js
@@ -521,6 +521,11 @@
     _.extend({}, Backbone.Events).once('event').trigger('event');
   });
 
+  test("listenToOnce without a callback is a noop", 0, function() {
+    var obj = _.extend({}, Backbone.Events);
+    obj.listenToOnce(obj, 'event').trigger('event');
+  });
+
   test("event functions are chainable", function() {
     var obj = _.extend({}, Backbone.Events);
     var obj2 = _.extend({}, Backbone.Events);


### PR DESCRIPTION
This mirrors the test directly above, ensuring `#once` without a callback noops.