### PR TITLE
Clarify reference to the parent constructor.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1792,7 +1792,7 @@
 
     // The constructor function for the new subclass is either defined by you
     // (the "constructor" property in your `extend` definition), or defaulted
-    // by us to simply call the parent's constructor.
+    // by us to simply call the parent constructor.
     if (protoProps && _.has(protoProps, 'constructor')) {
       child = protoProps.constructor;
     } else {
@@ -1803,7 +1803,7 @@
     _.extend(child, parent, staticProps);
 
     // Set the prototype chain to inherit from `parent`, without calling
-    // `parent`'s constructor function.
+    // `parent` constructor function.
     var Surrogate = function(){ this.constructor = child; };
     Surrogate.prototype = parent.prototype;
     child.prototype = new Surrogate;


### PR DESCRIPTION
The parent's constructor is 'Function', which is the constructor that created parent. 
The comments refer to the parent constructor function, not it's constructor function (that is, the constructor that created it).