### PR TITLE
[ADDED] events object to bind events to model and collection

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -540,6 +540,116 @@
     equal(coll.one, 1);
   });
 
+  test("delegateEvents", 6, function() {
+    var counter1 = 0, counter2 = 0;
+
+    var collection = new Backbone.collection([{id:1, name:'test'}]);
+
+    collection.increment = function(){ counter1++; };
+    collection.on('add', function(){ counter2++; });
+
+    var events = {'add': 'increment'};
+
+    collection.delegateEvents(events);
+    collection.add({id: 2, name: 'second'});
+    equal(counter1, 1);
+    equal(counter2, 1);
+
+    collection.add({id: 3, name: 'third'});
+    equal(counter1, 2);
+    equal(counter2, 2);
+
+    collection.delegateEvents(events);
+    collection.add({id: 4, name: 'fourth'});
+    equal(counter1, 3);
+    equal(counter2, 3);
+  });
+
+  test("delegate", 2, function() {
+    var collection = new Backbone.collection([{id:1, name:'test'}]);
+    collection.delegate('add', function() {
+      ok(true);
+    });
+    collection.delegate('add', function() {
+      ok(true);
+    });
+    collection.add({id: 2, name: 'second'});
+  });
+
+  test("delegateEvents allows functions for callbacks", 3, function() {
+    var collection = new Backbone.collection([{id:1, name:'test'}]);
+    collection.counter = 0;
+
+    var events = {
+      add: function() {
+        this.counter++;
+      }
+    };
+
+    collection.delegateEvents(events);
+    collection.trigger('add');
+    equal(collection.counter, 1);
+
+    collection.trigger('add');
+    equal(collection.counter, 2);
+
+    collection.delegateEvents(events);
+    collection.trigger('add');
+    equal(collection.counter, 3);
+  });
+
+
+  test("delegateEvents ignore undefined methods", 0, function() {
+    var collection = new Backbone.collection([{id:1, name:'test'}]);
+    collection.delegateEvents({'add': 'undefinedMethod'});
+    collection.trigger('add');
+  });
+
+  test("undelegateEvents", 6, function() {
+    var counter1 = 0, counter2 = 0;
+
+    var collection = new Backbone.collection([{id:1, name:'test'}]);
+    collection.increment = function(){ counter1++; };
+    collection.on('add', function(){ counter2++; });
+
+    var events = {'add': 'increment'};
+
+    collection.delegateEvents(events);
+    collection.trigger('add');
+    equal(counter1, 1);
+    equal(counter2, 1);
+
+    collection.undelegateEvents();
+    collection.trigger('add');
+    equal(counter1, 1);
+    equal(counter2, 2);
+
+    collection.delegateEvents(events);
+    collection.trigger('add');
+    equal(counter1, 2);
+    equal(counter2, 3);
+  });
+
+  test("undelegate", 0, function() {
+    var collection = new Backbone.collection([{id:1, name:'test'}]);
+    collection.delegate('add', function() { ok(false); });
+    collection.delegate('remove', function() { ok(false); });
+
+    collection.undelegate('add');
+
+    collection.trigger('remove');
+    collection.trigger('add');
+  });
+
+  test("undelegate with passed handler", 1, function() {
+    var collection = new Backbone.collection([{id:1, name:'test'}]);
+    var listener = function() { ok(false); };
+    collection.delegate('add', listener);
+    collection.delegate('add', function() { ok(true); });
+    collection.undelegate('add', listener);
+    collection.trigger('add');
+  });
+
   test("toJSON", 1, function() {
     equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });

--- a/test/model.js
+++ b/test/model.js
@@ -66,6 +66,116 @@
     equal(model.get('last_name'), 'Unknown');
   });
 
+  test("delegateEvents", 6, function() {
+    var counter1 = 0, counter2 = 0;
+
+    var model = new Backbone.model({id:1, name:'test'});
+
+    model.increment = function(){ counter1++; };
+    model.on('change', function(){ counter2++; });
+
+    var events = {'change:id': 'increment'};
+
+    model.delegateEvents(events);
+    model.set('id', 2)
+    equal(counter1, 1);
+    equal(counter2, 1);
+
+    model.set('id', 3)
+    equal(counter1, 2);
+    equal(counter2, 2);
+
+    model.delegateEvents(events);
+    model.set('id', 4)
+    equal(counter1, 3);
+    equal(counter2, 3);
+  });
+
+  test("delegate", 2, function() {
+    var model = new Backbone.model({id:1, name:'test'});
+    model.delegate('change:id', function() {
+      ok(true);
+    });
+    model.delegate('change', function() {
+      ok(true);
+    });
+    model.set('id', 2)
+  });
+
+  test("delegateEvents allows functions for callbacks", 3, function() {
+    var model = new Backbone.model({id:1, name:'test'});
+    model.counter = 0;
+
+    var events = {
+      change: function() {
+        this.counter++;
+      }
+    };
+
+    model.delegateEvents(events);
+    model.trigger('change')
+    equal(model.counter, 1);
+
+    model.trigger('change')
+    equal(model.counter, 2);
+
+    model.delegateEvents(events);
+    model.trigger('change')
+    equal(model.counter, 3);
+  });
+
+
+  test("delegateEvents ignore undefined methods", 0, function() {
+    var model = new Backbone.model({id:1, name:'test'});
+    model.delegateEvents({'change': 'undefinedMethod'});
+    model.trigger('change')
+  });
+
+  test("undelegateEvents", 6, function() {
+    var counter1 = 0, counter2 = 0;
+
+    var model = new Backbone.model({id:1, name:'test'});
+    model.increment = function(){ counter1++; };
+    model.on('change', function(){ counter2++; });
+
+    var events = {'change:id': 'increment'};
+
+    model.delegateEvents(events);
+    model.trigger('change:id');
+    equal(counter1, 1);
+    equal(counter2, 1);
+
+    model.undelegateEvents();
+    model.trigger('change:id');
+    equal(counter1, 1);
+    equal(counter2, 2);
+
+    model.delegateEvents(events);
+    model.trigger('change:id');
+    equal(counter1, 2);
+    equal(counter2, 3);
+  });
+
+  test("undelegate", 0, function() {
+    var model = new Backbone.model({id:1, name:'test'});
+    model.delegate('change', function() { ok(false); });
+    model.delegate('change:id', function() { ok(false); });
+
+    model.undelegate('change');
+
+    model.trigger('change:id');
+    model.trigger('change');
+  });
+
+  test("undelegate with passed handler", 1, function() {
+    var model = new Backbone.model({id:1, name:'test'});
+    var listener = function() { ok(false); };
+    model.delegate('change', listener);
+    model.delegate('change', function() { ok(true); });
+    model.undelegate('change', listener);
+    model.trigger('change');
+  });
+
   test("parse can return null", 1, function() {
     var Model = Backbone.Model.extend({
       parse: function(attrs) {


### PR DESCRIPTION
This takes a similar approach as a View with its events object that it uses to bind callbacks to specific event types. This pull request brings this functionality to the model and collection as well.