### PR TITLE
Customise model cid prefix

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -338,7 +338,7 @@
   var Model = Backbone.Model = function(attributes, options) {
     var attrs = attributes || {};
     options || (options = {});
-    this.cid = _.uniqueId('c');
+    this.cid = _.uniqueId(this.cidPrefix);
     this.attributes = {};
     if (options.collection) this.collection = options.collection;
     if (options.parse) attrs = this.parse(attrs, options) || {};
@@ -360,6 +360,10 @@
     // The default name for the JSON `id` attribute is `"id"`. MongoDB and
     // CouchDB users may want to set this to `"_id"`.
     idAttribute: 'id',
+
+    // The prefix is used to create the client id which is used to identify models locally.
+    // You may want to override this if you're experiencing name clashes with model ids.
+    cidPrefix: 'c',
 
     // Initialize is an empty function by default. Override it with your own
     // initialization logic.

--- a/test/model.js
+++ b/test/model.js
@@ -330,6 +330,31 @@
     equal(model.isNew(), true);
   });
 
+  test("setting an alternative cid prefix", 4, function() {
+    var Model = Backbone.Model.extend({
+      cidPrefix: 'm'
+    });
+    var model = new Model();
+
+    equal(model.cid.charAt(0), 'm');
+
+    model = new Backbone.Model();
+    equal(model.cid.charAt(0), 'c');
+
+    var Collection = Backbone.Collection.extend({
+      model: Model
+    });
+    var collection = new Collection([{id: 'c5'}, {id: 'c6'}, {id: 'c7'}]);
+
+    equal(collection.get('c6').cid.charAt(0), 'm');
+    collection.set([{id: 'c6', value: 'test'}], {
+      merge: true,
+      add: true,
+      remove: false
+    });
+    ok(collection.get('c6').has('value'));
+  });
+
   test("set an empty string", 1, function() {
     var model = new Backbone.Model({name : "Model"});
     model.set({name : ''});


### PR DESCRIPTION
This is a really simple change that will allow users to customise the cid prefix to prevent clashes with backend model ids and resolve issues like https://github.com/jashkenas/backbone/pull/3356 and https://github.com/jashkenas/backbone/issues/2920.

I know that this is an edge case but given the small amount of code change required I hope it won't be a problem.