### PR TITLE
explicitly pass options with .call to ensure consistent objects

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -723,7 +723,7 @@
     if (options.model) this.model = options.model;
     if (options.comparator !== void 0) this.comparator = options.comparator;
     this._reset();
-    this.initialize.apply(this, arguments);
+    this.initialize.call(this, models, options);
     if (models) this.reset(models, _.extend({silent: true}, options));
   };
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -1571,4 +1571,23 @@
     deepEqual(collection.pluck('id'), [1, 3, 2]);
   });
 
+  asyncTest("silence override", function() {
+    var C = Backbone.Collection.extend({
+      initialize: function(models, options) {
+        options.silent = false;
+
+        this.on("add", this.onAdd, this);
+
+        Backbone.Collection.prototype.initialize.call(this, models, options);
+      },
+
+      onAdd: function() {
+        equal(this.length, 1);
+
+        start();
+      }
+    });
+
+    var c = new C(["a"]);
+  });
 })();


### PR DESCRIPTION
The rational behind this commit is that the `initialize` method in some situations is unable to override `silent`.

This occurs when the user instantiating a collection does not pass in any options. In this case, the `Collection`
constructor creates an empty object ( https://github.com/jashkenas/backbone/blob/master/backbone.js#L722 ).

Then the user override initialize is called using `.apply` ( https://github.com/jashkenas/backbone/blob/master/backbone.js#L726 )
with `arguments`, then on the next line the `options` object is passed. If the user provided `options` it's all good, because `arguments[1]`
and `options` are the same object. But if they do not provide it, `arguments[1]` is `undefined` and `options` is the new created empty object.