### PR TITLE
Improve consistency for object notation.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1273,7 +1273,7 @@
       if (!this.el) {
         var attrs = _.extend({}, _.result(this, 'attributes'));
         if (this.id) attrs.id = _.result(this, 'id');
-        if (this.className) attrs['class'] = _.result(this, 'className');
+        if (this.className) attrs.class = _.result(this, 'className');
         this.setElement(this._createElement(_.result(this, 'tagName')));
         this._setAttributes(attrs);
       } else {


### PR DESCRIPTION
Use dot notation for property assignment rather than bracket notation.