### PR TITLE
Collection.reset should remove options.at to prevent not sorting

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -893,6 +893,8 @@
       }
       options.previousModels = this.models;
       this._reset();
+      // at is not supported for reset and causes sort not to fire in add
+      if (options.at !== undefined) delete options.at;
       models = this.add(models, _.extend({silent: true}, options));
       if (!options.silent) this.trigger('reset', this, options);
       return models;

--- a/test/collection.js
+++ b/test/collection.js
@@ -1571,4 +1571,14 @@
     deepEqual(collection.pluck('id'), [1, 3, 2]);
   });
 
+  test("#3543 - reset removes at option", 1, function() {
+    var collection = new Backbone.Collection();
+    var collection2 = new Backbone.Collection(null, {comparator: 'id'});
+    collection.on('add remove reset sort', function(coll, opts) {
+      collection2.reset(coll.models, opts);
+    });
+    collection.add([{id: 2}, {id: 3}, {id: 1}], {at: 0});
+    equal(collection2.pluck('id').join(','), "1,2,3");
+  });
+
 })();


### PR DESCRIPTION
Collection.add doesn't sort if you pass options.at but if that somehow gets passed to Collection.reset it passes that along to add which then doesn't sort the collection. options.at in reset is essentially useless
since the collection is emptied before adding.

See failing test for use case. Basically trying to keep 2 collections in sync by listening for `add remove reset sort` and then updating another collection while passing through options (since those might be helpful to things listening on other collection) inadvertently might pass through `options.at` which then causes second collection not to be sorted. 