### PR TITLE
model::equal()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -440,6 +440,14 @@
       return _.clone(this._previousAttributes);
     },
 
+    // Returns `true` if all attributes is equal to model attributes
+    equal: function (attrs) {
+      for (var key in attrs) {
+        if (attrs[key] !== this.get(key)) return false;
+      }
+      return true;
+    },
+
     // Fetch the model from the server. If the server's representation of the
     // model differs from its current attributes, they will be overridden,
     // triggering a `"change"` event.
@@ -835,10 +843,7 @@
     where: function(attrs, first) {
       if (_.isEmpty(attrs)) return first ? void 0 : [];
       return this[first ? 'find' : 'filter'](function(model) {
-        for (var key in attrs) {
-          if (attrs[key] !== model.get(key)) return false;
-        }
-        return true;
+        return model.equal(attrs);
       });
     },
 

--- a/test/model.js
+++ b/test/model.js
@@ -351,6 +351,15 @@
     equal(model.get('name'), undefined);
   });
 
+  test("equal", 5, function() {
+    var model = new Backbone.Model({id: 1, name : "Model"});
+      equal(model.equal({}), true);
+      equal(model.equal({id: 1, name: 'Model'}), true);
+      equal(model.equal({id: 1, name: 'model'}), false);
+      equal(model.equal({id: true, name: 'Model'}), false);
+      equal(model.equal({id: 2}), false);
+  });
+
   test("defaults", 4, function() {
     var Defaulted = Backbone.Model.extend({
       defaults: {


### PR DESCRIPTION
Sometimes it's useful to compare model with hash for example in some custom filters like
```javascript
// where (a = 1 and b = 1) or (a = 2 and b = 2)
collection.filter(function (model) {
  return model.equal({a: 1, b: 1}) || model.equal({a: 2, b: 2});
});
```
or when you need to set to attribute like
```javascript
showModelsByQuery: function (query) {
  this.forEach(function (model) {
    model.set('hidden', !model.equal({a: 1, b: 1}));
  });
})
```
You can't do such thing with `.where()` only if you will loop over models twice 