### PR TITLE
Set up sauce test runner

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,22 @@
 language: node_js
 node_js:
-  - '0.10'
-notifications:
-  email: false
-addons:
-  firefox: '31.0'
-install:
-  - sudo apt-get install chromium-browser
-  - npm install -g karma-cli
-  - npm install
-  - npm install karma-firefox-launcher karma-chrome-launcher
+  - "0.10"
 before_install:
-  - export CHROME_BIN=chromium-browser
+  - npm install -g npm
+  - npm install -g karma-cli
+before_script:
+  - npm install karma-sauce-launcher
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
 script:
-  - karma start --browsers Firefox,PhantomJS,Chrome_sandbox
+  - npm test
+  # Karma sauce is limited to running about 5-7 browsers (or it will tiemout) at a time so we just run vendor by vendor here
+  - "karma start karma.conf-sauce.js --browsers FIREFOX_V4,FIREFOX_V11,FIREFOX_V20,FIREFOX_V30,FIREFOX_V35"
+  - "karma start karma.conf-sauce.js --browsers CHROME_V28,CHROME_V35,CHROME_V40,ANDROID_V4.0,ANDROID_V4.3"
+  - "karma start karma.conf-sauce.js --browsers INTERNET_EXPLORER_V9,INTERNET_EXPLORER_V10,INTERNET_EXPLORER_V11"
+  - "karma start karma.conf-sauce.js --browsers SAFARI_V5,SAFARI_V6,SAFARI_V7"
+  - "karma start karma.conf-sauce.js --browsers OPERA_V11,OPERA_V12"
+notifications:
+  email: false
+env:
+  matrix: SAUCE_USERNAME=backbonejs SAUCE_ACCESS_KEY=23af9fb4-f413-42a1-aaec-d22bcaff7ad4

--- a/karma.conf-sauce.js
+++ b/karma.conf-sauce.js
@@ -1,0 +1,86 @@
+var _ = require('underscore');
+
+// Browsers to run on Sauce Labs platforms
+var sauceBrowsers = _.reduce([
+  ['firefox', '35'],
+  ['firefox', '30'],
+  ['firefox', '20'],
+  ['firefox', '11'],
+  ['firefox', '4'],
+
+  ['chrome', '40'],
+  ['chrome', '35'],
+  ['chrome', '28'],
+
+  ['internet explorer', '11', 'Windows 8.1'],
+  ['internet explorer', '10', 'Windows 8'],
+  ['internet explorer', '9', 'Windows 7'],
+  // Currently do not work with Karma.
+  // ['internet explorer', '8', 'Windows 7'],
+  // ['internet explorer', '7', 'Windows XP'],
+  // ['internet explorer', '6', 'Windows XP'],
+
+  ['opera', '12'],
+  ['opera', '11'],
+
+  ['android', '4.3'],
+  ['android', '4.0'],
+
+  ['safari', '8'],
+  ['safari', '6'],
+  ['safari', '7'],
+  ['safari', '5']
+], function(memo, platform) {
+  var label = (platform[0] + '_v' + platform[1]).replace(' ', '_').toUpperCase();
+  memo[label] = _.pick({
+    'base': 'SauceLabs',
+    'browserName': platform[0],
+    'version': platform[1],
+    'platform': platform[2]
+  }, Boolean);
+  return memo;
+}, {});
+
+module.exports = function(config) {
+  if ( !process.env.SAUCE_USERNAME || !process.env.SAUCE_ACCESS_KEY ) {
+    console.log('Sauce environments not set --- Skipping');
+    return process.exit(0);
+  }
+
+  config.set({
+    basePath: '',
+    frameworks: ['qunit'],
+    singleRun: true,
+
+    // list of files / patterns to load in the browser
+        files: [
+        'test/vendor/jquery.js',
+        'test/vendor/json2.js',
+        'test/vendor/underscore.js',
+        'backbone.js',
+        'test/setup/*.js',
+        'test/*.js'
+    ],
+    
+    // test results reporter to use
+    reporters: ['dots', 'saucelabs'],
+    port: 9876,
+    colors: true,
+    logLevel: config.LOG_INFO,
+    sauceLabs: {
+      build: 'TRAVIS #' + process.env.TRAVIS_BUILD_NUMBER + ' (' + process.env.TRAVIS_BUILD_ID + ')',
+      startConnect: true,
+      tunnelIdentifier: process.env.TRAVIS_JOB_NUMBER
+    },
+
+    // TODO(vojta): remove once SauceLabs supports websockets.
+    // This speeds up the capturing a bit, as browsers don't even try to use websocket.
+    transports: ['xhr-polling'],
+    captureTimeout: 120000,
+    customLaunchers: sauceBrowsers
+
+    // Browsers to launch, commented out to prevent karma from starting
+    // too many concurrent browsers and timing sauce out.
+    // browsers: _.keys(sauceBrowsers)
+  });
+};


### PR DESCRIPTION
[![Sauce Test Status](https://saucelabs.com/browser-matrix/backbonejs.svg)](https://saucelabs.com/u/backbonejs)

Work in progress. Same issues as https://github.com/jashkenas/underscore/pull/2059 + the token isn't currently encrypted. I'll regenerate and encrypted it when travis stops being silly

- [ ] run tests on IE6,7,8 (currently unsupported by Karma)
- [ ] clean up the travis file (develop a karma plugin to limit how many browsers they start at a single time, they have no interest in limiting based on IRC chats)

**DO NOT MERGE WITHOUT GREEN LIGHTS**