### PR TITLE
Use for-loop, instead of slice

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -277,7 +277,10 @@
   // receive the true name of the event as the first argument).
   Events.trigger =  function(name) {
     if (!this._events) return this;
-    var args = slice.call(arguments, 1);
+    
+    var length = Math.max(0, arguments.length - 1);
+    var args = Array(length);
+    for (var i = 0; i < length; i++) args[i] = arguments[i + 1];
 
     // Pass `triggerSentinel` as "callback" param. If `name` is an object,
     // it `triggerApi` will be passed the property's value instead.


### PR DESCRIPTION
http://jsperf.com/trigger-with-for-loop-vs-slice

One of the optimizations I've found in the linked-list events branch is using a for-loop to grab the trigger arguments. Perf testing `#trigger` on that branch (with slice) against master doesn't tell the whole truth, since this slice call _is_ the performance bottleneck. My linked-list trigger should be roughly ~8% slower than a simple array, but it's a dead heat as long as slice is in there.