### PR TITLE
Added `adds` and `removes` events

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -744,7 +744,10 @@
       var singular = !_.isArray(models);
       models = singular ? [models] : _.clone(models);
       options || (options = {});
-      for (var i = 0, length = models.length; i < length; i++) {
+      // In order to fire removes we're going to rewrite models
+      // as we go and j is going to keep our position. If a model
+      // is invalid and not actually removed, it won't be written.
+      for (var i = 0, length = models.length, j = 0; i < length; i++) {
         var model = models[i] = this.get(models[i]);
         if (!model) continue;
         var id = this.modelId(model.attributes);
@@ -757,7 +760,14 @@
           options.index = index;
           model.trigger('remove', model, this, options);
         }
+        models[j++] = model;
         this._removeReference(model, options);
+      }
+      // We only need to slice if models array should be smaller, which is
+      // caused by some models not actually getting removed.
+      if (models.length !== j) models = models.slice(0, j);
+      if (!options.silent && j > 0) {
+        this.trigger('removes', this, models, options);
       }
       return singular ? models[0] : models;
     },
@@ -852,9 +862,14 @@
       // Unless silenced, it's time to fire all appropriate add/sort events.
       if (!options.silent) {
         var addOpts = at != null ? _.clone(options) : options;
-        for (var i = 0, length = toAdd.length; i < length; i++) {
+        var numToAdd = toAdd.length;
+        for (var i = 0; i < numToAdd; i++) {
           if (at != null) addOpts.index = at + i;
           (model = toAdd[i]).trigger('add', model, this, addOpts);
+        }
+        if (numToAdd > 0) {
+          if (at != null) addOpts.index = at;
+          this.trigger('adds', this, toAdd, addOpts);
         }
         if (sort || orderChanged) this.trigger('sort', this, options);
       }


### PR DESCRIPTION
I'm adding the `adds` and `removes` events which fire an aggregated event with all the added/removed models. This is useful for batch changes that need to be listened for. Without this you'd have to listen to `add` and use debounce to collect all the changes within a certain period of time. This is difficult since you could collect changes with different `at`'s specified and you'll need to keep track of those.

I did change what `remove()` returns. It will only return the models that were actually removed, which could be undefined, if you passed in a singular model that wasn't in the collection. I added a test to back up this new behavior since I didn't see any tests backing up the current way it was working. The docs also weren't clear which way it was supposed to work but since `removes` will only give you the models actually removed, I thought `remove()` should work the same way.