### PR TITLE
coll.remove only returns models that were removed

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -763,7 +763,10 @@
       var singular = !_.isArray(models);
       models = singular ? [models] : _.clone(models);
       options || (options = {});
-      for (var i = 0; i < models.length; i++) {
+      // We're going to rewrite models as we go and j is going to keep our
+      // position. If a model is invalid and not actually removed, it won't
+      // be rewritten.
+      for (var i = 0, j = 0; i < models.length; i++) {
         var model = models[i] = this.get(models[i]);
         if (!model) continue;
         var id = this.modelId(model.attributes);
@@ -776,8 +779,12 @@
           options.index = index;
           model.trigger('remove', model, this, options);
         }
+        models[j++] = model;
         this._removeReference(model, options);
       }
+      // We only need to slice if models array should be smaller, which is
+      // caused by some models not actually getting removed.
+      if (models.length !== j) models = models.slice(0, j);
       return singular ? models[0] : models;
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -298,9 +298,10 @@
     deepEqual(col.pluck('id'), [1, 2, 3]);
   });
 
-  test("remove", 5, function() {
+  test("remove", 7, function() {
     var removed = null;
     var otherRemoved = null;
+    var result = null;
     col.on('remove', function(model, col, options) {
       removed = model.get('label');
       equal(options.index, 3);
@@ -308,8 +309,12 @@
     otherCol.on('remove', function(model, col, options) {
       otherRemoved = true;
     });
-    col.remove(d);
+    result = col.remove(d);
     equal(removed, 'd');
+    strictEqual(result, d);
+    //if we try to remove d again, it's not going to actually get removed
+    result = col.remove(d);
+    strictEqual(result, undefined);
     equal(col.length, 3);
     equal(col.first(), a);
     equal(otherRemoved, null);


### PR DESCRIPTION
This is taken from #3492.

`coll.remove` will only return the models that were actually removed, which could be undefined, if you passed in a singular model that wasn't in the collection. I added a test to back up this new behavior since I didn't see any tests backing up the current way it was working. The docs also weren't clear which way it was supposed to work but if a model wasn't actually removed it makes sense not to return it.