### PR TITLE
collection::count()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -848,6 +848,18 @@
       return this.where(attrs, true);
     },
 
+    // Return count of models with matching attributes.
+    count: function (attrs) {
+      var count = 0;
+      this.forEach(function (model) {
+        for (var key in attrs) {
+          if (attrs[key] !== model.get(key)) return;
+        }
+        count++;
+      });
+      return count;
+    },
+
     // Force the collection to re-sort itself. You don't need to call this under
     // normal circumstances, as the set will maintain sort order as each item
     // is added.

--- a/test/collection.js
+++ b/test/collection.js
@@ -547,7 +547,7 @@
     equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });
 
-  test("where and findWhere", 8, function() {
+  test("where, findWhere and count", 14, function() {
     var model = new Backbone.Model({a: 1});
     var coll = new Backbone.Collection([
       model,
@@ -562,6 +562,12 @@
     equal(coll.where({b: 1}).length, 0);
     equal(coll.where({b: 2}).length, 2);
     equal(coll.where({a: 1, b: 2}).length, 1);
+    equal(coll.count({a: 1}), 3);
+    equal(coll.count({a: 2}), 1);
+    equal(coll.count({a: 3}), 1);
+    equal(coll.count({b: 1}), 0);
+    equal(coll.count({b: 2}), 2);
+    equal(coll.count({a: 1, b: 2}), 1);
     equal(coll.findWhere({a: 1}), model);
     equal(coll.findWhere({a: 4}), void 0);
   });


### PR DESCRIPTION
Often we need exactly count of models, not array of them. This method will take less time and memory to do such job. Also it more semantic then `.where({...}).length`