### PR TITLE
Fragment Encoding

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1499,7 +1499,7 @@
 
   // Cached regex for detecting invalid percent-encoded octets. Will match any
   // "%" that is not followed by a hexadecimal number.
-  var invalidPercentOctets = /%(?![a-f0-9]{2}|[A-F0-9]{2})/;
+  var invalidPercentOctets = /%(?![a-fA-F0-9]{2})/;
 
   // Detect if fragment needs to be URI encoded.
   var shouldEncode = function(fragment) {

--- a/backbone.js
+++ b/backbone.js
@@ -1442,7 +1442,7 @@
     // Convert a route string into a regular expression, suitable for matching
     // against the current location hash.
     _routeToRegExp: function(route) {
-      route = route.replace(escapeRegExp, '\\$&')
+      route = encodeFragment(route).replace(escapeRegExp, '\\$&')
                    .replace(optionalParam, '(?:$1)?')
                    .replace(namedParam, function(match, optional) {
                      return optional ? match : '([^/?]+)';
@@ -1493,6 +1493,25 @@
   // Cached regex for stripping urls of hash.
   var pathStripper = /#.*$/;
 
+  // Cached regex for detecting any character that is invalid in an encoded URI.
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
+  var invalidURIEncoded = /[^;,/?:@&=+$a-zA-Z0-9-_.!~*'()#%]/;
+
+  // Cached regex for detecting invalid percent-encoded octets. Will match any
+  // "%" that is not followed by a hexadecimal number.
+  var invalidPercentOctets = /%(?![a-f0-9]{2}|[A-F0-9]{2})/;
+
+  // Detect if fragment needs to be URI encoded.
+  var shouldEncode = function(fragment) {
+      return invalidURIEncoded.test(fragment) || invalidPercentOctets.test(fragment);
+  };
+
+  // Normalize a URL fragment into percent-encoding, only if it is not already
+  // percent-encoded.
+  var encodeFragment = function(fragment) {
+      return shouldEncode(fragment) ? encodeURI(fragment) : fragment;
+  };
+
   // Has the history handling already been started?
   History.started = false;
 
@@ -1513,19 +1532,19 @@
     // fragment contains `?`.
     getSearch: function() {
       var match = this.location.href.replace(/#.*/, '').match(/\?.+/);
-      return match ? match[0] : '';
+      return match ? encodeFragment(match[0]) : '';
     },
 
     // Gets the true hash value. Cannot use location.hash directly due to bug
     // in Firefox where location.hash will always be decoded.
     getHash: function(window) {
       var match = (window || this).location.href.match(/#(.*)$/);
-      return match ? match[1] : '';
+      return match ? encodeFragment(match[1]) : '';
     },
 
     // Get the pathname and search params, without the root.
     getPath: function() {
-      var path = decodeURI(this.location.pathname + this.getSearch());
+      var path = encodeFragment(this.location.pathname + this.getSearch());
       var root = this.root.slice(0, -1);
       if (!path.indexOf(root)) path = path.slice(root.length);
       return path.charAt(0) === '/' ? path.slice(1) : path;
@@ -1688,7 +1707,7 @@
       if (!options || options === true) options = {trigger: !!options};
 
       // Normalize the fragment.
-      fragment = this.getFragment(fragment || '');
+      fragment = encodeFragment(this.getFragment(fragment || ''));
 
       // Don't include a trailing slash on the root.
       var root = this.root;
@@ -1698,7 +1717,7 @@
       var url = root + fragment;
 
       // Strip the hash and decode for matching.
-      fragment = decodeURI(fragment.replace(pathStripper, ''));
+      fragment = fragment.replace(pathStripper, '');
 
       if (this.fragment === fragment) return;
       this.fragment = fragment;

--- a/backbone.js
+++ b/backbone.js
@@ -1544,7 +1544,7 @@
 
     // Get the pathname and search params, without the root.
     getPath: function() {
-      var path = encodeFragment(this.location.pathname + this.getSearch());
+      var path = encodeFragment(this.location.pathname) + this.getSearch();
       var root = this.root.slice(0, -1);
       if (!path.indexOf(root)) path = path.slice(root.length);
       return path.charAt(0) === '/' ? path.slice(1) : path;

--- a/backbone.js
+++ b/backbone.js
@@ -1538,8 +1538,8 @@
     // Gets the true hash value. Cannot use location.hash directly due to bug
     // in Firefox where location.hash will always be decoded.
     getHash: function(window) {
-      var match = (window || this).location.href.match(/#(.*)$/);
-      return match ? encodeFragment(match[1]) : '';
+      var match = (window || this).location.href.match(/#.*$/);
+      return match ? encodeFragment(match[0]) : '';
     },
 
     // Get the pathname and search params, without the root.

--- a/test/router.js
+++ b/test/router.js
@@ -829,6 +829,21 @@
     Backbone.history.start({pushState: true});
   });
 
+  test('unicode pathname with % in a parameter', 1, function() {
+    location.replace('http://example.com/myyjä/foo%20%25%3F%2f%40%25%20bar');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    var Router = Backbone.Router.extend({
+      routes: {
+        'myyjä/:query': function(query) {
+          strictEqual(query, 'foo %?/@% bar');
+        }
+      }
+    });
+    new Router;
+    Backbone.history.start({pushState: true});
+  });
+
   test('newline in route', 1, function() {
     location.replace('http://example.com/stuff%0Anonsense?param=foo%0Abar');
     Backbone.history.stop();
@@ -886,7 +901,7 @@
     });
     Backbone.history.start({pushState: true});
     Backbone.history.navigate('shop/search?keyword=short%20dress', true);
-    strictEqual(Backbone.history.fragment, 'shop/search?keyword=short dress');
+    strictEqual(Backbone.history.fragment, 'shop/search?keyword=short%20dress');
   });
 
   test('#3175 - Urls in the params', 1, function() {

--- a/test/router.js
+++ b/test/router.js
@@ -830,7 +830,7 @@
   });
 
   test('unicode pathname with % in a parameter', 1, function() {
-    location.replace('http://example.com/myyjä/foo%20%25%3F%2f%40%25%20bar');
+    location.replace('http://example.com/myyj%C3%A4/foo%20%25%3F%2f%40%25%20bar');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({

--- a/test/router.js
+++ b/test/router.js
@@ -830,7 +830,8 @@
   });
 
   test('unicode pathname with % in a parameter', 1, function() {
-    location.replace('http://example.com/myyj%C3%A4/foo%20%25%3F%2f%40%25%20bar');
+    // Work around a bug in IE6's anchor pathname parsing
+    location.pathname = '/myyj%C3%A4/foo%20%25%3F%2f%40%25%20bar';
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({


### PR DESCRIPTION
This is another take on #3434. Instead of trying to decode the fragments, which leads to weird double decoding issues, we can just maintain them in the encoded state.

How can we do this? Because it's easy to determine if the fragment has been decoded (either from a browser bug, or from the dev who never encoded it) since we can just check for a decoded character. If we find one, we can assume that the fragment has been run through `decodeURI()` and just invert it with `encodeURI()`. Now we can match encoded fragments with encoded routes, and everything works perfectly. Static parts of the route match, because the route is encoded _and_ the fragment is. And params / splats will be mapped through `decodeURIComponent()`, guaranteeing it'll never throw (cause it's encoded!).

However, we can't do the opposite. Say we check to see if there are any decoded characters. If there are, then we treat it as already decoded, if not, we `decodeURI()`. The problem is, we don't know if that will leave the fragment in a state that will throw when we later `decodeURIComponent()`. Thus, we're back at #3434.