### PR TITLE
Fix for issue #3470

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -568,7 +568,7 @@
       options.success = function(resp) {
         // Ensure attributes are restored during synchronous saves.
         model.attributes = attributes;
-        var serverAttrs = model.parse(resp, options);
+        var serverAttrs = options.parse ? model.parse(resp, options) : resp;
         if (wait) serverAttrs = _.extend(attrs || {}, serverAttrs);
         if (_.isObject(serverAttrs) && !model.set(serverAttrs, options)) {
           return false;


### PR DESCRIPTION
Fix for issue #3470. Ensures that parse is not called when save is passed the option {parse:false} is set.