### PR TITLE
include dom-setup after jquery (and other deps)

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -6,11 +6,11 @@
   <link rel="stylesheet" href="vendor/qunit.css" type="text/css" media="screen">
 </head>
 <body>
-  <script src="setup/dom-setup.js"></script>
   <script src="vendor/json2.js"></script>
   <script src="vendor/jquery.js"></script>
   <script src="vendor/qunit.js"></script>
   <script src="vendor/underscore.js"></script>
+  <script src="setup/dom-setup.js"></script>
   <script src="../backbone.js"></script>
   <script src="setup/environment.js"></script>
   <script src="noconflict.js"></script>


### PR DESCRIPTION
Unit tests cannot run as dom-setup.js requires jquery, but is included before jquery.js