### PR TITLE
Implement Events as a linked list

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -287,10 +287,10 @@
   // `offer` unbinds the `onceWrapper` after it as been called.
   var onceMap = function(map, name, callback, offer) {
     if (callback) {
-      var once = map[name] = _.once(function() {
+      var once = map[name] = function() {
         offer(name, once);
         callback.apply(this, arguments);
-      });
+      };
       once._callback = callback;
     }
     return map;

--- a/backbone.js
+++ b/backbone.js
@@ -138,7 +138,7 @@
   var onApi = function(events, name, callback, context, ctx) {
     if (callback) {
       var list = events[name] || (events[name] = {});
-      var ev = {callback: callback, context: context, ctx: context || ctx, next: false};
+      var ev = {callback: callback, context: context, ctx: context || ctx, next: false, skip: false};
       var tail = list.tail || list;
       list.tail = tail.next = ev;
     }

--- a/backbone.js
+++ b/backbone.js
@@ -146,7 +146,7 @@
   // The reducing API that adds a callback to the `events` object.
   var onApi = function(events, name, callback, context, ctx, listening) {
     if (callback) {
-      var list = events.lists[name] || (events.lists[name] = {name: name, tail: void 0, next: void 0});
+      var list = events.lists[name] || (events.lists[name] = {tail: void 0, next: void 0});
       if (!list.next) events.count++;
       if (listening) listening.count++;
 

--- a/backbone.js
+++ b/backbone.js
@@ -303,7 +303,7 @@
     var args = Array(length);
     for (var i = 0; i < length; i++) args[i] = arguments[i + 1];
 
-    var alreadyTriggering = events.alreadyTriggering;
+    var alreadyTriggering = events.triggering;
     events.triggering = true;
 
     eventsApi(triggerApi, events.lists, name, void 0, args);

--- a/backbone.js
+++ b/backbone.js
@@ -191,7 +191,7 @@
       // listening to obj. Break out early.
       if (!listening) break;
 
-      if (listening.obj) listening.obj.off(name, callback, this);
+      listening.obj.off(name, callback, this);
       if (!listening.count) delete listeningTo[id];
     }
 

--- a/backbone.js
+++ b/backbone.js
@@ -315,11 +315,11 @@
   // Handles triggering the appropriate event callbacks.
   var triggerApi = function(lists, name, cb, args) {
     var list = lists[name];
-    var allList = lists.all;
     if (list) {
       triggerEvents(list, args);
       if (!list.next) delete lists[name];
     }
+    var allList = lists.all;
     if (allList) {
       triggerEvents(allList, [name].concat(args));
       if (!allList.next) delete lists.all;

--- a/backbone.js
+++ b/backbone.js
@@ -246,30 +246,28 @@
   // the callback is invoked, it will be removed.
   Events.once =  function(name, callback, context) {
     // Map the event into a `{event: once}` object.
-    var events = onceMap(name, callback, _.bind(this.off, this));
+    var events = eventsApi(onceMap, {}, name, callback, _.bind(this.off, this));
     return this.on(events, void 0, context);
   };
 
   // Inversion-of-control versions of `once`.
   Events.listenToOnce =  function(obj, name, callback) {
     // Map the event into a `{event: once}` object.
-    var events = onceMap(name, callback, _.bind(this.stopListening, this, obj));
+    var events = eventsApi(onceMap, {}, name, callback, _.bind(this.stopListening, this, obj));
     return this.listenTo(obj, events);
   };
 
   // Reduces the event callbacks into a map of `{event: onceWrapper}`.
   // `offer` unbinds the `onceWrapper` after it as been called.
-  var onceMap = function(name, callback, offer) {
-    return eventsApi(function(map, name, callback, offer) {
-      if (callback) {
-        var once = map[name] = _.once(function() {
-          offer(name, once);
-          callback.apply(this, arguments);
-        });
-        once._callback = callback;
-      }
-      return map;
-    }, {}, name, callback, offer);
+  var onceMap = function(map, name, callback, offer) {
+    if (callback) {
+      var once = map[name] = _.once(function() {
+        offer(name, once);
+        callback.apply(this, arguments);
+      });
+      once._callback = callback;
+    }
+    return map;
   };
 
   // Trigger one or many events, firing all bound callbacks. Callbacks are

--- a/backbone.js
+++ b/backbone.js
@@ -152,7 +152,6 @@
         list = events.lists[name] = {
           count: 0,
           triggering: false,
-          shouldDelete: false,
           tail: void 0,
           next: void 0
         };
@@ -249,11 +248,7 @@
       list.tail = tail;
       if (tail === list) {
         events.count--;
-        if (list.triggering) {
-          list.shouldDelete = true;
-        } else {
-          delete lists[name];
-        }
+        if (!list.triggering) delete lists[name];
       }
     }
     return events;
@@ -311,11 +306,11 @@
       var allList = lists.all;
       if (list) {
         triggerEvents(list, args);
-        if (list.shouldDelete) delete lists[name];
+        if (!list.next) delete lists[name];
       }
       if (allList) {
         triggerEvents(allList, [name].concat(args));
-        if (allList.shouldDelete) delete lists.all;
+        if (!allList.next) delete lists.all;
       }
     }
     return obj;

--- a/backbone.js
+++ b/backbone.js
@@ -87,7 +87,7 @@
   // Passes a normalized single event name and callback, as well as the `context`,
   // `ctx`, and `listening` arguments to `iteratee`.
   var eventsApi = function(iteratee, memo, name, callback, context, ctx, listening) {
-    var i = 0, names, length;
+    var i = 0, names;
     if (name && typeof name === 'object') {
       // Handle event maps.
       for (names = _.keys(name); i < names.length; i++) {
@@ -149,14 +149,9 @@
     if (callback) {
       var list = events.lists[name];
       if (!list) {
-        list = events.lists[name] = {
-          count: 0,
-          triggering: false,
-          tail: void 0,
-          next: void 0
-        };
+        list = events.lists[name] = { count: 0, triggering: false, tail: void 0, next: void 0 };
+        events.count++;
       }
-      if (!list.next) events.count++;
       list.count++;
       if (listening) listening.count++;
 
@@ -192,7 +187,7 @@
 
     var ids = obj ? [obj._listenId] : _.keys(listeningTo);
 
-    for (var i = 0, length = ids.length; i < length; i++) {
+    for (var i = 0; i < ids.length; i++) {
       var id = ids[i];
       var listening = listeningTo[id];
 
@@ -212,12 +207,12 @@
     // Remove all callbacks for all events.
     if (!events || !events.count) return events;
 
-    var i = 0, length, listening;
+    var i = 0, listening;
 
     // Delete all event listeners and "drop" events.
     if (!name && !callback && !context && !events.triggering) {
       var ids = _.keys(listeners);
-      for (length = ids.length; i < length; i++) {
+      for (; i < ids.length; i++) {
         var id = ids[i];
         listening = listeners[id];
         delete listeners[id];

--- a/backbone.js
+++ b/backbone.js
@@ -291,7 +291,7 @@
   // receive the true name of the event as the first argument).
   Events.trigger =  function(name) {
     if (!this._events) return this;
-    
+
     var length = Math.max(0, arguments.length - 1);
     var args = Array(length);
     for (var i = 0; i < length; i++) args[i] = arguments[i + 1];

--- a/backbone.js
+++ b/backbone.js
@@ -147,9 +147,10 @@
   // The reducing API that adds a callback to the `events` object.
   var onApi = function(events, name, callback, context, ctx, listening) {
     if (callback) {
-      var list = events.lists[name] || (events.lists[name] = {tail: void 0, next: void 0});
+      var list = events.lists[name] || (events.lists[name] = {count: 0, tail: void 0, next: void 0});
       if (!list.next) events.count++;
       if (listening) listening.count++;
+      list.count++;
 
       var tail = list.tail || list;
       list.tail = tail.next = {
@@ -222,6 +223,7 @@
         ) {
           tail = ev;
         } else {
+          list.count--;
           var next = tail.next = ev.next;
           if (next) next.prev = tail;
           ev.offed = true;

--- a/backbone.js
+++ b/backbone.js
@@ -214,8 +214,6 @@
       // Find any remaining events.
       var ev = list, tail = list;
       while ((ev = ev.next)) {
-        var listening = ev.listening;
-
         if (
           callback && callback !== ev.callback &&
             callback !== ev.callback._callback ||
@@ -227,9 +225,12 @@
           if (next) next.prev = tail;
           ev.offed = true;
 
-          if (listening && !--listening.count) {
+          var listening = ev.listening;
+          if (listening && --listening.count === 0) {
+            var obj = listening.obj;
             listening.obj = void 0;
             delete listeners[listening.id];
+            ev.context.stopListening(obj);
           }
         }
       }

--- a/backbone.js
+++ b/backbone.js
@@ -306,15 +306,21 @@
   // A difficult-to-believe, but optimized internal dispatch function for
   // triggering events. Tries to keep the usual cases speedy (most internal
   // Backbone events have 3 arguments).
+  var trigger0 = function(cb, ctx) { cb.call(ctx); };
+  var trigger1 = function(cb, ctx, a1) { cb.call(ctx, a1); };
+  var trigger2 = function(cb, ctx, a1, a2) { cb.call(ctx, a1, a2); };
+  var trigger3 = function(cb, ctx, a1, a2, a3) { cb.call(ctx, a1, a2, a3); };
+  var triggerApply = function(cb, ctx, a1, a2, a3, args) { cb.apply(ctx, args); };
   var triggerEvents = function(events, args) {
-    var ev = events, a1 = args[0], a2 = args[1], a3 = args[2];
+    var ev = events, a1 = args[0], a2 = args[1], a3 = args[2], caller;
     switch (args.length) {
-      case 0: while ((ev = ev.next)) ev.callback.call(ev.ctx); return;
-      case 1: while ((ev = ev.next)) ev.callback.call(ev.ctx, a1); return;
-      case 2: while ((ev = ev.next)) ev.callback.call(ev.ctx, a1, a2); return;
-      case 3: while ((ev = ev.next)) ev.callback.call(ev.ctx, a1, a2, a3); return;
-      default: while ((ev = ev.next)) ev.callback.apply(ev.ctx, args); return;
+      case 0: caller = trigger0; break;
+      case 1: caller = trigger1; break;
+      case 2: caller = trigger2; break;
+      case 3: caller = trigger3; break;
+      default: caller = triggerApply; break;
     }
+    while ((ev = ev.next)) caller(ev.callback, ev.ctx, a1, a2, a3, args);
   };
 
   // Proxy Underscore methods to a Backbone class' prototype using a

--- a/backbone.js
+++ b/backbone.js
@@ -134,8 +134,6 @@
     // Setup the necessary references to track the listening callbacks.
     if (!listening) {
       listening = listeningTo[id] = {obj: obj, id: _.uniqueId('l'), count: 0};
-    } else {
-      listening.obj = obj;
     }
 
     // Bind callbacks on obj, and keep track of them on listening.

--- a/backbone.js
+++ b/backbone.js
@@ -308,18 +308,13 @@
   // triggering events. Tries to keep the usual cases speedy (most internal
   // Backbone events have 3 arguments).
   var triggerEvents = function(events, args) {
-    var ev = events, a1 = args[0], a2 = args[1], a3 = args[2], caller;
+    var ev = events, a1 = args[0], a2 = args[1], a3 = args[2];
     switch (args.length) {
-      case 0:
-        while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx); return;
-      case 1:
-        while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx, a1); return;
-      case 2:
-        while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx, a1, a2); return;
-      case 3:
-        while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx, a1, a2, a3); return;
-      default:
-        while ((ev = ev.next)) if (!ev.skip) ev.callback.apply(ev.ctx, args); return;
+      case 0: while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx); return;
+      case 1: while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx, a1); return;
+      case 2: while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx, a1, a2); return;
+      case 3: while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx, a1, a2, a3); return;
+      default: while ((ev = ev.next)) if (!ev.skip) ev.callback.apply(ev.ctx, args); return;
     }
   };
 

--- a/backbone.js
+++ b/backbone.js
@@ -137,8 +137,8 @@
   // The reducing API that adds a callback to the `events` object.
   var onApi = function(events, name, callback, context, ctx) {
     if (callback) {
-      var list = events[name] || (events[name] = {});
-      var ev = {callback: callback, context: context, ctx: context || ctx, next: false, skip: false};
+      var list = events[name] || (events[name] = {tail: void 0, next: void 0});
+      var ev = {callback: callback, context: context, ctx: context || ctx, next: void 0, skip: false};
       var tail = list.tail || list;
       list.tail = tail.next = ev;
     }

--- a/backbone.js
+++ b/backbone.js
@@ -83,9 +83,9 @@
 
   // Iterates over the standard `event, callback` (as well as the fancy multiple
   // space-separated events `"change blur", callback` and jQuery-style event
-  // maps `{event: callback}`), reducing them by manipulating `events`.
-  // Passes a normalized (single event name and callback), as well as the `context`
-  // and `ctx` arguments to `iteratee`.
+  // maps `{event: callback}`), reducing them by manipulating `memo`.
+  // Passes a normalized single event name and callback, as well as the `context`,
+  // `ctx`, and `listening` arguments to `iteratee`.
   var eventsApi = function(iteratee, memo, name, callback, context, ctx, listening) {
     var i = 0, names, length;
     if (name && typeof name === 'object') {
@@ -110,6 +110,8 @@
     return internalOn(this, name, callback, context);
   };
 
+  // An internal use `on` function, used to guard the `listening` argument from
+  // the public API.
   var internalOn = function(obj, name, callback, context, listening) {
     var events = obj._events || {count: 0, lists: {}};
     obj._events = eventsApi(onApi, events, name, callback, context, obj, listening);

--- a/backbone.js
+++ b/backbone.js
@@ -307,21 +307,20 @@
   // A difficult-to-believe, but optimized internal dispatch function for
   // triggering events. Tries to keep the usual cases speedy (most internal
   // Backbone events have 3 arguments).
-  var trigger0 = function(cb, ctx) { cb.call(ctx); };
-  var trigger1 = function(cb, ctx, a1) { cb.call(ctx, a1); };
-  var trigger2 = function(cb, ctx, a1, a2) { cb.call(ctx, a1, a2); };
-  var trigger3 = function(cb, ctx, a1, a2, a3) { cb.call(ctx, a1, a2, a3); };
-  var triggerApply = function(cb, ctx, a1, a2, a3, args) { cb.apply(ctx, args); };
   var triggerEvents = function(events, args) {
     var ev = events, a1 = args[0], a2 = args[1], a3 = args[2], caller;
     switch (args.length) {
-      case 0: caller = trigger0; break;
-      case 1: caller = trigger1; break;
-      case 2: caller = trigger2; break;
-      case 3: caller = trigger3; break;
-      default: caller = triggerApply; break;
+      case 0:
+        while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx); return;
+      case 1:
+        while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx, a1); return;
+      case 2:
+        while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx, a1, a2); return;
+      case 3:
+        while ((ev = ev.next)) if (!ev.skip) ev.callback.call(ev.ctx, a1, a2, a3); return;
+      default:
+        while ((ev = ev.next)) if (!ev.skip) ev.callback.apply(ev.ctx, args); return;
     }
-    while ((ev = ev.next)) if (!ev.skip) caller(ev.callback, ev.ctx, a1, a2, a3, args);
   };
 
   // Proxy Underscore methods to a Backbone class' prototype using a

--- a/backbone.js
+++ b/backbone.js
@@ -200,7 +200,7 @@
       }
 
       // Find any remaining events.
-      var ev = list, tail = ev;
+      var ev = list, tail = list;
       while ((ev = ev.next)) {
         if (
           callback && callback !== ev.callback &&
@@ -215,7 +215,7 @@
       }
 
       // Update tail event if the list has any events.  Otherwise, clean up.
-      if (list.next) {
+      if (tail !== list) {
         list.tail = tail;
       } else {
         delete events[name];

--- a/backbone.js
+++ b/backbone.js
@@ -210,6 +210,7 @@
           tail = ev;
         } else {
           tail.next = ev.next;
+          ev.skip = true;
         }
       }
 
@@ -320,7 +321,7 @@
       case 3: caller = trigger3; break;
       default: caller = triggerApply; break;
     }
-    while ((ev = ev.next)) caller(ev.callback, ev.ctx, a1, a2, a3, args);
+    while ((ev = ev.next)) if (!ev.skip) caller(ev.callback, ev.ctx, a1, a2, a3, args);
   };
 
   // Proxy Underscore methods to a Backbone class' prototype using a

--- a/backbone.js
+++ b/backbone.js
@@ -213,7 +213,7 @@
         }
       }
 
-      // Replace events if there are any remaining.  Otherwise, clean up.
+      // Update tail event if the list has any events.  Otherwise, clean up.
       if (list.next) {
         list.tail = tail;
       } else {

--- a/backbone.js
+++ b/backbone.js
@@ -135,7 +135,8 @@
     // This object is not listening to any other events on `obj` yet.
     // Setup the necessary references to track the listening callbacks.
     if (!listening) {
-      listening = listeningTo[id] = {obj: obj, id: _.uniqueId('l'), count: 0};
+      var thisId = this._listenId || (this._listenId = _.uniqueId('l'));
+      listening = listeningTo[id] = {obj: obj, objId: id, id: thisId, listeningTo: listeningTo, count: 0};
     }
 
     // Bind callbacks on obj, and keep track of them on listening.
@@ -227,10 +228,8 @@
 
           var listening = ev.listening;
           if (listening && --listening.count === 0) {
-            var obj = listening.obj;
-            listening.obj = void 0;
+            delete listening.listeningTo[listening.objId];
             delete listeners[listening.id];
-            ev.context.stopListening(obj);
           }
         }
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -1396,7 +1396,7 @@
         calls.add++;
         equal(model, this._byId[model.id]);
         equal(model, this._byId[model.cid]);
-        equal(model._events.all.length, 1);
+        ok(model._events.all.next);
       },
 
       _removeReference: function(model) {

--- a/test/collection.js
+++ b/test/collection.js
@@ -1396,7 +1396,7 @@
         calls.add++;
         equal(model, this._byId[model.id]);
         equal(model, this._byId[model.cid]);
-        ok(model._events.all.next);
+        equal(model._events.count, 1);
       },
 
       _removeReference: function(model) {
@@ -1405,7 +1405,7 @@
         equal(this._byId[model.id], void 0);
         equal(this._byId[model.cid], void 0);
         equal(model.collection, void 0);
-        equal(model._events, void 0);
+        equal(model._events.count, 0);
       }
 
     });

--- a/test/events.js
+++ b/test/events.js
@@ -366,7 +366,7 @@
     equal(obj.counter, 3, 'counter should have been incremented three times');
   });
 
-  test("callback list never skips a still bound callback", 2, function () {
+  test("callback list never skips a still bound callback", 3, function () {
       var counter = 0, obj = _.extend({}, Backbone.Events);
       var fn = function(){ ok(false, 'linked list should not orphan nodes'); };
       var fnOff = function(){ obj.off('event', fnOff).off('event', fn); };
@@ -379,7 +379,9 @@
       obj.off().on('event', incr).on('event', fnOff).on('event', incr).trigger('event');
       equal(counter, 5, 'trigger with off does skip callbacks');
 
-      obj.off().on('event', fnOff).on('event', fn).trigger('event');
+      fnOff = function() { obj.off('event', fnOff).off('event').on('event', incr); };
+      obj.off().on('event', function() {}).on('event', fnOff).on('event', fn).trigger('event');
+      equal(counter, 6, 'offing does not orphan current trigger list');
   });
 
   test("#1282 - 'all' callback list is retrieved after each event.", 1, function() {

--- a/test/events.js
+++ b/test/events.js
@@ -212,11 +212,15 @@
     equal(_.size(b._listeners), 0);
   });
 
-  test("listenTo and off cleaning up references", 6, function() {
+  test("listenTo and off cleaning up references", 8, function() {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     var fn = function() {};
     var getObj = _.property('obj');
+    a.listenTo(b, 'event', fn);
+    b.off();
+    equal(_.size(a._listeningTo), 0);
+    equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn);
     b.off('event');
     equal(_.size(a._listeningTo), 0);

--- a/test/events.js
+++ b/test/events.js
@@ -366,18 +366,20 @@
     equal(obj.counter, 3, 'counter should have been incremented three times');
   });
 
-  test("callback list is not altered during trigger", 2, function () {
-    var counter = 0, obj = _.extend({}, Backbone.Events);
-    var fn = function(){};
-    var fnOff = function(){ obj.off('event', fn); };
-    var incr = function(){ counter++; };
-    var incrOn = function(){ obj.on('event all', incr); };
+  test("callback list never skips a still bound callback", 3, function () {
+      var counter = 0, obj = _.extend({}, Backbone.Events);
+      var fn = function(){};
+      var fnOff = function(){ obj.off('event', fn); };
+      var incr = function(){ counter++; };
+      var incrOn = function(){ obj.on('event all', incr); };
 
-    obj.on('event', incrOn).trigger('event');
-    equal(counter, 0, 'on does not alter callback list');
+      obj.on('event', incr).on('event', incrOn).on('event', incr).trigger('event');
+      equal(counter, 3, 'trigger with on does not skip callbacks');
 
-    obj.off().on('event', fn).on('event', fnOff).on('event', incr).trigger('event');
-    equal(counter, 1, 'off does not alter callback list');
+      obj.off().on('event', incr).on('event', fn).on('event', fnOff).on('event', incr).trigger('event');
+      equal(counter, 5, 'trigger with off does skip callbacks');
+      obj.off().on('event', incr).on('event', fnOff).on('event', fn).on('event', incr).trigger('event');
+      equal(counter, 7, 'trigger with off does skip callbacks');
   });
 
   test("#1282 - 'all' callback list is retrieved after each event.", 1, function() {

--- a/test/events.js
+++ b/test/events.js
@@ -171,21 +171,21 @@
     var fn = function() {};
     b.on('event', fn);
     a.listenTo(b, 'event', fn).stopListening();
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 1);
-    equal(_.size(b._listeners), 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._events.count, 1);
+    equal(b._listeners.count, 0);
     a.listenTo(b, 'event', fn).stopListening(b);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 1);
-    equal(_.size(b._listeners), 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._events.count, 1);
+    equal(b._listeners.count, 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event');
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 1);
-    equal(_.size(b._listeners), 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._events.count, 1);
+    equal(b._listeners.count, 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event', fn);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 1);
-    equal(_.size(b._listeners), 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._events.count, 1);
+    equal(b._listeners.count, 0);
   });
 
   test("stopListening cleans up references from listenToOnce", 12, function() {
@@ -194,21 +194,21 @@
     var fn = function() {};
     b.on('event', fn);
     a.listenToOnce(b, 'event', fn).stopListening();
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 1);
-    equal(_.size(b._listeners), 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._events.count, 1);
+    equal(b._listeners.count, 0);
     a.listenToOnce(b, 'event', fn).stopListening(b);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 1);
-    equal(_.size(b._listeners), 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._events.count, 1);
+    equal(b._listeners.count, 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event');
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 1);
-    equal(_.size(b._listeners), 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._events.count, 1);
+    equal(b._listeners.count, 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event', fn);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events), 1);
-    equal(_.size(b._listeners), 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._events.count, 1);
+    equal(b._listeners.count, 0);
   });
 
   test("listenTo and off cleaning up references", 6, function() {
@@ -217,16 +217,16 @@
     var fn = function() {};
     a.listenTo(b, 'event', fn);
     b.off('event');
-    equal(_.keys(a._listeningTo).length, 0);
-    equal(_.keys(b._listeners).length, 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._listeners.count, 0);
     a.listenTo(b, 'event', fn);
     b.off(null, fn);
-    equal(_.keys(a._listeningTo).length, 0);
-    equal(_.keys(b._listeners).length, 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._listeners.count, 0);
     a.listenTo(b, 'event', fn);
     b.off(null, null, a);
-    equal(_.keys(a._listeningTo).length, 0);
-    equal(_.keys(b._listeners).length, 0);
+    equal(a._listeningTo.count, 0);
+    equal(b._listeners.count, 0);
   });
 
   test("listenTo and stopListening cleaning up references", 2, function() {
@@ -237,7 +237,7 @@
     a.listenTo(b, 'other', function(){ ok(false); });
     a.stopListening(b, 'other');
     a.stopListening(b, 'all');
-    equal(_.keys(a._listeningTo).length, 0);
+    equal(a._listeningTo.count, 0);
   });
 
   test("listenToOnce without context cleans up references after the event has fired", 2, function() {
@@ -245,7 +245,7 @@
     var b = _.extend({}, Backbone.Events);
     a.listenToOnce(b, 'all', function(){ ok(true); });
     b.trigger('anything');
-    equal(_.keys(a._listeningTo).length, 0);
+    equal(a._listeningTo.count, 0);
   });
 
   test("listenToOnce with event maps cleans up references", 2, function() {
@@ -256,7 +256,7 @@
       two: function() { ok(false); }
     });
     b.trigger('one');
-    equal(_.keys(a._listeningTo).length, 1);
+    equal(a._listeningTo.count, 1);
   });
 
   test("listenToOnce with event maps binds the correct `this`", 1, function() {

--- a/test/events.js
+++ b/test/events.js
@@ -218,15 +218,15 @@
     var getObj = _.property('obj');
     a.listenTo(b, 'event', fn);
     b.off('event');
-    ok(!_.any(a._listeningTo, getObj));
+    equal(_.size(a._listeningTo), 0);
     equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn);
     b.off(null, fn);
-    ok(!_.any(a._listeningTo, getObj));
+    equal(_.size(a._listeningTo), 0);
     equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn);
     b.off(null, null, a);
-    ok(!_.any(a._listeningTo, getObj));
+    equal(_.size(a._listeningTo), 0);
     equal(_.size(b._listeners), 0);
   });
 

--- a/test/events.js
+++ b/test/events.js
@@ -79,7 +79,7 @@
   test("listenTo and stopListening with event maps", 4, function() {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    var cb = function(){ ok(true); };
+    var cb = function(){ console.log('ok'); ok(true); };
     a.listenTo(b, {event: cb});
     b.trigger('event');
     a.listenTo(b, {event2: cb});
@@ -93,7 +93,7 @@
   test("stopListening with omitted args", 2, function () {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    var cb = function () { ok(true); };
+    var cb = function () { console.log('ok'); ok(true); };
     a.listenTo(b, 'event', cb);
     b.on('event', cb);
     a.listenTo(b, 'event2', cb);
@@ -171,21 +171,21 @@
     var fn = function() {};
     b.on('event', fn);
     a.listenTo(b, 'event', fn).stopListening();
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
     equal(b._events.count, 1);
-    equal(b._listeners.count, 0);
+    equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b);
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
     equal(b._events.count, 1);
-    equal(b._listeners.count, 0);
+    equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event');
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
     equal(b._events.count, 1);
-    equal(b._listeners.count, 0);
+    equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event', fn);
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
     equal(b._events.count, 1);
-    equal(b._listeners.count, 0);
+    equal(_.size(b._listeners), 0);
   });
 
   test("stopListening cleans up references from listenToOnce", 12, function() {
@@ -194,39 +194,40 @@
     var fn = function() {};
     b.on('event', fn);
     a.listenToOnce(b, 'event', fn).stopListening();
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
     equal(b._events.count, 1);
-    equal(b._listeners.count, 0);
+    equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b);
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
     equal(b._events.count, 1);
-    equal(b._listeners.count, 0);
+    equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event');
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
     equal(b._events.count, 1);
-    equal(b._listeners.count, 0);
+    equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event', fn);
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
     equal(b._events.count, 1);
-    equal(b._listeners.count, 0);
+    equal(_.size(b._listeners), 0);
   });
 
   test("listenTo and off cleaning up references", 6, function() {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     var fn = function() {};
+    var getObj = _.property('obj');
     a.listenTo(b, 'event', fn);
     b.off('event');
-    equal(a._listeningTo.count, 0);
-    equal(b._listeners.count, 0);
+    ok(!_.any(a._listeningTo, getObj));
+    equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn);
     b.off(null, fn);
-    equal(a._listeningTo.count, 0);
-    equal(b._listeners.count, 0);
+    ok(!_.any(a._listeningTo, getObj));
+    equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn);
     b.off(null, null, a);
-    equal(a._listeningTo.count, 0);
-    equal(b._listeners.count, 0);
+    ok(!_.any(a._listeningTo, getObj));
+    equal(_.size(b._listeners), 0);
   });
 
   test("listenTo and stopListening cleaning up references", 2, function() {
@@ -237,7 +238,7 @@
     a.listenTo(b, 'other', function(){ ok(false); });
     a.stopListening(b, 'other');
     a.stopListening(b, 'all');
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
   });
 
   test("listenToOnce without context cleans up references after the event has fired", 2, function() {
@@ -245,7 +246,7 @@
     var b = _.extend({}, Backbone.Events);
     a.listenToOnce(b, 'all', function(){ ok(true); });
     b.trigger('anything');
-    equal(a._listeningTo.count, 0);
+    equal(_.size(a._listeningTo), 0);
   });
 
   test("listenToOnce with event maps cleans up references", 2, function() {
@@ -256,7 +257,7 @@
       two: function() { ok(false); }
     });
     b.trigger('one');
-    equal(a._listeningTo.count, 1);
+    equal(_.size(a._listeningTo), 1);
   });
 
   test("listenToOnce with event maps binds the correct `this`", 1, function() {

--- a/test/events.js
+++ b/test/events.js
@@ -366,20 +366,20 @@
     equal(obj.counter, 3, 'counter should have been incremented three times');
   });
 
-  test("callback list never skips a still bound callback", 3, function () {
+  test("callback list never skips a still bound callback", 2, function () {
       var counter = 0, obj = _.extend({}, Backbone.Events);
-      var fn = function(){};
-      var fnOff = function(){ obj.off('event', fn); };
+      var fn = function(){ ok(false, 'linked list should not orphan nodes'); };
+      var fnOff = function(){ obj.off('event', fnOff).off('event', fn); };
       var incr = function(){ counter++; };
       var incrOn = function(){ obj.on('event all', incr); };
 
       obj.on('event', incr).on('event', incrOn).on('event', incr).trigger('event');
       equal(counter, 3, 'trigger with on does not skip callbacks');
 
-      obj.off().on('event', incr).on('event', fn).on('event', fnOff).on('event', incr).trigger('event');
+      obj.off().on('event', incr).on('event', fnOff).on('event', incr).trigger('event');
       equal(counter, 5, 'trigger with off does skip callbacks');
-      obj.off().on('event', incr).on('event', fnOff).on('event', fn).on('event', incr).trigger('event');
-      equal(counter, 7, 'trigger with off does skip callbacks');
+
+      obj.off().on('event', fnOff).on('event', fn).trigger('event');
   });
 
   test("#1282 - 'all' callback list is retrieved after each event.", 1, function() {

--- a/test/events.js
+++ b/test/events.js
@@ -172,19 +172,19 @@
     b.on('event', fn);
     a.listenTo(b, 'event', fn).stopListening();
     equal(_.size(a._listeningTo), 0);
-    equal(b._events.count, 1);
+    equal(b._events.lists.event.count, 1);
     equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b);
     equal(_.size(a._listeningTo), 0);
-    equal(b._events.count, 1);
+    equal(b._events.lists.event.count, 1);
     equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event');
     equal(_.size(a._listeningTo), 0);
-    equal(b._events.count, 1);
+    equal(b._events.lists.event.count, 1);
     equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event', fn);
     equal(_.size(a._listeningTo), 0);
-    equal(b._events.count, 1);
+    equal(b._events.lists.event.count, 1);
     equal(_.size(b._listeners), 0);
   });
 
@@ -195,19 +195,19 @@
     b.on('event', fn);
     a.listenToOnce(b, 'event', fn).stopListening();
     equal(_.size(a._listeningTo), 0);
-    equal(b._events.count, 1);
+    equal(b._events.lists.event.count, 1);
     equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b);
     equal(_.size(a._listeningTo), 0);
-    equal(b._events.count, 1);
+    equal(b._events.lists.event.count, 1);
     equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event');
     equal(_.size(a._listeningTo), 0);
-    equal(b._events.count, 1);
+    equal(b._events.lists.event.count, 1);
     equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event', fn);
     equal(_.size(a._listeningTo), 0);
-    equal(b._events.count, 1);
+    equal(b._events.lists.event.count, 1);
     equal(_.size(b._listeners), 0);
   });
 

--- a/test/events.js
+++ b/test/events.js
@@ -80,7 +80,7 @@
   test("listenTo and stopListening with event maps", 4, function() {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    var cb = function(){ console.log('ok'); ok(true); };
+    var cb = function(){ ok(true); };
     a.listenTo(b, {event: cb});
     b.trigger('event');
     a.listenTo(b, {event2: cb});
@@ -94,7 +94,7 @@
   test("stopListening with omitted args", 2, function () {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    var cb = function () { console.log('ok'); ok(true); };
+    var cb = function () { ok(true); };
     a.listenTo(b, 'event', cb);
     b.on('event', cb);
     a.listenTo(b, 'event2', cb);

--- a/test/events.js
+++ b/test/events.js
@@ -66,13 +66,14 @@
     equal(obj.counter, 5);
   });
 
-  test("listenTo and stopListening", 1, function() {
+  test("listenTo and stopListening", 2, function() {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     a.listenTo(b, 'all', function(){ ok(true); });
     b.trigger('anything');
     a.listenTo(b, 'all', function(){ ok(false); });
     a.stopListening();
+    equal(b._events.lists.all, undefined, 'removes event list');
     b.trigger('anything');
   });
 
@@ -291,7 +292,7 @@
     equal(obj.counter, 2);
   });
 
-  test("on, then unbind all functions", 1, function() {
+  test("on, then unbind all functions", 2, function() {
     var obj = { counter: 0 };
     _.extend(obj,Backbone.Events);
     var callback = function() { obj.counter += 1; };
@@ -299,6 +300,7 @@
     obj.trigger('event');
     obj.off('event');
     obj.trigger('event');
+    equal(obj._events.lists.all, undefined, 'removes event list');
     equal(obj.counter, 1, 'counter should have only been incremented once.');
   });
 
@@ -315,7 +317,7 @@
     equal(obj.counterB, 2, 'counterB should have been incremented twice.');
   });
 
-  test("unbind a callback in the midst of it firing", 1, function() {
+  test("unbind a callback in the midst of it firing", 2, function() {
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
     var callback = function() {
@@ -326,6 +328,7 @@
     obj.trigger('event');
     obj.trigger('event');
     obj.trigger('event');
+    equal(obj._events.lists.event, undefined, 'removes event list after trigger');
     equal(obj.counter, 1, 'the callback should have been unbound.');
   });
 

--- a/test/events.js
+++ b/test/events.js
@@ -382,14 +382,14 @@
       var incrOn = function(){ obj.on('event all', incr); };
 
       obj.on('event', incr).on('event', incrOn).on('event', incr).trigger('event');
-      equal(counter, 3, 'trigger with on does not skip callbacks');
+      equal(counter, 4, 'trigger with on does not skip callbacks');
 
       obj.off().on('event', incr).on('event', fnOff).on('event', incr).trigger('event');
-      equal(counter, 5, 'trigger with off does skip callbacks');
+      equal(counter, 6, 'trigger with off does skip callbacks');
 
       fnOff = function() { obj.off('event', fnOff).off('event').on('event', incr); };
       obj.off().on('event', function() {}).on('event', fnOff).on('event', fn).trigger('event');
-      equal(counter, 6, 'offing does not orphan current trigger list');
+      equal(counter, 7, 'offing does not orphan current trigger list');
   });
 
   test("#1282 - 'all' callback list is retrieved after each event.", 1, function() {
@@ -400,7 +400,7 @@
       obj.on('y', incr).on('all', incr);
     })
     .trigger('x y');
-    strictEqual(counter, 2);
+    strictEqual(counter, 3);
   });
 
   test("if no callback is provided, `on` is a noop", 0, function() {


### PR DESCRIPTION
[jsperf](http://jsperf.com/backbone-events-linked-list/18)

Roughly equivalent performance. Using a linked list allows the events to be mutated by trigger, without skipping an event. This is a **breaking change**.

Events used to use a linked list (and switched to an array in #1284). But, it performed [very badly](http://jsperf.com/backbone-events-linked-list/8). I'm fairly certain that was due to [L106](https://github.com/jashkenas/backbone/blob/6c3d3838e10d5a070f0d1f604fb5c99ed34c8c93/backbone.js#L106) recreating the linked list's object every `#on`, and [L138](https://github.com/jashkenas/backbone/blob/6c3d3838e10d5a070f0d1f604fb5c99ed34c8c93/backbone.js#L138) calling `#on` to re-bind callbacks inside `#off`.

This fixes #3466 and closes #3463.