### PR TITLE
If the root doesn't match, no routes can match.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1529,7 +1529,9 @@
 
     // Does the pathname match the root?
     matchRoot: function() {
-      return this.rootMatcher.test(this.location.pathname);
+      var path = this.decodeFragment(this.location.pathname);
+      var root = path.slice(0, this.root.length - 1) + '/';
+      return root === this.root;
     },
 
     // Unicode characters in `location.pathname` are percent encoded so they're
@@ -1593,11 +1595,6 @@
 
       // Normalize root to always include a leading and trailing slash.
       this.root = ('/' + this.root + '/').replace(rootStripper, '/');
-
-      // A regular expression for testing the pathname against the root.
-      this.rootMatcher = new RegExp(
-        '^' + this.root.slice(0, -1).replace(escapeRegExp, '\\$&') + '(/|$)'
-      );
 
       // Transition from hashChange to pushState or vice versa if both are
       // requested.

--- a/backbone.js
+++ b/backbone.js
@@ -1595,7 +1595,9 @@
       this.root = ('/' + this.root + '/').replace(rootStripper, '/');
 
       // A regular expression for testing the pathname against the root.
-      this.rootMatcher = new RegExp('^' + this.root.slice(0, -1) + '(/|$)');
+      this.rootMatcher = new RegExp(
+        '^' + this.root.slice(0, -1).replace(escapeRegExp, '\\$&') + '(/|$)'
+      );
 
       // Transition from hashChange to pushState or vice versa if both are
       // requested.

--- a/backbone.js
+++ b/backbone.js
@@ -1527,6 +1527,11 @@
       return path === this.root && !this.getSearch();
     },
 
+    // Does the pathname match the root?
+    matchRoot: function() {
+      return this.rootMatcher.test(this.location.pathname);
+    },
+
     // Unicode characters in `location.pathname` are percent encoded so they're
     // decoded for comparison. `%25` should not be decoded since it may be part
     // of an encoded parameter.
@@ -1552,9 +1557,7 @@
     getPath: function() {
       var path = this.decodeFragment(
         this.location.pathname + this.getSearch()
-      );
-      var root = this.root.slice(0, -1);
-      if (!path.indexOf(root)) path = path.slice(root.length);
+      ).slice(this.root.length - 1);
       return path.charAt(0) === '/' ? path.slice(1) : path;
     },
 
@@ -1590,6 +1593,9 @@
 
       // Normalize root to always include a leading and trailing slash.
       this.root = ('/' + this.root + '/').replace(rootStripper, '/');
+
+      // A regular expression for testing the pathname against the root.
+      this.rootMatcher = new RegExp('^' + this.root.slice(0, -1) + '(/|$)');
 
       // Transition from hashChange to pushState or vice versa if both are
       // requested.
@@ -1696,6 +1702,8 @@
     // match, returns `true`. If no defined routes matches the fragment,
     // returns `false`.
     loadUrl: function(fragment) {
+      // If the root doesn't match, no routes can match either.
+      if (!this.matchRoot()) return false;
       fragment = this.fragment = this.getFragment(fragment);
       return _.any(this.handlers, function(handler) {
         if (handler.route.test(fragment)) {

--- a/test/router.js
+++ b/test/router.js
@@ -932,7 +932,7 @@
     Backbone.history.start({root: '/root', pushState: true});
   });
 
-  test("Paths that don't match the root should not match", 0, function() {
+  test("Paths that don't match the root should not match no root", 0, function() {
     location.replace('http://example.com/foo');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
@@ -944,7 +944,7 @@
     Backbone.history.start({root: 'root', pushState: true});
   });
 
-  test("Paths that don't match the root should not match", 0, function() {
+  test("Paths that don't match the root should not match roots of the same length", 0, function() {
     location.replace('http://example.com/xxxx/foo');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});

--- a/test/router.js
+++ b/test/router.js
@@ -968,4 +968,28 @@
     Backbone.history.start({root: 'x+y.z', pushState: true});
   });
 
+  test("roots with unicode characters", 1, function() {
+    location.replace('http://example.com/®ooτ/foo');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    var Router = Backbone.Router.extend({
+      routes: {'foo': 'foo'},
+      foo: function(){ ok(true); }
+    });
+    var router = new Router;
+    Backbone.history.start({root: '®ooτ', pushState: true});
+  });
+
+  test("roots without slash", 1, function() {
+    location.replace('http://example.com/®ooτ');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    var Router = Backbone.Router.extend({
+      routes: {'': 'index'},
+      index: function(){ ok(true); }
+    });
+    var router = new Router;
+    Backbone.history.start({root: '®ooτ', pushState: true});
+  });
+
 })();

--- a/test/router.js
+++ b/test/router.js
@@ -932,4 +932,28 @@
     Backbone.history.start({root: '/root', pushState: true});
   });
 
+  test("Paths that don't match the root should not match", 0, function() {
+    location.replace('http://example.com/foo');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    var Router = Backbone.Router.extend({
+      routes: {'foo': 'foo'},
+      foo: function(){ ok(false, 'should not match unless root matches'); }
+    });
+    var router = new Router;
+    Backbone.history.start({root: 'root', pushState: true});
+  });
+
+  test("Paths that don't match the root should not match", 0, function() {
+    location.replace('http://example.com/xxxx/foo');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    var Router = Backbone.Router.extend({
+      routes: {'foo': 'foo'},
+      foo: function(){ ok(false, 'should not match unless root matches'); }
+    });
+    var router = new Router;
+    Backbone.history.start({root: 'root', pushState: true});
+  });
+
 })();

--- a/test/router.js
+++ b/test/router.js
@@ -956,4 +956,16 @@
     Backbone.history.start({root: 'root', pushState: true});
   });
 
+  test("roots with regex characters", 1, function() {
+    location.replace('http://example.com/x+y.z/foo');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    var Router = Backbone.Router.extend({
+      routes: {'foo': 'foo'},
+      foo: function(){ ok(true); }
+    });
+    var router = new Router;
+    Backbone.history.start({root: 'x+y.z', pushState: true});
+  });
+
 })();

--- a/test/router.js
+++ b/test/router.js
@@ -937,8 +937,11 @@
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
-      routes: {'foo': 'foo'},
-      foo: function(){ ok(false, 'should not match unless root matches'); }
+      routes: {
+        foo: function(){
+          ok(false, 'should not match unless root matches');
+        }
+      }
     });
     var router = new Router;
     Backbone.history.start({root: 'root', pushState: true});
@@ -949,8 +952,11 @@
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
-      routes: {'foo': 'foo'},
-      foo: function(){ ok(false, 'should not match unless root matches'); }
+      routes: {
+        foo: function(){
+          ok(false, 'should not match unless root matches');
+        }
+      }
     });
     var router = new Router;
     Backbone.history.start({root: 'root', pushState: true});
@@ -961,8 +967,7 @@
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
-      routes: {'foo': 'foo'},
-      foo: function(){ ok(true); }
+      routes: {foo: function(){ ok(true); }}
     });
     var router = new Router;
     Backbone.history.start({root: 'x+y.z', pushState: true});
@@ -973,8 +978,7 @@
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
-      routes: {'foo': 'foo'},
-      foo: function(){ ok(true); }
+      routes: {foo: function(){ ok(true); }}
     });
     var router = new Router;
     Backbone.history.start({root: '®ooτ', pushState: true});
@@ -985,8 +989,7 @@
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
-      routes: {'': 'index'},
-      index: function(){ ok(true); }
+      routes: {'': function(){ ok(true); }}
     });
     var router = new Router;
     Backbone.history.start({root: '®ooτ', pushState: true});


### PR DESCRIPTION
It's hard to believe this has gone unreported for so long, but here it is! Currently, a route like 'test' will match the url `/test`, regardless of the root, and the url `/xxxx/test`, as long as the root is four characters long. This is obviously incorrect as routes should only be executed when the root matches.

There may be further implications from matching the root, but this is certainly more correct than what exists currently.

Thanks to @pfiller for catching it! :heart: