### PR TITLE
Fixed duplicate models with parsed ids being added multiple times

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -808,7 +808,12 @@
 
         // If a duplicate is found, prevent it from being added and
         // optionally merge it into the existing model.
-        if (existing = this.get(attrs)) {
+        existing = this.get(attrs);
+        if (!existing) {
+          model = this._prepareModel(attrs, options);
+          if (model) existing = this.get(model);
+        }
+        if (existing) {
           if (remove) modelMap[existing.cid] = true;
           if (merge && attrs !== existing) {
             attrs = this._isModel(attrs) ? attrs.attributes : attrs;
@@ -820,7 +825,7 @@
 
         // If this is a new, valid model, push it to the `toAdd` list.
         } else if (add) {
-          model = models[i] = this._prepareModel(attrs, options);
+          models[i] = model;
           if (!model) continue;
           toAdd.push(model);
           this._addReference(model, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -1431,6 +1431,25 @@
     equal(c.models.length, 1);
   });
 
+  test('Do not allow duplicate models (with parsed id) to be `add`ed or `set`', function() {
+    var Stooge = Backbone.Model.extend({
+      idAttribute: '_id',
+      parse: function(a) {
+        var attrs = {};
+        attrs._id = a.__id;
+        return attrs;
+      }
+    });
+    var StoogeCollection = Backbone.Collection.extend({model: Stooge});
+    var c = new StoogeCollection();
+    c.add([{__id: 1}, {__id: 1}], {parse: true});
+    equal(c.length, 1);
+    equal(c.models.length, 1);
+    c.set([{__id: 1}, {__id: 1}], {parse: true});
+    equal(c.length, 1);
+    equal(c.models.length, 1);
+  });
+
   test('#3020: #set with {add: false} should not throw.', 2, function() {
     var collection = new Backbone.Collection;
     collection.set([{id: 1}], {add: false});


### PR DESCRIPTION
Brought up with @akre54 on getter. I think we're waiting for @caseywebdev's input.

Basically the issue is that the attributes are not `parse`d before being sent to `get` so `modelId` doesn't return the right properties. You *could* make `modelId` do the same thing as parse but its not clear you'd have to do that and then you're duplicating functionality that you have to remember to update whenever properties change.