### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     (_'_______________________________________________________________________________'_)
     (_.———————————————————————————————————————————————————————————————————————————————._)
 
+[![NPM version][npm-image]][npm-url] [![Build status][travis-image]][travis-url]
 
 Backbone supplies structure to JavaScript-heavy applications by providing models with key-value binding and custom events, collections with a rich API of enumerable functions, views with declarative event handling, and connects it all to your existing application over a RESTful JSON interface.
 
@@ -27,3 +28,8 @@ https://github.com/jashkenas/backbone/graphs/contributors
 
 Special thanks to Robert Kieffer for the original philosophy behind Backbone.
 https://github.com/broofa
+
+[travis-url]: http://travis-ci.org/jashkenas/backbone
+[travis-image]: https://img.shields.io/travis/jashkenas/backbone.png
+[npm-url]: https://npmjs.org/package/backbone
+[npm-image]: https://img.shields.io/npm/v/backbone.svg

--- a/README.md
+++ b/README.md
@@ -15,19 +15,19 @@
 Backbone supplies structure to JavaScript-heavy applications by providing models with key-value binding and custom events, collections with a rich API of enumerable functions, views with declarative event handling, and connects it all to your existing application over a RESTful JSON interface.
 
 For Docs, License, Tests, pre-packed downloads, and everything else, really, see:
-http://backbonejs.org
+[http://backbonejs.org](http://backbonejs.org)
 
 To suggest a feature, report a bug, or general discussion:
-https://github.com/jashkenas/backbone/issues
+[https://github.com/jashkenas/backbone/issues](https://github.com/jashkenas/backbone/issues)
 
 Backbone is an open-sourced component of DocumentCloud:
-https://github.com/documentcloud
+[https://github.com/documentcloud](https://github.com/documentcloud)
 
 Many thanks to our contributors:
-https://github.com/jashkenas/backbone/graphs/contributors
+[https://github.com/jashkenas/backbone/graphs/contributors](https://github.com/jashkenas/backbone/graphs/contributors)
 
 Special thanks to Robert Kieffer for the original philosophy behind Backbone.
-https://github.com/broofa
+[https://github.com/broofa](https://github.com/broofa)
 
 [travis-url]: http://travis-ci.org/jashkenas/backbone
 [travis-image]: https://img.shields.io/travis/jashkenas/backbone.png


### PR DESCRIPTION
I'm aware of https://github.com/jashkenas/backbone/pull/1876#issuecomment-11148492, but reading the README on [npmjs.com](https://www.npmjs.com/package/backbone) is pretty normal now, I'd think.

I added an npm badge as well. It's an easy way to identify latest release.

Also made the links into actual clickable links. It works fine here on GitHub, but npmjs.com doesn't automatically create links.

If it's accepted, I could do the same for underscore.

EDIT: According to [this](http://daringfireball.net/projects/markdown/syntax#autolink) adding `<>` to the links should be enough, I'm not sure though. Anybody knows?