### PR TITLE
Capitalize constructor functions.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1787,36 +1787,36 @@
   // Similar to `goog.inherits`, but uses a hash of prototype properties and
   // class properties to be extended.
   var extend = function(protoProps, staticProps) {
-    var parent = this;
-    var child;
+    var Parent = this;
+    var Child;
 
     // The constructor function for the new subclass is either defined by you
     // (the "constructor" property in your `extend` definition), or defaulted
-    // by us to simply call the parent's constructor.
+    // by us to simply call the Parent's constructor.
     if (protoProps && _.has(protoProps, 'constructor')) {
-      child = protoProps.constructor;
+      Child = protoProps.constructor;
     } else {
-      child = function(){ return parent.apply(this, arguments); };
+      Child = function(){ return Parent.apply(this, arguments); };
     }
 
     // Add static properties to the constructor function, if supplied.
-    _.extend(child, parent, staticProps);
+    _.extend(Child, Parent, staticProps);
 
-    // Set the prototype chain to inherit from `parent`, without calling
-    // `parent`'s constructor function.
-    var Surrogate = function(){ this.constructor = child; };
-    Surrogate.prototype = parent.prototype;
-    child.prototype = new Surrogate;
+    // Set the prototype chain to inherit from `Parent`, without calling
+    // `Parent`'s constructor function.
+    var Surrogate = function(){ this.constructor = Child; };
+    Surrogate.prototype = Parent.prototype;
+    Child.prototype = new Surrogate;
 
     // Add prototype properties (instance properties) to the subclass,
     // if supplied.
-    if (protoProps) _.extend(child.prototype, protoProps);
+    if (protoProps) _.extend(Child.prototype, protoProps);
 
-    // Set a convenience property in case the parent's prototype is needed
+    // Set a convenience property in case the Parent's prototype is needed
     // later.
-    child.__super__ = parent.prototype;
+    Child.__super__ = Parent.prototype;
 
-    return child;
+    return Child;
   };
 
   // Set up inheritance for the model, collection, router, view and history.


### PR DESCRIPTION
Indicate that 'parent' and 'child' in the 'extend' function are constructor functions by capitalizing them per convention, clarifying their purpose.