### PR TITLE
Fix #3477. Clarify Model.fetch docs

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -518,9 +518,7 @@
       return _.clone(this._previousAttributes);
     },
 
-    // Fetch the model from the server. If the server's representation of the
-    // model differs from its current attributes, they will be overridden,
-    // triggering a `"change"` event.
+    // Fetch the model from the server. If the models differ the two are merged.
     fetch: function(options) {
       options = options ? _.clone(options) : {};
       if (options.parse === void 0) options.parse = true;

--- a/index.html
+++ b/index.html
@@ -1219,7 +1219,7 @@ alert(JSON.stringify(artist));
     <p id="Model-fetch">
       <b class="header">fetch</b><code>model.fetch([options])</code>
       <br />
-      Resets the model's state from the server by delegating to
+      Merges the model's state with one fetched from the server by delegating to
       <a href="#Sync">Backbone.sync</a>. Returns a
       <a href="http://api.jquery.com/jQuery.ajax/#jqXHR">jqXHR</a>.
       Useful if the model has never


### PR DESCRIPTION
Modified the docs for Model.fetch to describe what happens to attributes set on 
the model but not sent by the server. This should address BUG #3477

Before:
Fetch the model from the server. If the server's representation of the
model differs from its current attributes, they will be overridden,
triggering a `"change"` event.

After:
Fetch the model from the server. If the models differ the two are merged. 
Conflicting attributes are overridden by the server's model, triggering a 
`"change"` event.