### PR TITLE
Always call success async

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -639,18 +639,18 @@
       };
 
       options.success = function(resp) {
-        if (wait || model.isNew()) destroy();
+        if (wait) destroy();
         if (success) success.call(options.context, model, resp, options);
         if (!model.isNew()) model.trigger('sync', model, resp, options);
       };
 
+      var xhr = false;
       if (this.isNew()) {
-        options.success();
-        return false;
+        _.defer(options.success);
+      } else {
+        wrapError(this, options);
+        xhr = this.sync('delete', this, options);
       }
-      wrapError(this, options);
-
-      var xhr = this.sync('delete', this, options);
       if (!wait) destroy();
       return xhr;
     },

--- a/test/model.js
+++ b/test/model.js
@@ -1131,11 +1131,14 @@
     model.destroy();
   });
 
-  test("#1365 - Destroy: New models execute success callback.", 2, function() {
+  asyncTest("#1365 - Destroy: New models execute success callback.", 2, function() {
     new Backbone.Model()
     .on('sync', function() { ok(false); })
     .on('destroy', function(){ ok(true); })
-    .destroy({ success: function(){ ok(true); }});
+    .destroy({ success: function(){
+        ok(true);
+        start();
+    }});
   });
 
   test("#1433 - Save: An invalid model cannot be persisted.", 1, function() {


### PR DESCRIPTION
Since the `success` callback is called async when `model` isn't new, we should always call `success` async.

Let's not [unleash Zalgo](http://blog.izs.me/post/59142742143/designing-apis-for-asynchrony).