### PR TITLE
Set the pathname explicitly for phantomjs.

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -831,6 +831,7 @@
 
   test('unicode pathname with % in a parameter', 1, function() {
     location.replace('http://example.com/myyjä/foo%20%25%3F%2f%40%25%20bar');
+    location.pathname = '/myyj%C3%A4/foo%20%25%3F%2f%40%25%20bar';
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({


### PR DESCRIPTION
This fixes the test in phantomjs by setting the pathname to what it would be anyway in a browser.