### PR TITLE
Remvoe trigger with object's value prepending

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -279,22 +279,13 @@
     if (!this._events) return this;
     var args = slice.call(arguments, 1);
 
-    // Pass `triggerSentinel` as "callback" param. If `name` is an object,
-    // it `triggerApi` will be passed the property's value instead.
-    eventsApi(triggerApi, this, name, triggerSentinel, args);
+    eventsApi(triggerApi, this, name, void 0, args);
     return this;
   };
 
-  // A known sentinel to detect triggering with a `{event: value}` object.
-  var triggerSentinel = {};
-
   // Handles triggering the appropriate event callbacks.
-  var triggerApi = function(obj, name, sentinel, args) {
+  var triggerApi = function(obj, name, cb, args) {
     if (obj._events) {
-      // If `sentinel` is not the trigger sentinel, trigger was called
-      // with a `{event: value}` object, and it is `value`.
-      if (sentinel !== triggerSentinel) args = [sentinel].concat(args);
-
       var events = obj._events[name];
       var allEvents = obj._events.all;
       if (events) triggerEvents(events, args);

--- a/test/events.js
+++ b/test/events.js
@@ -15,40 +15,33 @@
     equal(obj.counter, 5, 'counter should be incremented five times.');
   });
 
-  test("binding and triggering multiple events", 9, function() {
+  test("binding and triggering multiple events", 4, function() {
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
-    var arg = {};
 
-    obj.on('a b c', function(x) {
-      obj.counter += 1;
-      strictEqual(x, arg);
-    });
+    obj.on('a b c', function() { obj.counter += 1; });
 
-    obj.trigger('a', arg);
+    obj.trigger('a');
     equal(obj.counter, 1);
 
-    obj.trigger('a b', arg);
+    obj.trigger('a b');
     equal(obj.counter, 3);
 
-    obj.trigger('c', arg);
+    obj.trigger('c');
     equal(obj.counter, 4);
 
     obj.off('a c');
-    obj.trigger('a b c', arg);
+    obj.trigger('a b c');
     equal(obj.counter, 5);
   });
 
-  test("binding and triggering with event maps", 14, function() {
+  test("binding and triggering with event maps", function() {
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
 
-    var increment = function(x, y) {
+    var increment = function() {
       this.counter += 1;
-      strictEqual(x, arg);
-      strictEqual(y, arg2);
     };
-    var arg = {}, arg2 = {};
 
     obj.on({
       a: increment,
@@ -56,20 +49,20 @@
       c: increment
     }, obj);
 
-    obj.trigger({ a: arg }, arg2);
+    obj.trigger('a');
     equal(obj.counter, 1);
 
-    obj.trigger({ a: arg, b: arg }, arg2);
+    obj.trigger('a b');
     equal(obj.counter, 3);
 
-    obj.trigger({ c: arg }, arg2);
+    obj.trigger('c');
     equal(obj.counter, 4);
 
     obj.off({
       a: increment,
       c: increment
     }, obj);
-    obj.trigger({ a: arg, b: arg, c: arg }, arg2);
+    obj.trigger('a b c');
     equal(obj.counter, 5);
   });
 


### PR DESCRIPTION
https://github.com/jashkenas/backbone/issues/3460#issuecomment-74762412

Backbone still supports triggering with an object, but the args passed to `#trigger` will not be prepended with the object's value.