### PR TITLE
Use global jquery if it exists for CommonJS and UMD

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -6,25 +6,25 @@
 //     http://backbonejs.org
 
 (function(root, factory) {
+  var $ = (root.jQuery || root.Zepto || root.ender || root.$);
 
   // Set up Backbone appropriately for the environment. Start with AMD.
   if (typeof define === 'function' && define.amd) {
-    define(['underscore', 'jquery', 'exports'], function(_, $, exports) {
+    define(['underscore', 'jquery', 'exports'], function(_, jQuery, exports) {
       // Export global even in AMD case in case this script is loaded with
       // others that may still expect a global Backbone.
-      root.Backbone = factory(root, exports, _, $);
+      root.Backbone = factory(root, exports, _, jQuery);
     });
 
   // Next for Node.js or CommonJS. jQuery may not be needed as a module.
   } else if (typeof exports !== 'undefined') {
     var _ = require('underscore');
-    factory(root, exports, _);
+    factory(root, exports, _, $);
 
   // Finally, as a browser global.
   } else {
-    root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender || root.$));
+    root.Backbone = factory(root, {}, root._, $);
   }
-
 }(this, function(root, Backbone, _, $) {
 
   // Initial Setup
@@ -277,7 +277,7 @@
   // receive the true name of the event as the first argument).
   Events.trigger =  function(name) {
     if (!this._events) return this;
-    
+
     var length = Math.max(0, arguments.length - 1);
     var args = Array(length);
     for (var i = 0; i < length; i++) args[i] = arguments[i + 1];


### PR DESCRIPTION
Carrying on discussion from #2862, I feel this is the most practical and non-invasive way to support CommonJS and jQuery. jQuery is often loaded via CDN on websites (including those using browserify) or exposed globally for plugin support.

This enables developers using browserify to avoid having to do in many cases (though they would be expected to load jQuery before backbone. They would still be able to select a different version of jQuery for their package ofc by setting BB.$

```
Backbone.$ = global.$ = require('jquery');
```