### PR TITLE
change child.__super__ to child.super_

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1803,7 +1803,7 @@
 
     // Set a convenience property in case the parent's prototype is needed
     // later.
-    child.__super__ = parent.prototype;
+    child.super_ = parent.prototype;
 
     return child;
   };


### PR DESCRIPTION
When inheritance structure become more complicated and deep , in  subClass's method we want to call superClass's method , it's  quite long to write the code .

    var app.BaseView = Backbone.View.extend({
        render:function(data){
        // to do
        }
    });

    var app.SlidePanel = app.BaseView.extend({
        render:function(data){
        // call super
        app.BaseView.__super__.render.call(this,data);

        // to do
       }
    })

    var app.CommentSlidePanel = app.SlidePanel.extend({
        render:function(data){
        // call super
        app.SlidePanel.__super__.render.call(this,data);

        // to do
       }
    });