### PR TITLE
Fix the collection.prototype.modelId method to don't crash when the model property is undefined

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1006,7 +1006,7 @@
 
     // Define how to uniquely identify models in the collection.
     modelId: function (attrs) {
-      return attrs[this.model.prototype.idAttribute || 'id'];
+      return attrs[this.model && this.model.prototype.idAttribute || 'id'];
     },
 
     // Private method to reset all internal state. Called when the collection

--- a/test/collection.js
+++ b/test/collection.js
@@ -1414,6 +1414,13 @@
     equal(StoogeCollection.prototype.modelId({_id: 1}), 1);
   });
 
+  test("modelId with no model in the collection", function() {
+    var StoogeCollection = Backbone.Collection.extend({model: undefined});
+
+    // Default to using `Collection::model::idAttribute`.
+    equal(StoogeCollection.prototype.modelId({id: 1}), 1);
+  });
+
   test('Polymorphic models work with "simple" constructors', function () {
     var A = Backbone.Model.extend();
     var B = Backbone.Model.extend();


### PR DESCRIPTION
Create generic collections where has no model property defined, should not crash on the method `modelId`, it just should search for the default `idAttribute`, and keep working.

Tests included.