### PR TITLE
Wrap commonjs jQuery require in a try-catch

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -17,8 +17,9 @@
 
   // Next for Node.js or CommonJS. jQuery may not be needed as a module.
   } else if (typeof exports !== 'undefined') {
-    var _ = require('underscore');
-    factory(root, exports, _);
+    var _ = require('underscore'), $;
+    try { $ = require('jquery'); } catch(e) {}
+    factory(root, exports, _, $);
 
   // Finally, as a browser global.
   } else {
@@ -277,7 +278,7 @@
   // receive the true name of the event as the first argument).
   Events.trigger =  function(name) {
     if (!this._events) return this;
-    
+
     var length = Math.max(0, arguments.length - 1);
     var args = Array(length);
     for (var i = 0; i < length; i++) args[i] = arguments[i + 1];


### PR DESCRIPTION
Addresses issues from #3421.

* If your app uses jQuery with AMD or global, or you set `Backbone.$` directly, nothing changes.
* If your app uses jQuery with commonjs, you must specify the dependency in your own app (unchanged). However, we now automatically register `Backbone.$` for you so you can remove the setup line from your code.
* If your app doesn't use jQuery and you're using a commonjs loader like webpack or browserify, you must [tell your build tool to exclude or ignore jQuery](https://github.com/jashkenas/backbone/issues/2997#issuecomment-67675558).
* If your app uses a jQuery mock (like Zepto) with commonjs, you need to aliasify (or use ContextReplacementPlugin if Webpack), or set `Backbone.$` directly.