### PR TITLE
Fix #3597 revert annotated src to v1.1.2

### DIFF
--- a/docs/backbone.html
+++ b/docs/backbone.html
@@ -10,33 +10,33 @@
 <body>
   <div id="container">
     <div id="background"></div>
-    
+
     <ul class="sections">
-        
+
           <li id="title">
               <div class="annotation">
                   <h1>backbone.js</h1>
               </div>
           </li>
-        
-        
-        
+
+
+
         <li id="section-1">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-1">&#182;</a>
               </div>
               <pre><code>Backbone.js <span class="hljs-number">1.1</span><span class="hljs-number">.2</span>
 </code></pre>
             </div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-2">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-2">&#182;</a>
               </div>
@@ -46,32 +46,32 @@ For all details and documentation:
 http:<span class="hljs-comment">//backbonejs.org</span>
 </code></pre>
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>
 (<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(root, factory)</span> </span>{</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-3">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-3">&#182;</a>
               </div>
               <p>Set up Backbone appropriately for the environment. Start with AMD.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> define === <span class="hljs-string">'function'</span> &amp;&amp; define.amd) {
     define([<span class="hljs-string">'underscore'</span>, <span class="hljs-string">'jquery'</span>, <span class="hljs-string">'exports'</span>], <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(_, $, exports)</span> </span>{</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-4">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-4">&#182;</a>
               </div>
@@ -79,77 +79,77 @@ http:<span class="hljs-comment">//backbonejs.org</span>
 others that may still expect a global Backbone.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      root.Backbone = factory(root, exports, _, $);
     });</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-5">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-5">&#182;</a>
               </div>
               <p>Next for Node.js or CommonJS. jQuery may not be needed as a module.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> exports !== <span class="hljs-string">'undefined'</span>) {
     <span class="hljs-keyword">var</span> _ = <span class="hljs-built_in">require</span>(<span class="hljs-string">'underscore'</span>);
     factory(root, exports, _);</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-6">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-6">&#182;</a>
               </div>
               <p>Finally, as a browser global.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  } <span class="hljs-keyword">else</span> {
     root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender || root.$));
   }
 
 }(<span class="hljs-keyword">this</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(root, Backbone, _, $)</span> </span>{</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-7">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-7">&#182;</a>
               </div>
               <h2 id="initial-setup">Initial Setup</h2>
 
             </div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-8">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-8">&#182;</a>
               </div>
-              
+
             </div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-9">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-9">&#182;</a>
               </div>
@@ -157,46 +157,48 @@ others that may still expect a global Backbone.</p>
 restored later on, if <code>noConflict</code> is used.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> previousBackbone = root.Backbone;</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-10">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-10">&#182;</a>
               </div>
               <p>Create local references to array methods we’ll want to use later.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> array = [];
-  <span class="hljs-keyword">var</span> slice = array.slice;</pre></div></div>
-            
+  <span class="hljs-keyword">var</span> push = array.push;
+  <span class="hljs-keyword">var</span> slice = array.slice;
+  <span class="hljs-keyword">var</span> splice = array.splice;</pre></div></div>
+
         </li>
-        
-        
+
+
         <li id="section-11">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-11">&#182;</a>
               </div>
               <p>Current version of the library. Keep in sync with <code>package.json</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Backbone.VERSION = <span class="hljs-string">'1.1.2'</span>;</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-12">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-12">&#182;</a>
               </div>
@@ -204,15 +206,15 @@ restored later on, if <code>noConflict</code> is used.</p>
 the <code>$</code> variable.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Backbone.$ = $;</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-13">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-13">&#182;</a>
               </div>
@@ -220,18 +222,18 @@ the <code>$</code> variable.</p>
 to its previous owner. Returns a reference to this Backbone object.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Backbone.noConflict = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
     root.Backbone = previousBackbone;
     <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
   };</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-14">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-14">&#182;</a>
               </div>
@@ -240,58 +242,58 @@ will fake <code>&quot;PATCH&quot;</code>, <code>&quot;PUT&quot;</code> and <code
 set a <code>X-Http-Method-Override</code> header.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Backbone.emulateHTTP = <span class="hljs-literal">false</span>;</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-15">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-15">&#182;</a>
               </div>
               <p>Turn on <code>emulateJSON</code> to support legacy servers that can’t deal with direct
-<code>application/json</code> requests … this will encode the body as
+<code>application/json</code> requests … will encode the body as
 <code>application/x-www-form-urlencoded</code> instead and will send the model in a
 form param named <code>model</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Backbone.emulateJSON = <span class="hljs-literal">false</span>;</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-16">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-16">&#182;</a>
               </div>
               <h2 id="backbone-events">Backbone.Events</h2>
 
             </div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-17">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-17">&#182;</a>
               </div>
-              
+
             </div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-18">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-18">&#182;</a>
               </div>
@@ -305,15 +307,15 @@ object.on(<span class="hljs-string">'expand'</span>, <span class="hljs-function"
 object.trigger(<span class="hljs-string">'expand'</span>);
 </code></pre>
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> Events = Backbone.Events = {</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-19">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-19">&#182;</a>
               </div>
@@ -321,7 +323,7 @@ object.trigger(<span class="hljs-string">'expand'</span>);
 the callback to all events fired.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    on: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name, callback, context)</span> </span>{
       <span class="hljs-keyword">if</span> (!eventsApi(<span class="hljs-keyword">this</span>, <span class="hljs-string">'on'</span>, name, [callback, context]) || !callback) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
       <span class="hljs-keyword">this</span>._events || (<span class="hljs-keyword">this</span>._events = {});
@@ -329,13 +331,13 @@ the callback to all events fired.</p>
       events.push({callback: callback, context: context, ctx: context || <span class="hljs-keyword">this</span>});
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-20">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-20">&#182;</a>
               </div>
@@ -343,7 +345,7 @@ the callback to all events fired.</p>
 the callback is invoked, it will be removed.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    once: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name, callback, context)</span> </span>{
       <span class="hljs-keyword">if</span> (!eventsApi(<span class="hljs-keyword">this</span>, <span class="hljs-string">'once'</span>, name, [callback, context]) || !callback) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
       <span class="hljs-keyword">var</span> self = <span class="hljs-keyword">this</span>;
@@ -354,13 +356,13 @@ the callback is invoked, it will be removed.</p>
       once._callback = callback;
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.on(name, once, context);
     },</pre></div></div>
-            
+
         </li>
-        
-        
+
+
         <li id="section-21">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
                 <a class="pilcrow" href="#section-21">&#182;</a>
               </div>
@@ -370,122 +372,43 @@ callbacks for the event. If <code>name</code> is null, removes all bound
 callbacks for all events.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    off: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name, callback, context)</span> </span>{
-      <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>._events || !eventsApi(<span class="hljs-keyword">this</span>, <span class="hljs-string">'off'</span>, name, [callback, context])) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-22">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-22">&#182;</a>
-              </div>
-              <p>Remove all callbacks for all events.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (!name &amp;&amp; !callback &amp;&amp; !context) {
+            <div class="content"><div class='highlight'><pre>    off: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name, callback, context)</span> </span>{
+      <span class="hljs-keyword">var</span> retain, ev, events, names, i, l, j, k;
+      <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>._events || !eventsApi(<span class="hljs-keyword">this</span>, <span class="hljs-string">'off'</span>, name, [callback, context])) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
+      <span class="hljs-keyword">if</span> (!name &amp;&amp; !callback &amp;&amp; !context) {
         <span class="hljs-keyword">this</span>._events = <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>;
         <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
       }
-
-      <span class="hljs-keyword">var</span> names = name ? [name] : _.keys(<span class="hljs-keyword">this</span>._events);
-      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = names.length; i &lt; length; i++) {
-        name = names[i];</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-23">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-23">&#182;</a>
-              </div>
-              <p>Bail out if there are no events stored.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">var</span> events = <span class="hljs-keyword">this</span>._events[name];
-        <span class="hljs-keyword">if</span> (!events) <span class="hljs-keyword">continue</span>;</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-24">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-24">&#182;</a>
-              </div>
-              <p>Remove all callbacks for this event.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> (!callback &amp;&amp; !context) {
-          <span class="hljs-keyword">delete</span> <span class="hljs-keyword">this</span>._events[name];
-          <span class="hljs-keyword">continue</span>;
-        }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-25">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-25">&#182;</a>
-              </div>
-              <p>Find any remaining events.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">var</span> remaining = [];
-        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> j = <span class="hljs-number">0</span>, k = events.length; j &lt; k; j++) {
-          <span class="hljs-keyword">var</span> event = events[j];
-          <span class="hljs-keyword">if</span> (
-            callback &amp;&amp; callback !== event.callback &amp;&amp;
-            callback !== event.callback._callback ||
-            context &amp;&amp; context !== event.context
-          ) {
-            remaining.push(event);
+      names = name ? [name] : _.keys(<span class="hljs-keyword">this</span>._events);
+      <span class="hljs-keyword">for</span> (i = <span class="hljs-number">0</span>, l = names.length; i &lt; l; i++) {
+        name = names[i];
+        <span class="hljs-keyword">if</span> (events = <span class="hljs-keyword">this</span>._events[name]) {
+          <span class="hljs-keyword">this</span>._events[name] = retain = [];
+          <span class="hljs-keyword">if</span> (callback || context) {
+            <span class="hljs-keyword">for</span> (j = <span class="hljs-number">0</span>, k = events.length; j &lt; k; j++) {
+              ev = events[j];
+              <span class="hljs-keyword">if</span> ((callback &amp;&amp; callback !== ev.callback &amp;&amp; callback !== ev.callback._callback) ||
+                  (context &amp;&amp; context !== ev.context)) {
+                retain.push(ev);
+              }
+            }
           }
-        }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-26">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-26">&#182;</a>
-              </div>
-              <p>Replace events if there are any remaining.  Otherwise, clean up.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> (remaining.length) {
-          <span class="hljs-keyword">this</span>._events[name] = remaining;
-        } <span class="hljs-keyword">else</span> {
-          <span class="hljs-keyword">delete</span> <span class="hljs-keyword">this</span>._events[name];
+          <span class="hljs-keyword">if</span> (!retain.length) <span class="hljs-keyword">delete</span> <span class="hljs-keyword">this</span>._events[name];
         }
       }
 
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-27">
+
+
+        <li id="section-22">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-27">&#182;</a>
+                <a class="pilcrow" href="#section-22">&#182;</a>
               </div>
               <p>Trigger one or many events, firing all bound callbacks. Callbacks are
 passed the same arguments as <code>trigger</code> is, apart from the event name
@@ -493,7 +416,7 @@ passed the same arguments as <code>trigger</code> is, apart from the event name
 receive the true name of the event as the first argument).</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    trigger: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(name)</span> </span>{
       <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>._events) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
       <span class="hljs-keyword">var</span> args = slice.call(<span class="hljs-built_in">arguments</span>, <span class="hljs-number">1</span>);
@@ -504,58 +427,21 @@ receive the true name of the event as the first argument).</p>
       <span class="hljs-keyword">if</span> (allEvents) triggerEvents(allEvents, <span class="hljs-built_in">arguments</span>);
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-28">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-28">&#182;</a>
-              </div>
-              <p>Inversion-of-control versions of <code>on</code> and <code>once</code>. Tell <em>this</em> object to
-listen to an event in another object … keeping track of what it’s
-listening to.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    listenTo: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, name, callback)</span> </span>{
-      <span class="hljs-keyword">var</span> listeningTo = <span class="hljs-keyword">this</span>._listeningTo || (<span class="hljs-keyword">this</span>._listeningTo = {});
-      <span class="hljs-keyword">var</span> id = obj._listenId || (obj._listenId = _.uniqueId(<span class="hljs-string">'l'</span>));
-      listeningTo[id] = obj;
-      <span class="hljs-keyword">if</span> (!callback &amp;&amp; <span class="hljs-keyword">typeof</span> name === <span class="hljs-string">'object'</span>) callback = <span class="hljs-keyword">this</span>;
-      obj.on(name, callback, <span class="hljs-keyword">this</span>);
-      <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
-    },
-
-    listenToOnce: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, name, callback)</span> </span>{
-      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> name === <span class="hljs-string">'object'</span>) {
-        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> event <span class="hljs-keyword">in</span> name) <span class="hljs-keyword">this</span>.listenToOnce(obj, event, name[event]);
-        <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
-      }
-      <span class="hljs-keyword">var</span> cb = _.once(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-        <span class="hljs-keyword">this</span>.stopListening(obj, name, cb);
-        callback.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
-      });
-      cb._callback = callback;
-      <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.listenTo(obj, name, cb);
-    },</pre></div></div>
-            
         </li>
-        
-        
-        <li id="section-29">
+
+
+        <li id="section-23">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-29">&#182;</a>
+                <a class="pilcrow" href="#section-23">&#182;</a>
               </div>
               <p>Tell this object to stop listening to either specific events … or
 to every object it’s currently listening to.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    stopListening: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, name, callback)</span> </span>{
       <span class="hljs-keyword">var</span> listeningTo = <span class="hljs-keyword">this</span>._listeningTo;
       <span class="hljs-keyword">if</span> (!listeningTo) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
@@ -571,76 +457,76 @@ to every object it’s currently listening to.</p>
     }
 
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-30">
+
+
+        <li id="section-24">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-30">&#182;</a>
+                <a class="pilcrow" href="#section-24">&#182;</a>
               </div>
               <p>Regular expression used to split event strings.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> eventSplitter = <span class="hljs-regexp">/\s+/</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-31">
+
+
+        <li id="section-25">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-31">&#182;</a>
+                <a class="pilcrow" href="#section-25">&#182;</a>
               </div>
               <p>Implement fancy features of the Events API such as multiple event
 names <code>&quot;change blur&quot;</code> and jQuery-style event maps <code>{change: action}</code>
 in terms of the existing API.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> eventsApi = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, action, name, rest)</span> </span>{
     <span class="hljs-keyword">if</span> (!name) <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-32">
+
+
+        <li id="section-26">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-32">&#182;</a>
+                <a class="pilcrow" href="#section-26">&#182;</a>
               </div>
               <p>Handle event maps.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> name === <span class="hljs-string">'object'</span>) {
       <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> key <span class="hljs-keyword">in</span> name) {
         obj[action].apply(obj, [key, name[key]].concat(rest));
       }
       <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
     }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-33">
+
+
+        <li id="section-27">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-33">&#182;</a>
+                <a class="pilcrow" href="#section-27">&#182;</a>
               </div>
               <p>Handle space separated event names.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (eventSplitter.test(name)) {
       <span class="hljs-keyword">var</span> names = name.split(eventSplitter);
-      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = names.length; i &lt; length; i++) {
+      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, l = names.length; i &lt; l; i++) {
         obj[action].apply(obj, [names[i]].concat(rest));
       }
       <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
@@ -648,22 +534,22 @@ in terms of the existing API.</p>
 
     <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>;
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-34">
+
+
+        <li id="section-28">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-34">&#182;</a>
+                <a class="pilcrow" href="#section-28">&#182;</a>
               </div>
               <p>A difficult-to-believe, but optimized internal dispatch function for
 triggering events. Tries to keep the usual cases speedy (most internal
 Backbone events have 3 arguments).</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> triggerEvents = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(events, args)</span> </span>{
     <span class="hljs-keyword">var</span> ev, i = -<span class="hljs-number">1</span>, l = events.length, a1 = args[<span class="hljs-number">0</span>], a2 = args[<span class="hljs-number">1</span>], a3 = args[<span class="hljs-number">2</span>];
     <span class="hljs-keyword">switch</span> (args.length) {
@@ -673,73 +559,101 @@ Backbone events have 3 arguments).</p>
       <span class="hljs-keyword">case</span> <span class="hljs-number">3</span>: <span class="hljs-keyword">while</span> (++i &lt; l) (ev = events[i]).callback.call(ev.ctx, a1, a2, a3); <span class="hljs-keyword">return</span>;
       <span class="hljs-keyword">default</span>: <span class="hljs-keyword">while</span> (++i &lt; l) (ev = events[i]).callback.apply(ev.ctx, args); <span class="hljs-keyword">return</span>;
     }
-  };</pre></div></div>
-            
+  };
+
+  <span class="hljs-keyword">var</span> listenMethods = {listenTo: <span class="hljs-string">'on'</span>, listenToOnce: <span class="hljs-string">'once'</span>};</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-35">
+
+
+        <li id="section-29">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-35">&#182;</a>
+                <a class="pilcrow" href="#section-29">&#182;</a>
+              </div>
+              <p>Inversion-of-control versions of <code>on</code> and <code>once</code>. Tell <em>this</em> object to
+listen to an event in another object … keeping track of what it’s
+listening to.</p>
+
+            </div>
+
+            <div class="content"><div class='highlight'><pre>  _.each(listenMethods, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(implementation, method)</span> </span>{
+    Events[method] = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj, name, callback)</span> </span>{
+      <span class="hljs-keyword">var</span> listeningTo = <span class="hljs-keyword">this</span>._listeningTo || (<span class="hljs-keyword">this</span>._listeningTo = {});
+      <span class="hljs-keyword">var</span> id = obj._listenId || (obj._listenId = _.uniqueId(<span class="hljs-string">'l'</span>));
+      listeningTo[id] = obj;
+      <span class="hljs-keyword">if</span> (!callback &amp;&amp; <span class="hljs-keyword">typeof</span> name === <span class="hljs-string">'object'</span>) callback = <span class="hljs-keyword">this</span>;
+      obj[implementation](name, callback, <span class="hljs-keyword">this</span>);
+      <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
+    };
+  });</pre></div></div>
+
+        </li>
+
+
+        <li id="section-30">
+            <div class="annotation">
+
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-30">&#182;</a>
               </div>
               <p>Aliases for backwards compatibility.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Events.bind   = Events.on;
   Events.unbind = Events.off;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-36">
+
+
+        <li id="section-31">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-36">&#182;</a>
+                <a class="pilcrow" href="#section-31">&#182;</a>
               </div>
               <p>Allow the <code>Backbone</code> object to serve as a global event bus, for folks who
 want global “pubsub” in a convenient place.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  _.extend(Backbone, Events);</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-37">
+
+
+        <li id="section-32">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-37">&#182;</a>
+                <a class="pilcrow" href="#section-32">&#182;</a>
               </div>
               <h2 id="backbone-model">Backbone.Model</h2>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-38">
+
+
+        <li id="section-33">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-38">&#182;</a>
+                <a class="pilcrow" href="#section-33">&#182;</a>
               </div>
-              
+
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-39">
+
+
+        <li id="section-34">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-39">&#182;</a>
+                <a class="pilcrow" href="#section-34">&#182;</a>
               </div>
               <p>Backbone <strong>Models</strong> are the basic data object in the framework —
 frequently representing a row in a table in a database on your server.
@@ -747,21 +661,21 @@ A discrete chunk of data and a bunch of useful, related methods for
 performing computations and transformations on that data.</p>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-40">
+
+
+        <li id="section-35">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-40">&#182;</a>
+                <a class="pilcrow" href="#section-35">&#182;</a>
               </div>
               <p>Create a new model with the specified attributes. A client id (<code>cid</code>)
 is automatically generated and assigned for you.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> Model = Backbone.Model = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attributes, options)</span> </span>{
     <span class="hljs-keyword">var</span> attrs = attributes || {};
     options || (options = {});
@@ -774,203 +688,203 @@ is automatically generated and assigned for you.</p>
     <span class="hljs-keyword">this</span>.changed = {};
     <span class="hljs-keyword">this</span>.initialize.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-41">
+
+
+        <li id="section-36">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-41">&#182;</a>
+                <a class="pilcrow" href="#section-36">&#182;</a>
               </div>
               <p>Attach all inheritable methods to the Model prototype.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  _.extend(Model.prototype, Events, {</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-42">
+
+
+        <li id="section-37">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-42">&#182;</a>
+                <a class="pilcrow" href="#section-37">&#182;</a>
               </div>
               <p>A hash of attributes whose current and previous value differ.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    changed: <span class="hljs-literal">null</span>,</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-43">
+
+
+        <li id="section-38">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-43">&#182;</a>
+                <a class="pilcrow" href="#section-38">&#182;</a>
               </div>
               <p>The value returned during the last failed validation.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    validationError: <span class="hljs-literal">null</span>,</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-44">
+
+
+        <li id="section-39">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-44">&#182;</a>
+                <a class="pilcrow" href="#section-39">&#182;</a>
               </div>
               <p>The default name for the JSON <code>id</code> attribute is <code>&quot;id&quot;</code>. MongoDB and
 CouchDB users may want to set this to <code>&quot;_id&quot;</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    idAttribute: <span class="hljs-string">'id'</span>,</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-45">
+
+
+        <li id="section-40">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-45">&#182;</a>
+                <a class="pilcrow" href="#section-40">&#182;</a>
               </div>
               <p>Initialize is an empty function by default. Override it with your own
 initialization logic.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    initialize: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{},</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-46">
+
+
+        <li id="section-41">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-46">&#182;</a>
+                <a class="pilcrow" href="#section-41">&#182;</a>
               </div>
               <p>Return a copy of the model’s <code>attributes</code> object.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    toJSON: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       <span class="hljs-keyword">return</span> _.clone(<span class="hljs-keyword">this</span>.attributes);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-47">
+
+
+        <li id="section-42">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-47">&#182;</a>
+                <a class="pilcrow" href="#section-42">&#182;</a>
               </div>
               <p>Proxy <code>Backbone.sync</code> by default — but override this if you need
 custom syncing semantics for <em>this</em> particular model.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    sync: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">return</span> Backbone.sync.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-48">
+
+
+        <li id="section-43">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-48">&#182;</a>
+                <a class="pilcrow" href="#section-43">&#182;</a>
               </div>
               <p>Get the value of an attribute.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    get: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attr)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.attributes[attr];
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-49">
+
+
+        <li id="section-44">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-49">&#182;</a>
+                <a class="pilcrow" href="#section-44">&#182;</a>
               </div>
               <p>Get the HTML-escaped value of an attribute.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-built_in">escape</span>: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attr)</span> </span>{
       <span class="hljs-keyword">return</span> _.escape(<span class="hljs-keyword">this</span>.get(attr));
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-50">
+
+
+        <li id="section-45">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-50">&#182;</a>
+                <a class="pilcrow" href="#section-45">&#182;</a>
               </div>
               <p>Returns <code>true</code> if the attribute contains a value that is not null
 or undefined.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    has: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attr)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.get(attr) != <span class="hljs-literal">null</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-51">
+
+
+        <li id="section-46">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-51">&#182;</a>
+                <a class="pilcrow" href="#section-46">&#182;</a>
               </div>
               <p>Set a hash of model attributes on the object, firing <code>&quot;change&quot;</code>. This is
 the core primitive operation of a model, updating the data and notifying
 anyone who needs to know about the change in state. The heart of the beast.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    set: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(key, val, options)</span> </span>{
       <span class="hljs-keyword">var</span> attr, attrs, unset, changes, silent, changing, prev, current;
       <span class="hljs-keyword">if</span> (key == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-52">
+
+
+        <li id="section-47">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-52">&#182;</a>
+                <a class="pilcrow" href="#section-47">&#182;</a>
               </div>
               <p>Handle both <code>&quot;key&quot;, value</code> and <code>{key: value}</code> -style arguments.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> key === <span class="hljs-string">'object'</span>) {
         attrs = key;
         options = val;
@@ -979,35 +893,35 @@ anyone who needs to know about the change in state. The heart of the beast.</p>
       }
 
       options || (options = {});</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-53">
+
+
+        <li id="section-48">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-53">&#182;</a>
+                <a class="pilcrow" href="#section-48">&#182;</a>
               </div>
               <p>Run validation.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>._validate(attrs, options)) <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-54">
+
+
+        <li id="section-49">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-54">&#182;</a>
+                <a class="pilcrow" href="#section-49">&#182;</a>
               </div>
               <p>Extract attributes and options.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      unset           = options.unset;
       silent          = options.silent;
       changes         = [];
@@ -1019,35 +933,35 @@ anyone who needs to know about the change in state. The heart of the beast.</p>
         <span class="hljs-keyword">this</span>.changed = {};
       }
       current = <span class="hljs-keyword">this</span>.attributes, prev = <span class="hljs-keyword">this</span>._previousAttributes;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-55">
+
+
+        <li id="section-50">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-55">&#182;</a>
+                <a class="pilcrow" href="#section-50">&#182;</a>
               </div>
               <p>Check for changes of <code>id</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.idAttribute <span class="hljs-keyword">in</span> attrs) <span class="hljs-keyword">this</span>.id = attrs[<span class="hljs-keyword">this</span>.idAttribute];</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-56">
+
+
+        <li id="section-51">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-56">&#182;</a>
+                <a class="pilcrow" href="#section-51">&#182;</a>
               </div>
               <p>For each <code>set</code> attribute, update or delete the current value.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">for</span> (attr <span class="hljs-keyword">in</span> attrs) {
         val = attrs[attr];
         <span class="hljs-keyword">if</span> (!_.isEqual(current[attr], val)) changes.push(attr);
@@ -1058,41 +972,41 @@ anyone who needs to know about the change in state. The heart of the beast.</p>
         }
         unset ? <span class="hljs-keyword">delete</span> current[attr] : current[attr] = val;
       }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-57">
+
+
+        <li id="section-52">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-57">&#182;</a>
+                <a class="pilcrow" href="#section-52">&#182;</a>
               </div>
               <p>Trigger all relevant attribute changes.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (!silent) {
         <span class="hljs-keyword">if</span> (changes.length) <span class="hljs-keyword">this</span>._pending = options;
-        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = changes.length; i &lt; length; i++) {
+        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, l = changes.length; i &lt; l; i++) {
           <span class="hljs-keyword">this</span>.trigger(<span class="hljs-string">'change:'</span> + changes[i], <span class="hljs-keyword">this</span>, current[changes[i]], options);
         }
       }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-58">
+
+
+        <li id="section-53">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-58">&#182;</a>
+                <a class="pilcrow" href="#section-53">&#182;</a>
               </div>
               <p>You might be wondering why there’s a <code>while</code> loop here. Changes can
 be recursively nested within <code>&quot;change&quot;</code> events.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (changing) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
       <span class="hljs-keyword">if</span> (!silent) {
         <span class="hljs-keyword">while</span> (<span class="hljs-keyword">this</span>._pending) {
@@ -1105,71 +1019,71 @@ be recursively nested within <code>&quot;change&quot;</code> events.</p>
       <span class="hljs-keyword">this</span>._changing = <span class="hljs-literal">false</span>;
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-59">
+
+
+        <li id="section-54">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-59">&#182;</a>
+                <a class="pilcrow" href="#section-54">&#182;</a>
               </div>
               <p>Remove an attribute from the model, firing <code>&quot;change&quot;</code>. <code>unset</code> is a noop
 if the attribute doesn’t exist.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    unset: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attr, options)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.set(attr, <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>, _.extend({}, options, {unset: <span class="hljs-literal">true</span>}));
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-60">
+
+
+        <li id="section-55">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-60">&#182;</a>
+                <a class="pilcrow" href="#section-55">&#182;</a>
               </div>
               <p>Clear all attributes on the model, firing <code>&quot;change&quot;</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    clear: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       <span class="hljs-keyword">var</span> attrs = {};
       <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> key <span class="hljs-keyword">in</span> <span class="hljs-keyword">this</span>.attributes) attrs[key] = <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>;
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.set(attrs, _.extend({}, options, {unset: <span class="hljs-literal">true</span>}));
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-61">
+
+
+        <li id="section-56">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-61">&#182;</a>
+                <a class="pilcrow" href="#section-56">&#182;</a>
               </div>
               <p>Determine if the model has changed since the last <code>&quot;change&quot;</code> event.
 If you specify an attribute name, determine if that attribute has changed.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    hasChanged: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attr)</span> </span>{
       <span class="hljs-keyword">if</span> (attr == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> !_.isEmpty(<span class="hljs-keyword">this</span>.changed);
       <span class="hljs-keyword">return</span> _.has(<span class="hljs-keyword">this</span>.changed, attr);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-62">
+
+
+        <li id="section-57">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-62">&#182;</a>
+                <a class="pilcrow" href="#section-57">&#182;</a>
               </div>
               <p>Return an object containing all the attributes that have changed, or
 false if there are no changed attributes. Useful for determining what
@@ -1179,7 +1093,7 @@ You can also pass an attributes object to diff against the model,
 determining if there <em>would be</em> a change.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    changedAttributes: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(diff)</span> </span>{
       <span class="hljs-keyword">if</span> (!diff) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.hasChanged() ? _.clone(<span class="hljs-keyword">this</span>.changed) : <span class="hljs-literal">false</span>;
       <span class="hljs-keyword">var</span> val, changed = <span class="hljs-literal">false</span>;
@@ -1190,59 +1104,59 @@ determining if there <em>would be</em> a change.</p>
       }
       <span class="hljs-keyword">return</span> changed;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-63">
+
+
+        <li id="section-58">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-63">&#182;</a>
+                <a class="pilcrow" href="#section-58">&#182;</a>
               </div>
               <p>Get the previous value of an attribute, recorded at the time the last
 <code>&quot;change&quot;</code> event was fired.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    previous: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attr)</span> </span>{
       <span class="hljs-keyword">if</span> (attr == <span class="hljs-literal">null</span> || !<span class="hljs-keyword">this</span>._previousAttributes) <span class="hljs-keyword">return</span> <span class="hljs-literal">null</span>;
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>._previousAttributes[attr];
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-64">
+
+
+        <li id="section-59">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-64">&#182;</a>
+                <a class="pilcrow" href="#section-59">&#182;</a>
               </div>
               <p>Get all of the attributes of the model at the time of the previous
 <code>&quot;change&quot;</code> event.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    previousAttributes: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">return</span> _.clone(<span class="hljs-keyword">this</span>._previousAttributes);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-65">
+
+
+        <li id="section-60">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-65">&#182;</a>
+                <a class="pilcrow" href="#section-60">&#182;</a>
               </div>
               <p>Fetch the model from the server. If the server’s representation of the
 model differs from its current attributes, they will be overridden,
 triggering a <code>&quot;change&quot;</code> event.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    fetch: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       options = options ? _.clone(options) : {};
       <span class="hljs-keyword">if</span> (options.parse === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) options.parse = <span class="hljs-literal">true</span>;
@@ -1256,38 +1170,38 @@ triggering a <code>&quot;change&quot;</code> event.</p>
       wrapError(<span class="hljs-keyword">this</span>, options);
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.sync(<span class="hljs-string">'read'</span>, <span class="hljs-keyword">this</span>, options);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-66">
+
+
+        <li id="section-61">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-66">&#182;</a>
+                <a class="pilcrow" href="#section-61">&#182;</a>
               </div>
               <p>Set a hash of model attributes, and sync the model to the server.
 If the server returns an attributes hash that differs, the model’s
 state will be <code>set</code> again.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    save: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(key, val, options)</span> </span>{
       <span class="hljs-keyword">var</span> attrs, method, xhr, attributes = <span class="hljs-keyword">this</span>.attributes;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-67">
+
+
+        <li id="section-62">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-67">&#182;</a>
+                <a class="pilcrow" href="#section-62">&#182;</a>
               </div>
               <p>Handle both <code>&quot;key&quot;, value</code> and <code>{key: value}</code> -style arguments.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (key == <span class="hljs-literal">null</span> || <span class="hljs-keyword">typeof</span> key === <span class="hljs-string">'object'</span>) {
         attrs = key;
         options = val;
@@ -1296,77 +1210,77 @@ state will be <code>set</code> again.</p>
       }
 
       options = _.extend({validate: <span class="hljs-literal">true</span>}, options);</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-68">
+
+
+        <li id="section-63">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-68">&#182;</a>
+                <a class="pilcrow" href="#section-63">&#182;</a>
               </div>
               <p>If we’re not waiting and attributes exist, save acts as
 <code>set(attr).save(null, opts)</code> with validation. Otherwise, check if
 the model will be valid when the attributes, if any, are set.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (attrs &amp;&amp; !options.wait) {
         <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>.set(attrs, options)) <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
       } <span class="hljs-keyword">else</span> {
         <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>._validate(attrs, options)) <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
       }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-69">
+
+
+        <li id="section-64">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-69">&#182;</a>
+                <a class="pilcrow" href="#section-64">&#182;</a>
               </div>
               <p>Set temporary attributes if <code>{wait: true}</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (attrs &amp;&amp; options.wait) {
         <span class="hljs-keyword">this</span>.attributes = _.extend({}, attributes, attrs);
       }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-70">
+
+
+        <li id="section-65">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-70">&#182;</a>
+                <a class="pilcrow" href="#section-65">&#182;</a>
               </div>
               <p>After a successful server-side save, the client is (optionally)
 updated with the server-side state.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (options.parse === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) options.parse = <span class="hljs-literal">true</span>;
       <span class="hljs-keyword">var</span> model = <span class="hljs-keyword">this</span>;
       <span class="hljs-keyword">var</span> success = options.success;
       options.success = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(resp)</span> </span>{</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-71">
+
+
+        <li id="section-66">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-71">&#182;</a>
+                <a class="pilcrow" href="#section-66">&#182;</a>
               </div>
               <p>Ensure attributes are restored during synchronous saves.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>        model.attributes = attributes;
         <span class="hljs-keyword">var</span> serverAttrs = model.parse(resp, options);
         <span class="hljs-keyword">if</span> (options.wait) serverAttrs = _.extend(attrs || {}, serverAttrs);
@@ -1379,49 +1293,48 @@ updated with the server-side state.</p>
       wrapError(<span class="hljs-keyword">this</span>, options);
 
       method = <span class="hljs-keyword">this</span>.isNew() ? <span class="hljs-string">'create'</span> : (options.patch ? <span class="hljs-string">'patch'</span> : <span class="hljs-string">'update'</span>);
-      <span class="hljs-keyword">if</span> (method === <span class="hljs-string">'patch'</span> &amp;&amp; !options.attrs) options.attrs = attrs;
+      <span class="hljs-keyword">if</span> (method === <span class="hljs-string">'patch'</span>) options.attrs = attrs;
       xhr = <span class="hljs-keyword">this</span>.sync(method, <span class="hljs-keyword">this</span>, options);</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-72">
+
+
+        <li id="section-67">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-72">&#182;</a>
+                <a class="pilcrow" href="#section-67">&#182;</a>
               </div>
               <p>Restore attributes.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (attrs &amp;&amp; options.wait) <span class="hljs-keyword">this</span>.attributes = attributes;
 
       <span class="hljs-keyword">return</span> xhr;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-73">
+
+
+        <li id="section-68">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-73">&#182;</a>
+                <a class="pilcrow" href="#section-68">&#182;</a>
               </div>
               <p>Destroy this model on the server if it was already persisted.
 Optimistically removes the model from its collection, if it has one.
 If <code>wait: true</code> is passed, waits for the server to respond before removal.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    destroy: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       options = options ? _.clone(options) : {};
       <span class="hljs-keyword">var</span> model = <span class="hljs-keyword">this</span>;
       <span class="hljs-keyword">var</span> success = options.success;
 
       <span class="hljs-keyword">var</span> destroy = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-        model.stopListening();
         model.trigger(<span class="hljs-string">'destroy'</span>, model, model.collection, options);
       };
 
@@ -1441,22 +1354,22 @@ If <code>wait: true</code> is passed, waits for the server to respond before rem
       <span class="hljs-keyword">if</span> (!options.wait) destroy();
       <span class="hljs-keyword">return</span> xhr;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-74">
+
+
+        <li id="section-69">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-74">&#182;</a>
+                <a class="pilcrow" href="#section-69">&#182;</a>
               </div>
               <p>Default URL for the model’s representation on the server — if you’re
 using Backbone’s restful methods, override this to change the endpoint
 that will be called.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    url: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">var</span> base =
         _.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'urlRoot'</span>) ||
@@ -1465,90 +1378,90 @@ that will be called.</p>
       <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.isNew()) <span class="hljs-keyword">return</span> base;
       <span class="hljs-keyword">return</span> base.replace(<span class="hljs-regexp">/([^\/])$/</span>, <span class="hljs-string">'$1/'</span>) + <span class="hljs-built_in">encodeURIComponent</span>(<span class="hljs-keyword">this</span>.id);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-75">
+
+
+        <li id="section-70">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-75">&#182;</a>
+                <a class="pilcrow" href="#section-70">&#182;</a>
               </div>
               <p><strong>parse</strong> converts a response into the hash of attributes to be <code>set</code> on
 the model. The default implementation is just to pass the response along.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    parse: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(resp, options)</span> </span>{
       <span class="hljs-keyword">return</span> resp;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-76">
+
+
+        <li id="section-71">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-76">&#182;</a>
+                <a class="pilcrow" href="#section-71">&#182;</a>
               </div>
               <p>Create a new model with identical attributes to this one.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    clone: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-keyword">this</span>.constructor(<span class="hljs-keyword">this</span>.attributes);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-77">
+
+
+        <li id="section-72">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-77">&#182;</a>
+                <a class="pilcrow" href="#section-72">&#182;</a>
               </div>
               <p>A model is new if it has never been saved to the server, and lacks an id.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    isNew: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">return</span> !<span class="hljs-keyword">this</span>.has(<span class="hljs-keyword">this</span>.idAttribute);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-78">
+
+
+        <li id="section-73">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-78">&#182;</a>
+                <a class="pilcrow" href="#section-73">&#182;</a>
               </div>
               <p>Check if the model is currently in a valid state.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    isValid: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>._validate({}, _.extend(options || {}, { validate: <span class="hljs-literal">true</span> }));
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-79">
+
+
+        <li id="section-74">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-79">&#182;</a>
+                <a class="pilcrow" href="#section-74">&#182;</a>
               </div>
               <p>Run validation against the next complete set of model attributes,
 returning <code>true</code> if all is well. Otherwise, fire an <code>&quot;invalid&quot;</code> event.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _validate: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attrs, options)</span> </span>{
       <span class="hljs-keyword">if</span> (!options.validate || !<span class="hljs-keyword">this</span>.validate) <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>;
       attrs = _.extend({}, <span class="hljs-keyword">this</span>.attributes, attrs);
@@ -1559,102 +1472,101 @@ returning <code>true</code> if all is well. Otherwise, fire an <code>&quot;inval
     }
 
   });</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-80">
+
+
+        <li id="section-75">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-80">&#182;</a>
+                <a class="pilcrow" href="#section-75">&#182;</a>
               </div>
               <p>Underscore methods that we want to implement on the Model.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> modelMethods = [<span class="hljs-string">'keys'</span>, <span class="hljs-string">'values'</span>, <span class="hljs-string">'pairs'</span>, <span class="hljs-string">'invert'</span>, <span class="hljs-string">'pick'</span>, <span class="hljs-string">'omit'</span>, <span class="hljs-string">'chain'</span>, <span class="hljs-string">'isEmpty'</span>];</pre></div></div>
-            
+
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> modelMethods = [<span class="hljs-string">'keys'</span>, <span class="hljs-string">'values'</span>, <span class="hljs-string">'pairs'</span>, <span class="hljs-string">'invert'</span>, <span class="hljs-string">'pick'</span>, <span class="hljs-string">'omit'</span>];</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-81">
+
+
+        <li id="section-76">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-81">&#182;</a>
+                <a class="pilcrow" href="#section-76">&#182;</a>
               </div>
               <p>Mix in each Underscore method as a proxy to <code>Model#attributes</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  _.each(modelMethods, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(method)</span> </span>{
-    <span class="hljs-keyword">if</span> (!_[method]) <span class="hljs-keyword">return</span>;
     Model.prototype[method] = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">var</span> args = slice.call(<span class="hljs-built_in">arguments</span>);
       args.unshift(<span class="hljs-keyword">this</span>.attributes);
       <span class="hljs-keyword">return</span> _[method].apply(_, args);
     };
   });</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-82">
+
+
+        <li id="section-77">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-82">&#182;</a>
+                <a class="pilcrow" href="#section-77">&#182;</a>
               </div>
               <h2 id="backbone-collection">Backbone.Collection</h2>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-83">
+
+
+        <li id="section-78">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-83">&#182;</a>
+                <a class="pilcrow" href="#section-78">&#182;</a>
               </div>
-              
+
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-84">
+
+
+        <li id="section-79">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-84">&#182;</a>
+                <a class="pilcrow" href="#section-79">&#182;</a>
               </div>
               <p>If models tend to represent a single row of data, a Backbone Collection is
-more analogous to a table full of data … or a small slice or page of that
+more analagous to a table full of data … or a small slice or page of that
 table, or a collection of rows that belong together for a particular reason
 — all of the messages in this particular folder, all of the documents
 belonging to this particular author, and so on. Collections maintain
 indexes of their models, both in order, and for lookup by <code>id</code>.</p>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-85">
+
+
+        <li id="section-80">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-85">&#182;</a>
+                <a class="pilcrow" href="#section-80">&#182;</a>
               </div>
               <p>Create a new <strong>Collection</strong>, perhaps to contain a specific type of <code>model</code>.
 If a <code>comparator</code> is specified, the Collection will maintain
 its models in sort order, as they’re added and removed.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> Collection = Backbone.Collection = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(models, options)</span> </span>{
     options || (options = {});
     <span class="hljs-keyword">if</span> (options.model) <span class="hljs-keyword">this</span>.model = options.model;
@@ -1663,146 +1575,146 @@ its models in sort order, as they’re added and removed.</p>
     <span class="hljs-keyword">this</span>.initialize.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
     <span class="hljs-keyword">if</span> (models) <span class="hljs-keyword">this</span>.reset(models, _.extend({silent: <span class="hljs-literal">true</span>}, options));
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-86">
+
+
+        <li id="section-81">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-86">&#182;</a>
+                <a class="pilcrow" href="#section-81">&#182;</a>
               </div>
               <p>Default options for <code>Collection#set</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> setOptions = {add: <span class="hljs-literal">true</span>, remove: <span class="hljs-literal">true</span>, merge: <span class="hljs-literal">true</span>};
   <span class="hljs-keyword">var</span> addOptions = {add: <span class="hljs-literal">true</span>, remove: <span class="hljs-literal">false</span>};</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-87">
+
+
+        <li id="section-82">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-87">&#182;</a>
+                <a class="pilcrow" href="#section-82">&#182;</a>
               </div>
               <p>Define the Collection’s inheritable methods.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  _.extend(Collection.prototype, Events, {</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-88">
+
+
+        <li id="section-83">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-88">&#182;</a>
+                <a class="pilcrow" href="#section-83">&#182;</a>
               </div>
               <p>The default model for a collection is just a <strong>Backbone.Model</strong>.
 This should be overridden in most cases.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    model: Model,</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-89">
+
+
+        <li id="section-84">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-89">&#182;</a>
+                <a class="pilcrow" href="#section-84">&#182;</a>
               </div>
               <p>Initialize is an empty function by default. Override it with your own
 initialization logic.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    initialize: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{},</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-90">
+
+
+        <li id="section-85">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-90">&#182;</a>
+                <a class="pilcrow" href="#section-85">&#182;</a>
               </div>
               <p>The JSON representation of a Collection is an array of the
 models’ attributes.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    toJSON: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.map(<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(model)</span></span>{ <span class="hljs-keyword">return</span> model.toJSON(options); });
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-91">
+
+
+        <li id="section-86">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-91">&#182;</a>
+                <a class="pilcrow" href="#section-86">&#182;</a>
               </div>
               <p>Proxy <code>Backbone.sync</code> by default.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    sync: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">return</span> Backbone.sync.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-92">
+
+
+        <li id="section-87">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-92">&#182;</a>
+                <a class="pilcrow" href="#section-87">&#182;</a>
               </div>
               <p>Add a model, or list of models to the set.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    add: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(models, options)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.set(models, _.extend({merge: <span class="hljs-literal">false</span>}, options, addOptions));
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-93">
+
+
+        <li id="section-88">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-93">&#182;</a>
+                <a class="pilcrow" href="#section-88">&#182;</a>
               </div>
               <p>Remove a model, or a list of models from the set.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    remove: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(models, options)</span> </span>{
       <span class="hljs-keyword">var</span> singular = !_.isArray(models);
       models = singular ? [models] : _.clone(models);
       options || (options = {});
-      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = models.length; i &lt; length; i++) {
-        <span class="hljs-keyword">var</span> model = models[i] = <span class="hljs-keyword">this</span>.get(models[i]);
+      <span class="hljs-keyword">var</span> i, l, index, model;
+      <span class="hljs-keyword">for</span> (i = <span class="hljs-number">0</span>, l = models.length; i &lt; l; i++) {
+        model = models[i] = <span class="hljs-keyword">this</span>.get(models[i]);
         <span class="hljs-keyword">if</span> (!model) <span class="hljs-keyword">continue</span>;
-        <span class="hljs-keyword">var</span> id = <span class="hljs-keyword">this</span>.modelId(model.attributes);
-        <span class="hljs-keyword">if</span> (id != <span class="hljs-literal">null</span>) <span class="hljs-keyword">delete</span> <span class="hljs-keyword">this</span>._byId[id];
+        <span class="hljs-keyword">delete</span> <span class="hljs-keyword">this</span>._byId[model.id];
         <span class="hljs-keyword">delete</span> <span class="hljs-keyword">this</span>._byId[model.cid];
-        <span class="hljs-keyword">var</span> index = <span class="hljs-keyword">this</span>.indexOf(model);
+        index = <span class="hljs-keyword">this</span>.indexOf(model);
         <span class="hljs-keyword">this</span>.models.splice(index, <span class="hljs-number">1</span>);
         <span class="hljs-keyword">this</span>.length--;
         <span class="hljs-keyword">if</span> (!options.silent) {
@@ -1813,15 +1725,15 @@ models’ attributes.</p>
       }
       <span class="hljs-keyword">return</span> singular ? models[<span class="hljs-number">0</span>] : models;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-94">
+
+
+        <li id="section-89">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-94">&#182;</a>
+                <a class="pilcrow" href="#section-89">&#182;</a>
               </div>
               <p>Update a collection by <code>set</code>-ing a new list of models, adding new ones,
 removing models that are no longer present, and merging models that
@@ -1829,231 +1741,213 @@ already exist in the collection, as necessary. Similar to <strong>Model#set</str
 the core operation for updating the data contained by the collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    set: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(models, options)</span> </span>{
       options = _.defaults({}, options, setOptions);
       <span class="hljs-keyword">if</span> (options.parse) models = <span class="hljs-keyword">this</span>.parse(models, options);
       <span class="hljs-keyword">var</span> singular = !_.isArray(models);
-      models = singular ? (models ? [models] : []) : models.slice();
-      <span class="hljs-keyword">var</span> id, model, attrs, existing, sort;
+      models = singular ? (models ? [models] : []) : _.clone(models);
+      <span class="hljs-keyword">var</span> i, l, id, model, attrs, existing, sort;
       <span class="hljs-keyword">var</span> at = options.at;
-      <span class="hljs-keyword">if</span> (at &lt; <span class="hljs-number">0</span>) at += <span class="hljs-keyword">this</span>.length + <span class="hljs-number">1</span>;
+      <span class="hljs-keyword">var</span> targetModel = <span class="hljs-keyword">this</span>.model;
       <span class="hljs-keyword">var</span> sortable = <span class="hljs-keyword">this</span>.comparator &amp;&amp; (at == <span class="hljs-literal">null</span>) &amp;&amp; options.sort !== <span class="hljs-literal">false</span>;
       <span class="hljs-keyword">var</span> sortAttr = _.isString(<span class="hljs-keyword">this</span>.comparator) ? <span class="hljs-keyword">this</span>.comparator : <span class="hljs-literal">null</span>;
       <span class="hljs-keyword">var</span> toAdd = [], toRemove = [], modelMap = {};
       <span class="hljs-keyword">var</span> add = options.add, merge = options.merge, remove = options.remove;
-      <span class="hljs-keyword">var</span> order = !sortable &amp;&amp; add &amp;&amp; remove ? [] : <span class="hljs-literal">false</span>;
-      <span class="hljs-keyword">var</span> orderChanged = <span class="hljs-literal">false</span>;</pre></div></div>
-            
+      <span class="hljs-keyword">var</span> order = !sortable &amp;&amp; add &amp;&amp; remove ? [] : <span class="hljs-literal">false</span>;</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-95">
+
+
+        <li id="section-90">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-95">&#182;</a>
+                <a class="pilcrow" href="#section-90">&#182;</a>
               </div>
               <p>Turn bare objects into model references, and prevent invalid models
 from being added.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = models.length; i &lt; length; i++) {
-        attrs = models[i];</pre></div></div>
-            
+
+            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">for</span> (i = <span class="hljs-number">0</span>, l = models.length; i &lt; l; i++) {
+        attrs = models[i] || {};
+        <span class="hljs-keyword">if</span> (attrs <span class="hljs-keyword">instanceof</span> Model) {
+          id = model = attrs;
+        } <span class="hljs-keyword">else</span> {
+          id = attrs[targetModel.prototype.idAttribute || <span class="hljs-string">'id'</span>];
+        }</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-96">
+
+
+        <li id="section-91">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-96">&#182;</a>
+                <a class="pilcrow" href="#section-91">&#182;</a>
               </div>
               <p>If a duplicate is found, prevent it from being added and
 optionally merge it into the existing model.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> (existing = <span class="hljs-keyword">this</span>.get(attrs)) {
+
+            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> (existing = <span class="hljs-keyword">this</span>.get(id)) {
           <span class="hljs-keyword">if</span> (remove) modelMap[existing.cid] = <span class="hljs-literal">true</span>;
-          <span class="hljs-keyword">if</span> (merge &amp;&amp; attrs !== existing) {
-            attrs = <span class="hljs-keyword">this</span>._isModel(attrs) ? attrs.attributes : attrs;
+          <span class="hljs-keyword">if</span> (merge) {
+            attrs = attrs === model ? model.attributes : attrs;
             <span class="hljs-keyword">if</span> (options.parse) attrs = existing.parse(attrs, options);
             existing.set(attrs, options);
             <span class="hljs-keyword">if</span> (sortable &amp;&amp; !sort &amp;&amp; existing.hasChanged(sortAttr)) sort = <span class="hljs-literal">true</span>;
           }
           models[i] = existing;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-97">
+
+
+        <li id="section-92">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-97">&#182;</a>
+                <a class="pilcrow" href="#section-92">&#182;</a>
               </div>
               <p>If this is a new, valid model, push it to the <code>toAdd</code> list.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>        } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (add) {
           model = models[i] = <span class="hljs-keyword">this</span>._prepareModel(attrs, options);
           <span class="hljs-keyword">if</span> (!model) <span class="hljs-keyword">continue</span>;
           toAdd.push(model);
           <span class="hljs-keyword">this</span>._addReference(model, options);
         }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-98">
+
+
+        <li id="section-93">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-98">&#182;</a>
+                <a class="pilcrow" href="#section-93">&#182;</a>
               </div>
               <p>Do not add multiple models with the same <code>id</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>        model = existing || model;
-        <span class="hljs-keyword">if</span> (!model) <span class="hljs-keyword">continue</span>;
-        id = <span class="hljs-keyword">this</span>.modelId(model.attributes);
-        <span class="hljs-keyword">if</span> (order &amp;&amp; (model.isNew() || !modelMap[id])) {
-          order.push(model);</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-99">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-99">&#182;</a>
-              </div>
-              <p>Check to see if this is actually a new model at this index.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>          orderChanged = orderChanged || !<span class="hljs-keyword">this</span>.models[i] || model.cid !== <span class="hljs-keyword">this</span>.models[i].cid;
-        }
-
-        modelMap[id] = <span class="hljs-literal">true</span>;
+        <span class="hljs-keyword">if</span> (order &amp;&amp; (model.isNew() || !modelMap[model.id])) order.push(model);
+        modelMap[model.id] = <span class="hljs-literal">true</span>;
       }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-100">
+
+
+        <li id="section-94">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-100">&#182;</a>
+                <a class="pilcrow" href="#section-94">&#182;</a>
               </div>
               <p>Remove nonexistent models if appropriate.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (remove) {
-        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = <span class="hljs-keyword">this</span>.length; i &lt; length; i++) {
+        <span class="hljs-keyword">for</span> (i = <span class="hljs-number">0</span>, l = <span class="hljs-keyword">this</span>.length; i &lt; l; ++i) {
           <span class="hljs-keyword">if</span> (!modelMap[(model = <span class="hljs-keyword">this</span>.models[i]).cid]) toRemove.push(model);
         }
         <span class="hljs-keyword">if</span> (toRemove.length) <span class="hljs-keyword">this</span>.remove(toRemove, options);
       }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-101">
+
+
+        <li id="section-95">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-101">&#182;</a>
+                <a class="pilcrow" href="#section-95">&#182;</a>
               </div>
               <p>See if sorting is needed, update <code>length</code> and splice in new models.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (toAdd.length || orderChanged) {
+
+            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (toAdd.length || (order &amp;&amp; order.length)) {
         <span class="hljs-keyword">if</span> (sortable) sort = <span class="hljs-literal">true</span>;
         <span class="hljs-keyword">this</span>.length += toAdd.length;
         <span class="hljs-keyword">if</span> (at != <span class="hljs-literal">null</span>) {
-          <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = toAdd.length; i &lt; length; i++) {
+          <span class="hljs-keyword">for</span> (i = <span class="hljs-number">0</span>, l = toAdd.length; i &lt; l; i++) {
             <span class="hljs-keyword">this</span>.models.splice(at + i, <span class="hljs-number">0</span>, toAdd[i]);
           }
         } <span class="hljs-keyword">else</span> {
           <span class="hljs-keyword">if</span> (order) <span class="hljs-keyword">this</span>.models.length = <span class="hljs-number">0</span>;
           <span class="hljs-keyword">var</span> orderedModels = order || toAdd;
-          <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = orderedModels.length; i &lt; length; i++) {
+          <span class="hljs-keyword">for</span> (i = <span class="hljs-number">0</span>, l = orderedModels.length; i &lt; l; i++) {
             <span class="hljs-keyword">this</span>.models.push(orderedModels[i]);
           }
         }
       }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-102">
+
+
+        <li id="section-96">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-102">&#182;</a>
+                <a class="pilcrow" href="#section-96">&#182;</a>
               </div>
               <p>Silently sort the collection if appropriate.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (sort) <span class="hljs-keyword">this</span>.sort({silent: <span class="hljs-literal">true</span>});</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-103">
+
+
+        <li id="section-97">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-103">&#182;</a>
+                <a class="pilcrow" href="#section-97">&#182;</a>
               </div>
               <p>Unless silenced, it’s time to fire all appropriate add/sort events.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (!options.silent) {
-        <span class="hljs-keyword">var</span> addOpts = at != <span class="hljs-literal">null</span> ? _.clone(options) : options;
-        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = toAdd.length; i &lt; length; i++) {
-          <span class="hljs-keyword">if</span> (at != <span class="hljs-literal">null</span>) addOpts.index = at + i;
-          (model = toAdd[i]).trigger(<span class="hljs-string">'add'</span>, model, <span class="hljs-keyword">this</span>, addOpts);
+        <span class="hljs-keyword">for</span> (i = <span class="hljs-number">0</span>, l = toAdd.length; i &lt; l; i++) {
+          (model = toAdd[i]).trigger(<span class="hljs-string">'add'</span>, model, <span class="hljs-keyword">this</span>, options);
         }
-        <span class="hljs-keyword">if</span> (sort || orderChanged) <span class="hljs-keyword">this</span>.trigger(<span class="hljs-string">'sort'</span>, <span class="hljs-keyword">this</span>, options);
+        <span class="hljs-keyword">if</span> (sort || (order &amp;&amp; order.length)) <span class="hljs-keyword">this</span>.trigger(<span class="hljs-string">'sort'</span>, <span class="hljs-keyword">this</span>, options);
       }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-104">
+
+
+        <li id="section-98">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-104">&#182;</a>
+                <a class="pilcrow" href="#section-98">&#182;</a>
               </div>
               <p>Return the added (or merged) model (or models).</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">return</span> singular ? models[<span class="hljs-number">0</span>] : models;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-105">
+
+
+        <li id="section-99">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-105">&#182;</a>
+                <a class="pilcrow" href="#section-99">&#182;</a>
               </div>
               <p>When you have more items than you want to add or remove individually,
 you can reset the entire set with a new list of models, without firing
@@ -2061,10 +1955,10 @@ any granular <code>add</code> or <code>remove</code> events. Fires <code>reset</
 Useful for bulk operations and optimizations.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    reset: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(models, options)</span> </span>{
-      options = options ? _.clone(options) : {};
-      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, length = <span class="hljs-keyword">this</span>.models.length; i &lt; length; i++) {
+      options || (options = {});
+      <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> i = <span class="hljs-number">0</span>, l = <span class="hljs-keyword">this</span>.models.length; i &lt; l; i++) {
         <span class="hljs-keyword">this</span>._removeReference(<span class="hljs-keyword">this</span>.models[i], options);
       }
       options.previousModels = <span class="hljs-keyword">this</span>.models;
@@ -2073,204 +1967,205 @@ Useful for bulk operations and optimizations.</p>
       <span class="hljs-keyword">if</span> (!options.silent) <span class="hljs-keyword">this</span>.trigger(<span class="hljs-string">'reset'</span>, <span class="hljs-keyword">this</span>, options);
       <span class="hljs-keyword">return</span> models;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-106">
+
+
+        <li id="section-100">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-106">&#182;</a>
+                <a class="pilcrow" href="#section-100">&#182;</a>
               </div>
               <p>Add a model to the end of the collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    push: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(model, options)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.add(model, _.extend({at: <span class="hljs-keyword">this</span>.length}, options));
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-107">
+
+
+        <li id="section-101">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-107">&#182;</a>
+                <a class="pilcrow" href="#section-101">&#182;</a>
               </div>
               <p>Remove a model from the end of the collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    pop: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       <span class="hljs-keyword">var</span> model = <span class="hljs-keyword">this</span>.at(<span class="hljs-keyword">this</span>.length - <span class="hljs-number">1</span>);
       <span class="hljs-keyword">this</span>.remove(model, options);
       <span class="hljs-keyword">return</span> model;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-108">
+
+
+        <li id="section-102">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-108">&#182;</a>
+                <a class="pilcrow" href="#section-102">&#182;</a>
               </div>
               <p>Add a model to the beginning of the collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    unshift: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(model, options)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.add(model, _.extend({at: <span class="hljs-number">0</span>}, options));
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-109">
+
+
+        <li id="section-103">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-109">&#182;</a>
+                <a class="pilcrow" href="#section-103">&#182;</a>
               </div>
               <p>Remove a model from the beginning of the collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    shift: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       <span class="hljs-keyword">var</span> model = <span class="hljs-keyword">this</span>.at(<span class="hljs-number">0</span>);
       <span class="hljs-keyword">this</span>.remove(model, options);
       <span class="hljs-keyword">return</span> model;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-110">
+
+
+        <li id="section-104">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-110">&#182;</a>
+                <a class="pilcrow" href="#section-104">&#182;</a>
               </div>
               <p>Slice out a sub-array of models from the collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    slice: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">return</span> slice.apply(<span class="hljs-keyword">this</span>.models, <span class="hljs-built_in">arguments</span>);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-111">
+
+
+        <li id="section-105">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-111">&#182;</a>
+                <a class="pilcrow" href="#section-105">&#182;</a>
               </div>
               <p>Get a model from the set by id.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    get: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(obj)</span> </span>{
       <span class="hljs-keyword">if</span> (obj == <span class="hljs-literal">null</span>) <span class="hljs-keyword">return</span> <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>;
-      <span class="hljs-keyword">var</span> id = <span class="hljs-keyword">this</span>.modelId(<span class="hljs-keyword">this</span>._isModel(obj) ? obj.attributes : obj);
-      <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>._byId[obj] || <span class="hljs-keyword">this</span>._byId[id] || <span class="hljs-keyword">this</span>._byId[obj.cid];
+      <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>._byId[obj] || <span class="hljs-keyword">this</span>._byId[obj.id] || <span class="hljs-keyword">this</span>._byId[obj.cid];
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-112">
+
+
+        <li id="section-106">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-112">&#182;</a>
+                <a class="pilcrow" href="#section-106">&#182;</a>
               </div>
               <p>Get the model at the given index.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    at: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(index)</span> </span>{
-      <span class="hljs-keyword">if</span> (index &lt; <span class="hljs-number">0</span>) index += <span class="hljs-keyword">this</span>.length;
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.models[index];
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-113">
+
+
+        <li id="section-107">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-113">&#182;</a>
+                <a class="pilcrow" href="#section-107">&#182;</a>
               </div>
               <p>Return models with matching attributes. Useful for simple cases of
 <code>filter</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    where: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attrs, first)</span> </span>{
-      <span class="hljs-keyword">var</span> matches = _.matches(attrs);
+      <span class="hljs-keyword">if</span> (_.isEmpty(attrs)) <span class="hljs-keyword">return</span> first ? <span class="hljs-keyword">void</span> <span class="hljs-number">0</span> : [];
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>[first ? <span class="hljs-string">'find'</span> : <span class="hljs-string">'filter'</span>](<span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(model)</span> </span>{
-        <span class="hljs-keyword">return</span> matches(model.attributes);
+        <span class="hljs-keyword">for</span> (<span class="hljs-keyword">var</span> key <span class="hljs-keyword">in</span> attrs) {
+          <span class="hljs-keyword">if</span> (attrs[key] !== model.get(key)) <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
+        }
+        <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>;
       });
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-114">
+
+
+        <li id="section-108">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-114">&#182;</a>
+                <a class="pilcrow" href="#section-108">&#182;</a>
               </div>
               <p>Return the first model with matching attributes. Useful for simple cases
 of <code>find</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    findWhere: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attrs)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.where(attrs, <span class="hljs-literal">true</span>);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-115">
+
+
+        <li id="section-109">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-115">&#182;</a>
+                <a class="pilcrow" href="#section-109">&#182;</a>
               </div>
               <p>Force the collection to re-sort itself. You don’t need to call this under
 normal circumstances, as the set will maintain sort order as each item
 is added.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    sort: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>.comparator) <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">'Cannot sort a set without a comparator'</span>);
       options || (options = {});</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-116">
+
+
+        <li id="section-110">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-116">&#182;</a>
+                <a class="pilcrow" href="#section-110">&#182;</a>
               </div>
               <p>Run sort based on type of <code>comparator</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (_.isString(<span class="hljs-keyword">this</span>.comparator) || <span class="hljs-keyword">this</span>.comparator.length === <span class="hljs-number">1</span>) {
         <span class="hljs-keyword">this</span>.models = <span class="hljs-keyword">this</span>.sortBy(<span class="hljs-keyword">this</span>.comparator, <span class="hljs-keyword">this</span>);
       } <span class="hljs-keyword">else</span> {
@@ -2280,39 +2175,39 @@ is added.</p>
       <span class="hljs-keyword">if</span> (!options.silent) <span class="hljs-keyword">this</span>.trigger(<span class="hljs-string">'sort'</span>, <span class="hljs-keyword">this</span>, options);
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-117">
+
+
+        <li id="section-111">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-117">&#182;</a>
+                <a class="pilcrow" href="#section-111">&#182;</a>
               </div>
               <p>Pluck an attribute from each model in the collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    pluck: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attr)</span> </span>{
       <span class="hljs-keyword">return</span> _.invoke(<span class="hljs-keyword">this</span>.models, <span class="hljs-string">'get'</span>, attr);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-118">
+
+
+        <li id="section-112">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-118">&#182;</a>
+                <a class="pilcrow" href="#section-112">&#182;</a>
               </div>
               <p>Fetch the default set of models for this collection, resetting the
 collection when they arrive. If <code>reset: true</code> is passed, the response
 data will be passed through the <code>reset</code> method instead of <code>set</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    fetch: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
       options = options ? _.clone(options) : {};
       <span class="hljs-keyword">if</span> (options.parse === <span class="hljs-keyword">void</span> <span class="hljs-number">0</span>) options.parse = <span class="hljs-literal">true</span>;
@@ -2327,22 +2222,22 @@ data will be passed through the <code>reset</code> method instead of <code>set</
       wrapError(<span class="hljs-keyword">this</span>, options);
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.sync(<span class="hljs-string">'read'</span>, <span class="hljs-keyword">this</span>, options);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-119">
+
+
+        <li id="section-113">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-119">&#182;</a>
+                <a class="pilcrow" href="#section-113">&#182;</a>
               </div>
               <p>Create a new instance of a model in this collection. Add the model to the
 collection immediately, unless <code>wait: true</code> is passed, in which case we
 wait for the server to agree.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    create: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(model, options)</span> </span>{
       options = options ? _.clone(options) : {};
       <span class="hljs-keyword">if</span> (!(model = <span class="hljs-keyword">this</span>._prepareModel(model, options))) <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
@@ -2356,101 +2251,78 @@ wait for the server to agree.</p>
       model.save(<span class="hljs-literal">null</span>, options);
       <span class="hljs-keyword">return</span> model;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-120">
+
+
+        <li id="section-114">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-120">&#182;</a>
+                <a class="pilcrow" href="#section-114">&#182;</a>
               </div>
               <p><strong>parse</strong> converts a response into a list of models to be added to the
 collection. The default implementation is just to pass it through.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    parse: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(resp, options)</span> </span>{
       <span class="hljs-keyword">return</span> resp;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-121">
+
+
+        <li id="section-115">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-121">&#182;</a>
+                <a class="pilcrow" href="#section-115">&#182;</a>
               </div>
               <p>Create a new collection with an identical list of models as this one.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    clone: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-keyword">this</span>.constructor(<span class="hljs-keyword">this</span>.models, {
-        model: <span class="hljs-keyword">this</span>.model,
-        comparator: <span class="hljs-keyword">this</span>.comparator
-      });
-    },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-122">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-122">&#182;</a>
-              </div>
-              <p>Define how to uniquely identify models in the collection.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    modelId: <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(attrs)</span> </span>{
-      <span class="hljs-keyword">return</span> attrs[<span class="hljs-keyword">this</span>.model.prototype.idAttribute || <span class="hljs-string">'id'</span>];
+            <div class="content"><div class='highlight'><pre>    clone: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+      <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-keyword">this</span>.constructor(<span class="hljs-keyword">this</span>.models);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-123">
+
+
+        <li id="section-116">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-123">&#182;</a>
+                <a class="pilcrow" href="#section-116">&#182;</a>
               </div>
               <p>Private method to reset all internal state. Called when the collection
 is first initialized or reset.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _reset: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">this</span>.length = <span class="hljs-number">0</span>;
       <span class="hljs-keyword">this</span>.models = [];
       <span class="hljs-keyword">this</span>._byId  = {};
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-124">
+
+
+        <li id="section-117">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-124">&#182;</a>
+                <a class="pilcrow" href="#section-117">&#182;</a>
               </div>
               <p>Prepare a hash of attributes (or other model) to be added to this
 collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _prepareModel: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attrs, options)</span> </span>{
-      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._isModel(attrs)) {
-        <span class="hljs-keyword">if</span> (!attrs.collection) attrs.collection = <span class="hljs-keyword">this</span>;
-        <span class="hljs-keyword">return</span> attrs;
-      }
+      <span class="hljs-keyword">if</span> (attrs <span class="hljs-keyword">instanceof</span> Model) <span class="hljs-keyword">return</span> attrs;
       options = options ? _.clone(options) : {};
       options.collection = <span class="hljs-keyword">this</span>;
       <span class="hljs-keyword">var</span> model = <span class="hljs-keyword">new</span> <span class="hljs-keyword">this</span>.model(attrs, options);
@@ -2458,71 +2330,53 @@ collection.</p>
       <span class="hljs-keyword">this</span>.trigger(<span class="hljs-string">'invalid'</span>, <span class="hljs-keyword">this</span>, model.validationError, options);
       <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
     },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-125">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-125">&#182;</a>
-              </div>
-              <p>Method for checking whether an object should be considered a model for
-the purposes of adding to the collection.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    _isModel: <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(model)</span> </span>{
-      <span class="hljs-keyword">return</span> model <span class="hljs-keyword">instanceof</span> Model;
-    },</pre></div></div>
-            
         </li>
-        
-        
-        <li id="section-126">
+
+
+        <li id="section-118">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-126">&#182;</a>
+                <a class="pilcrow" href="#section-118">&#182;</a>
               </div>
               <p>Internal method to create a model’s ties to a collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _addReference: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(model, options)</span> </span>{
       <span class="hljs-keyword">this</span>._byId[model.cid] = model;
-      <span class="hljs-keyword">var</span> id = <span class="hljs-keyword">this</span>.modelId(model.attributes);
-      <span class="hljs-keyword">if</span> (id != <span class="hljs-literal">null</span>) <span class="hljs-keyword">this</span>._byId[id] = model;
+      <span class="hljs-keyword">if</span> (model.id != <span class="hljs-literal">null</span>) <span class="hljs-keyword">this</span>._byId[model.id] = model;
+      <span class="hljs-keyword">if</span> (!model.collection) model.collection = <span class="hljs-keyword">this</span>;
       model.on(<span class="hljs-string">'all'</span>, <span class="hljs-keyword">this</span>._onModelEvent, <span class="hljs-keyword">this</span>);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-127">
+
+
+        <li id="section-119">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-127">&#182;</a>
+                <a class="pilcrow" href="#section-119">&#182;</a>
               </div>
               <p>Internal method to sever a model’s ties to a collection.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _removeReference: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(model, options)</span> </span>{
       <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span> === model.collection) <span class="hljs-keyword">delete</span> model.collection;
       model.off(<span class="hljs-string">'all'</span>, <span class="hljs-keyword">this</span>._onModelEvent, <span class="hljs-keyword">this</span>);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-128">
+
+
+        <li id="section-120">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-128">&#182;</a>
+                <a class="pilcrow" href="#section-120">&#182;</a>
               </div>
               <p>Internal method called every time a model in the set fires an event.
 Sets need to update their indexes when models change ids. All other
@@ -2530,97 +2384,91 @@ events simply proxy through. “add” and “remove” events that originate
 in other collections are ignored.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _onModelEvent: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(event, model, collection, options)</span> </span>{
       <span class="hljs-keyword">if</span> ((event === <span class="hljs-string">'add'</span> || event === <span class="hljs-string">'remove'</span>) &amp;&amp; collection !== <span class="hljs-keyword">this</span>) <span class="hljs-keyword">return</span>;
       <span class="hljs-keyword">if</span> (event === <span class="hljs-string">'destroy'</span>) <span class="hljs-keyword">this</span>.remove(model, options);
-      <span class="hljs-keyword">if</span> (event === <span class="hljs-string">'change'</span>) {
-        <span class="hljs-keyword">var</span> prevId = <span class="hljs-keyword">this</span>.modelId(model.previousAttributes());
-        <span class="hljs-keyword">var</span> id = <span class="hljs-keyword">this</span>.modelId(model.attributes);
-        <span class="hljs-keyword">if</span> (prevId !== id) {
-          <span class="hljs-keyword">if</span> (prevId != <span class="hljs-literal">null</span>) <span class="hljs-keyword">delete</span> <span class="hljs-keyword">this</span>._byId[prevId];
-          <span class="hljs-keyword">if</span> (id != <span class="hljs-literal">null</span>) <span class="hljs-keyword">this</span>._byId[id] = model;
-        }
+      <span class="hljs-keyword">if</span> (model &amp;&amp; event === <span class="hljs-string">'change:'</span> + model.idAttribute) {
+        <span class="hljs-keyword">delete</span> <span class="hljs-keyword">this</span>._byId[model.previous(model.idAttribute)];
+        <span class="hljs-keyword">if</span> (model.id != <span class="hljs-literal">null</span>) <span class="hljs-keyword">this</span>._byId[model.id] = model;
       }
       <span class="hljs-keyword">this</span>.trigger.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
     }
 
   });</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-129">
+
+
+        <li id="section-121">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-129">&#182;</a>
+                <a class="pilcrow" href="#section-121">&#182;</a>
               </div>
               <p>Underscore methods that we want to implement on the Collection.
 90% of the core usefulness of Backbone Collections is actually implemented
 right here:</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> methods = [<span class="hljs-string">'forEach'</span>, <span class="hljs-string">'each'</span>, <span class="hljs-string">'map'</span>, <span class="hljs-string">'collect'</span>, <span class="hljs-string">'reduce'</span>, <span class="hljs-string">'foldl'</span>,
     <span class="hljs-string">'inject'</span>, <span class="hljs-string">'reduceRight'</span>, <span class="hljs-string">'foldr'</span>, <span class="hljs-string">'find'</span>, <span class="hljs-string">'detect'</span>, <span class="hljs-string">'filter'</span>, <span class="hljs-string">'select'</span>,
     <span class="hljs-string">'reject'</span>, <span class="hljs-string">'every'</span>, <span class="hljs-string">'all'</span>, <span class="hljs-string">'some'</span>, <span class="hljs-string">'any'</span>, <span class="hljs-string">'include'</span>, <span class="hljs-string">'contains'</span>, <span class="hljs-string">'invoke'</span>,
     <span class="hljs-string">'max'</span>, <span class="hljs-string">'min'</span>, <span class="hljs-string">'toArray'</span>, <span class="hljs-string">'size'</span>, <span class="hljs-string">'first'</span>, <span class="hljs-string">'head'</span>, <span class="hljs-string">'take'</span>, <span class="hljs-string">'initial'</span>, <span class="hljs-string">'rest'</span>,
     <span class="hljs-string">'tail'</span>, <span class="hljs-string">'drop'</span>, <span class="hljs-string">'last'</span>, <span class="hljs-string">'without'</span>, <span class="hljs-string">'difference'</span>, <span class="hljs-string">'indexOf'</span>, <span class="hljs-string">'shuffle'</span>,
-    <span class="hljs-string">'lastIndexOf'</span>, <span class="hljs-string">'isEmpty'</span>, <span class="hljs-string">'chain'</span>, <span class="hljs-string">'sample'</span>, <span class="hljs-string">'partition'</span>];</pre></div></div>
-            
+    <span class="hljs-string">'lastIndexOf'</span>, <span class="hljs-string">'isEmpty'</span>, <span class="hljs-string">'chain'</span>, <span class="hljs-string">'sample'</span>];</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-130">
+
+
+        <li id="section-122">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-130">&#182;</a>
+                <a class="pilcrow" href="#section-122">&#182;</a>
               </div>
               <p>Mix in each Underscore method as a proxy to <code>Collection#models</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  _.each(methods, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(method)</span> </span>{
-    <span class="hljs-keyword">if</span> (!_[method]) <span class="hljs-keyword">return</span>;
     Collection.prototype[method] = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">var</span> args = slice.call(<span class="hljs-built_in">arguments</span>);
       args.unshift(<span class="hljs-keyword">this</span>.models);
       <span class="hljs-keyword">return</span> _[method].apply(_, args);
     };
   });</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-131">
+
+
+        <li id="section-123">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-131">&#182;</a>
+                <a class="pilcrow" href="#section-123">&#182;</a>
               </div>
               <p>Underscore methods that take a property name as an argument.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> attributeMethods = [<span class="hljs-string">'groupBy'</span>, <span class="hljs-string">'countBy'</span>, <span class="hljs-string">'sortBy'</span>, <span class="hljs-string">'indexBy'</span>];</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-132">
+
+
+        <li id="section-124">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-132">&#182;</a>
+                <a class="pilcrow" href="#section-124">&#182;</a>
               </div>
               <p>Use attributes instead of properties.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  _.each(attributeMethods, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(method)</span> </span>{
-    <span class="hljs-keyword">if</span> (!_[method]) <span class="hljs-keyword">return</span>;
     Collection.prototype[method] = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(value, context)</span> </span>{
       <span class="hljs-keyword">var</span> iterator = _.isFunction(value) ? value : <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(model)</span> </span>{
         <span class="hljs-keyword">return</span> model.get(value);
@@ -2628,40 +2476,40 @@ right here:</p>
       <span class="hljs-keyword">return</span> _[method](<span class="hljs-keyword">this</span>.models, iterator, context);
     };
   });</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-133">
+
+
+        <li id="section-125">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-133">&#182;</a>
+                <a class="pilcrow" href="#section-125">&#182;</a>
               </div>
               <h2 id="backbone-view">Backbone.View</h2>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-134">
+
+
+        <li id="section-126">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-134">&#182;</a>
+                <a class="pilcrow" href="#section-126">&#182;</a>
               </div>
-              
+
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-135">
+
+
+        <li id="section-127">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-135">&#182;</a>
+                <a class="pilcrow" href="#section-127">&#182;</a>
               </div>
               <p>Backbone Views are almost more convention than they are actual code. A View
 is simply a JavaScript object that represents a logical chunk of UI in the
@@ -2672,232 +2520,193 @@ having to worry about render order … and makes it easy for the view to
 react to specific changes in the state of your models.</p>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-136">
+
+
+        <li id="section-128">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-136">&#182;</a>
+                <a class="pilcrow" href="#section-128">&#182;</a>
               </div>
               <p>Creating a Backbone.View creates its initial element outside of the DOM,
 if an existing element is not provided…</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> View = Backbone.View = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
     <span class="hljs-keyword">this</span>.cid = _.uniqueId(<span class="hljs-string">'view'</span>);
     options || (options = {});
     _.extend(<span class="hljs-keyword">this</span>, _.pick(options, viewOptions));
     <span class="hljs-keyword">this</span>._ensureElement();
     <span class="hljs-keyword">this</span>.initialize.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
+    <span class="hljs-keyword">this</span>.delegateEvents();
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-137">
+
+
+        <li id="section-129">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-137">&#182;</a>
+                <a class="pilcrow" href="#section-129">&#182;</a>
               </div>
               <p>Cached regex to split keys for <code>delegate</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> delegateEventSplitter = <span class="hljs-regexp">/^(\S+)\s*(.*)$/</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-138">
+
+
+        <li id="section-130">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-138">&#182;</a>
+                <a class="pilcrow" href="#section-130">&#182;</a>
               </div>
               <p>List of view options to be merged as properties.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> viewOptions = [<span class="hljs-string">'model'</span>, <span class="hljs-string">'collection'</span>, <span class="hljs-string">'el'</span>, <span class="hljs-string">'id'</span>, <span class="hljs-string">'attributes'</span>, <span class="hljs-string">'className'</span>, <span class="hljs-string">'tagName'</span>, <span class="hljs-string">'events'</span>];</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-139">
+
+
+        <li id="section-131">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-139">&#182;</a>
+                <a class="pilcrow" href="#section-131">&#182;</a>
               </div>
               <p>Set up all inheritable <strong>Backbone.View</strong> properties and methods.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  _.extend(View.prototype, Events, {</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-140">
+
+
+        <li id="section-132">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-140">&#182;</a>
+                <a class="pilcrow" href="#section-132">&#182;</a>
               </div>
               <p>The default <code>tagName</code> of a View’s element is <code>&quot;div&quot;</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    tagName: <span class="hljs-string">'div'</span>,</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-141">
+
+
+        <li id="section-133">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-141">&#182;</a>
+                <a class="pilcrow" href="#section-133">&#182;</a>
               </div>
               <p>jQuery delegate for element lookup, scoped to DOM elements within the
 current view. This should be preferred to global lookups where possible.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    $: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(selector)</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.$el.find(selector);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-142">
+
+
+        <li id="section-134">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-142">&#182;</a>
+                <a class="pilcrow" href="#section-134">&#182;</a>
               </div>
               <p>Initialize is an empty function by default. Override it with your own
 initialization logic.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    initialize: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{},</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-143">
+
+
+        <li id="section-135">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-143">&#182;</a>
+                <a class="pilcrow" href="#section-135">&#182;</a>
               </div>
               <p><strong>render</strong> is the core function that your view should override, in order
 to populate its element (<code>this.el</code>), with the appropriate HTML. The
 convention is for <strong>render</strong> to always return <code>this</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    render: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-144">
+
+
+        <li id="section-136">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-144">&#182;</a>
+                <a class="pilcrow" href="#section-136">&#182;</a>
               </div>
               <p>Remove this view by taking the element out of the DOM, and removing any
 applicable Backbone.Events listeners.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    remove: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">this</span>._removeElement();
+      <span class="hljs-keyword">this</span>.$el.remove();
       <span class="hljs-keyword">this</span>.stopListening();
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-145">
+
+
+        <li id="section-137">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-145">&#182;</a>
+                <a class="pilcrow" href="#section-137">&#182;</a>
               </div>
-              <p>Remove this view’s element from the document and all event listeners
-attached to it. Exposed for subclasses using an alternative DOM
-manipulation API.</p>
+              <p>Change the view’s element (<code>this.el</code> property), including event
+re-delegation.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    _removeElement: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">this</span>.$el.remove();
-    },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-146">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-146">&#182;</a>
-              </div>
-              <p>Change the view’s element (<code>this.el</code> property) and re-delegate the
-view’s events on the new element.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    setElement: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(element)</span> </span>{
-      <span class="hljs-keyword">this</span>.undelegateEvents();
-      <span class="hljs-keyword">this</span>._setElement(element);
-      <span class="hljs-keyword">this</span>.delegateEvents();
+            <div class="content"><div class='highlight'><pre>    setElement: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(element, delegate)</span> </span>{
+      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.$el) <span class="hljs-keyword">this</span>.undelegateEvents();
+      <span class="hljs-keyword">this</span>.$el = element <span class="hljs-keyword">instanceof</span> Backbone.$ ? element : Backbone.$(element);
+      <span class="hljs-keyword">this</span>.el = <span class="hljs-keyword">this</span>.$el[<span class="hljs-number">0</span>];
+      <span class="hljs-keyword">if</span> (delegate !== <span class="hljs-literal">false</span>) <span class="hljs-keyword">this</span>.delegateEvents();
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-147">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-147">&#182;</a>
-              </div>
-              <p>Creates the <code>this.el</code> and <code>this.$el</code> references for this view using the
-given <code>el</code>. <code>el</code> can be a CSS selector or an HTML string, a jQuery
-context or an element. Subclasses can override this to utilize an
-alternative DOM manipulation API and are only required to set the
-<code>this.el</code> property.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    _setElement: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(el)</span> </span>{
-      <span class="hljs-keyword">this</span>.$el = el <span class="hljs-keyword">instanceof</span> Backbone.$ ? el : Backbone.$(el);
-      <span class="hljs-keyword">this</span>.el = <span class="hljs-keyword">this</span>.$el[<span class="hljs-number">0</span>];
-    },</pre></div></div>
-            
         </li>
-        
-        
-        <li id="section-148">
+
+
+        <li id="section-138">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-148">&#182;</a>
+                <a class="pilcrow" href="#section-138">&#182;</a>
               </div>
               <p>Set callbacks, where <code>this.events</code> is a hash of</p>
 <p><em>{“event selector”: “callback”}</em></p>
@@ -2908,10 +2717,12 @@ alternative DOM manipulation API and are only required to set the
 }
 </code></pre><p>pairs. Callbacks will be bound to the view, with <code>this</code> set properly.
 Uses event delegation for efficiency.
-Omitting the selector binds the event to <code>this.el</code>.</p>
+Omitting the selector binds the event to <code>this.el</code>.
+This only works for delegate-able events: not <code>focus</code>, <code>blur</code>, and
+not <code>change</code>, <code>submit</code>, and <code>reset</code> in Internet Explorer.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    delegateEvents: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(events)</span> </span>{
       <span class="hljs-keyword">if</span> (!(events || (events = _.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'events'</span>)))) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
       <span class="hljs-keyword">this</span>.undelegateEvents();
@@ -2919,95 +2730,48 @@ Omitting the selector binds the event to <code>this.el</code>.</p>
         <span class="hljs-keyword">var</span> method = events[key];
         <span class="hljs-keyword">if</span> (!_.isFunction(method)) method = <span class="hljs-keyword">this</span>[events[key]];
         <span class="hljs-keyword">if</span> (!method) <span class="hljs-keyword">continue</span>;
+
         <span class="hljs-keyword">var</span> match = key.match(delegateEventSplitter);
-        <span class="hljs-keyword">this</span>.delegate(match[<span class="hljs-number">1</span>], match[<span class="hljs-number">2</span>], _.bind(method, <span class="hljs-keyword">this</span>));
+        <span class="hljs-keyword">var</span> eventName = match[<span class="hljs-number">1</span>], selector = match[<span class="hljs-number">2</span>];
+        method = _.bind(method, <span class="hljs-keyword">this</span>);
+        eventName += <span class="hljs-string">'.delegateEvents'</span> + <span class="hljs-keyword">this</span>.cid;
+        <span class="hljs-keyword">if</span> (selector === <span class="hljs-string">''</span>) {
+          <span class="hljs-keyword">this</span>.$el.on(eventName, method);
+        } <span class="hljs-keyword">else</span> {
+          <span class="hljs-keyword">this</span>.$el.on(eventName, selector, method);
+        }
       }
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-149">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-149">&#182;</a>
-              </div>
-              <p>Add a single event listener to the view’s element (or a child element
-using <code>selector</code>). This only works for delegate-able events: not <code>focus</code>,
-<code>blur</code>, and not <code>change</code>, <code>submit</code>, and <code>reset</code> in Internet Explorer.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    delegate: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(eventName, selector, listener)</span> </span>{
-      <span class="hljs-keyword">this</span>.$el.on(eventName + <span class="hljs-string">'.delegateEvents'</span> + <span class="hljs-keyword">this</span>.cid, selector, listener);
-    },</pre></div></div>
-            
         </li>
-        
-        
-        <li id="section-150">
+
+
+        <li id="section-139">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-150">&#182;</a>
+                <a class="pilcrow" href="#section-139">&#182;</a>
               </div>
-              <p>Clears all callbacks previously bound to the view by <code>delegateEvents</code>.
+              <p>Clears all callbacks previously bound to the view with <code>delegateEvents</code>.
 You usually don’t need to use this, but may wish to if you have multiple
 Backbone views attached to the same DOM element.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    undelegateEvents: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.$el) <span class="hljs-keyword">this</span>.$el.off(<span class="hljs-string">'.delegateEvents'</span> + <span class="hljs-keyword">this</span>.cid);
+      <span class="hljs-keyword">this</span>.$el.off(<span class="hljs-string">'.delegateEvents'</span> + <span class="hljs-keyword">this</span>.cid);
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-151">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-151">&#182;</a>
-              </div>
-              <p>A finer-grained <code>undelegateEvents</code> for removing a single delegated event.
-<code>selector</code> and <code>listener</code> are both optional.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    undelegate: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(eventName, selector, listener)</span> </span>{
-      <span class="hljs-keyword">this</span>.$el.off(eventName + <span class="hljs-string">'.delegateEvents'</span> + <span class="hljs-keyword">this</span>.cid, selector, listener);
-    },</pre></div></div>
-            
         </li>
-        
-        
-        <li id="section-152">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-152">&#182;</a>
-              </div>
-              <p>Produces a DOM element to be assigned to your view. Exposed for
-subclasses using an alternative DOM manipulation API.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    _createElement: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(tagName)</span> </span>{
-      <span class="hljs-keyword">return</span> <span class="hljs-built_in">document</span>.createElement(tagName);
-    },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-153">
+
+        <li id="section-140">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-153">&#182;</a>
+                <a class="pilcrow" href="#section-140">&#182;</a>
               </div>
               <p>Ensure that the View has a DOM element to render into.
 If <code>this.el</code> is a string, pass it through <code>$()</code>, take the first
@@ -3015,72 +2779,54 @@ matching element, and re-assign it to <code>el</code>. Otherwise, create
 an element from the <code>id</code>, <code>className</code> and <code>tagName</code> properties.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _ensureElement: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>.el) {
         <span class="hljs-keyword">var</span> attrs = _.extend({}, _.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'attributes'</span>));
         <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.id) attrs.id = _.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'id'</span>);
         <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.className) attrs[<span class="hljs-string">'class'</span>] = _.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'className'</span>);
-        <span class="hljs-keyword">this</span>.setElement(<span class="hljs-keyword">this</span>._createElement(_.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'tagName'</span>)));
-        <span class="hljs-keyword">this</span>._setAttributes(attrs);
+        <span class="hljs-keyword">var</span> $el = Backbone.$(<span class="hljs-string">'&lt;'</span> + _.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'tagName'</span>) + <span class="hljs-string">'&gt;'</span>).attr(attrs);
+        <span class="hljs-keyword">this</span>.setElement($el, <span class="hljs-literal">false</span>);
       } <span class="hljs-keyword">else</span> {
-        <span class="hljs-keyword">this</span>.setElement(_.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'el'</span>));
+        <span class="hljs-keyword">this</span>.setElement(_.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'el'</span>), <span class="hljs-literal">false</span>);
       }
-    },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-154">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-154">&#182;</a>
-              </div>
-              <p>Set attributes from a hash on this view’s element.  Exposed for
-subclasses using an alternative DOM manipulation API.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    _setAttributes: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(attributes)</span> </span>{
-      <span class="hljs-keyword">this</span>.$el.attr(attributes);
     }
 
   });</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-155">
+
+
+        <li id="section-141">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-155">&#182;</a>
+                <a class="pilcrow" href="#section-141">&#182;</a>
               </div>
               <h2 id="backbone-sync">Backbone.sync</h2>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-156">
+
+
+        <li id="section-142">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-156">&#182;</a>
+                <a class="pilcrow" href="#section-142">&#182;</a>
               </div>
-              
+
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-157">
+
+
+        <li id="section-143">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-157">&#182;</a>
+                <a class="pilcrow" href="#section-143">&#182;</a>
               </div>
               <p>Override this function to change the manner in which Backbone persists
 models to the server. You will be passed the type of request, and the
@@ -3099,110 +2845,110 @@ Useful when interfacing with server-side languages like <strong>PHP</strong> tha
 it difficult to read the body of <code>PUT</code> requests.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Backbone.sync = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(method, model, options)</span> </span>{
     <span class="hljs-keyword">var</span> type = methodMap[method];</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-158">
+
+
+        <li id="section-144">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-158">&#182;</a>
+                <a class="pilcrow" href="#section-144">&#182;</a>
               </div>
               <p>Default options, unless specified.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _.defaults(options || (options = {}), {
       emulateHTTP: Backbone.emulateHTTP,
       emulateJSON: Backbone.emulateJSON
     });</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-159">
+
+
+        <li id="section-145">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-159">&#182;</a>
+                <a class="pilcrow" href="#section-145">&#182;</a>
               </div>
               <p>Default JSON-request options.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">var</span> params = {type: type, dataType: <span class="hljs-string">'json'</span>};</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-160">
+
+
+        <li id="section-146">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-160">&#182;</a>
+                <a class="pilcrow" href="#section-146">&#182;</a>
               </div>
               <p>Ensure that we have a URL.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (!options.url) {
       params.url = _.result(model, <span class="hljs-string">'url'</span>) || urlError();
     }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-161">
+
+
+        <li id="section-147">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-161">&#182;</a>
+                <a class="pilcrow" href="#section-147">&#182;</a>
               </div>
               <p>Ensure that we have the appropriate request data.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (options.data == <span class="hljs-literal">null</span> &amp;&amp; model &amp;&amp; (method === <span class="hljs-string">'create'</span> || method === <span class="hljs-string">'update'</span> || method === <span class="hljs-string">'patch'</span>)) {
       params.contentType = <span class="hljs-string">'application/json'</span>;
       params.data = <span class="hljs-built_in">JSON</span>.stringify(options.attrs || model.toJSON(options));
     }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-162">
+
+
+        <li id="section-148">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-162">&#182;</a>
+                <a class="pilcrow" href="#section-148">&#182;</a>
               </div>
               <p>For older servers, emulate JSON by encoding the request into an HTML-form.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (options.emulateJSON) {
       params.contentType = <span class="hljs-string">'application/x-www-form-urlencoded'</span>;
       params.data = params.data ? {model: params.data} : {};
     }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-163">
+
+
+        <li id="section-149">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-163">&#182;</a>
+                <a class="pilcrow" href="#section-149">&#182;</a>
               </div>
               <p>For older servers, emulate HTTP by mimicking the HTTP method with <code>_method</code>
 And an <code>X-HTTP-Method-Override</code> header.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (options.emulateHTTP &amp;&amp; (type === <span class="hljs-string">'PUT'</span> || type === <span class="hljs-string">'DELETE'</span> || type === <span class="hljs-string">'PATCH'</span>)) {
       params.type = <span class="hljs-string">'POST'</span>;
       <span class="hljs-keyword">if</span> (options.emulateJSON) params.data._method = type;
@@ -3212,75 +2958,80 @@ And an <code>X-HTTP-Method-Override</code> header.</p>
         <span class="hljs-keyword">if</span> (beforeSend) <span class="hljs-keyword">return</span> beforeSend.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
       };
     }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-164">
+
+
+        <li id="section-150">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-164">&#182;</a>
+                <a class="pilcrow" href="#section-150">&#182;</a>
               </div>
               <p>Don’t process data on a non-GET request.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (params.type !== <span class="hljs-string">'GET'</span> &amp;&amp; !options.emulateJSON) {
       params.processData = <span class="hljs-literal">false</span>;
     }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-165">
+
+
+        <li id="section-151">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-165">&#182;</a>
+                <a class="pilcrow" href="#section-151">&#182;</a>
               </div>
-              <p>Pass along <code>textStatus</code> and <code>errorThrown</code> from jQuery.</p>
+              <p>If we’re sending a <code>PATCH</code> request, and we’re in an old Internet Explorer
+that still has ActiveX enabled by default, override jQuery to use that
+for XHR instead. Remove this line when jQuery supports <code>PATCH</code> on IE8.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">var</span> error = options.error;
-    options.error = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(xhr, textStatus, errorThrown)</span> </span>{
-      options.textStatus = textStatus;
-      options.errorThrown = errorThrown;
-      <span class="hljs-keyword">if</span> (error) error.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
-    };</pre></div></div>
-            
+
+            <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (params.type === <span class="hljs-string">'PATCH'</span> &amp;&amp; noXhrPatch) {
+      params.xhr = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+        <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> ActiveXObject(<span class="hljs-string">"Microsoft.XMLHTTP"</span>);
+      };
+    }</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-166">
+
+
+        <li id="section-152">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-166">&#182;</a>
+                <a class="pilcrow" href="#section-152">&#182;</a>
               </div>
               <p>Make the request, allowing the user to override any Ajax options.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">var</span> xhr = options.xhr = Backbone.ajax(_.extend(params, options));
     model.trigger(<span class="hljs-string">'request'</span>, model, xhr, options);
     <span class="hljs-keyword">return</span> xhr;
-  };</pre></div></div>
-            
+  };
+
+  <span class="hljs-keyword">var</span> noXhrPatch =
+    <span class="hljs-keyword">typeof</span> <span class="hljs-built_in">window</span> !== <span class="hljs-string">'undefined'</span> &amp;&amp; !!<span class="hljs-built_in">window</span>.ActiveXObject &amp;&amp;
+      !(<span class="hljs-built_in">window</span>.XMLHttpRequest &amp;&amp; (<span class="hljs-keyword">new</span> XMLHttpRequest).dispatchEvent);</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-167">
+
+
+        <li id="section-153">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-167">&#182;</a>
+                <a class="pilcrow" href="#section-153">&#182;</a>
               </div>
               <p>Map from CRUD to HTTP for our default <code>Backbone.sync</code> implementation.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> methodMap = {
     <span class="hljs-string">'create'</span>: <span class="hljs-string">'POST'</span>,
     <span class="hljs-string">'update'</span>: <span class="hljs-string">'PUT'</span>,
@@ -3288,129 +3039,129 @@ And an <code>X-HTTP-Method-Override</code> header.</p>
     <span class="hljs-string">'delete'</span>: <span class="hljs-string">'DELETE'</span>,
     <span class="hljs-string">'read'</span>:   <span class="hljs-string">'GET'</span>
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-168">
+
+
+        <li id="section-154">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-168">&#182;</a>
+                <a class="pilcrow" href="#section-154">&#182;</a>
               </div>
               <p>Set the default implementation of <code>Backbone.ajax</code> to proxy through to <code>$</code>.
 Override this if you’d like to use a different library.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Backbone.ajax = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
     <span class="hljs-keyword">return</span> Backbone.$.ajax.apply(Backbone.$, <span class="hljs-built_in">arguments</span>);
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-169">
+
+
+        <li id="section-155">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-169">&#182;</a>
+                <a class="pilcrow" href="#section-155">&#182;</a>
               </div>
               <h2 id="backbone-router">Backbone.Router</h2>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-170">
+
+
+        <li id="section-156">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-170">&#182;</a>
+                <a class="pilcrow" href="#section-156">&#182;</a>
               </div>
-              
+
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-171">
+
+
+        <li id="section-157">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-171">&#182;</a>
+                <a class="pilcrow" href="#section-157">&#182;</a>
               </div>
               <p>Routers map faux-URLs to actions, and fire events when routes are
 matched. Creating a new one sets its <code>routes</code> hash, if not set statically.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> Router = Backbone.Router = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
     options || (options = {});
     <span class="hljs-keyword">if</span> (options.routes) <span class="hljs-keyword">this</span>.routes = options.routes;
     <span class="hljs-keyword">this</span>._bindRoutes();
     <span class="hljs-keyword">this</span>.initialize.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>);
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-172">
+
+
+        <li id="section-158">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-172">&#182;</a>
+                <a class="pilcrow" href="#section-158">&#182;</a>
               </div>
               <p>Cached regular expressions for matching named param parts and splatted
 parts of route strings.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> optionalParam = <span class="hljs-regexp">/\((.*?)\)/g</span>;
   <span class="hljs-keyword">var</span> namedParam    = <span class="hljs-regexp">/(\(\?)?:\w+/g</span>;
   <span class="hljs-keyword">var</span> splatParam    = <span class="hljs-regexp">/\*\w+/g</span>;
   <span class="hljs-keyword">var</span> escapeRegExp  = <span class="hljs-regexp">/[\-{}\[\]+?.,\\\^$|#\s]/g</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-173">
+
+
+        <li id="section-159">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-173">&#182;</a>
+                <a class="pilcrow" href="#section-159">&#182;</a>
               </div>
               <p>Set up all inheritable <strong>Backbone.Router</strong> properties and methods.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  _.extend(Router.prototype, Events, {</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-174">
+
+
+        <li id="section-160">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-174">&#182;</a>
+                <a class="pilcrow" href="#section-160">&#182;</a>
               </div>
               <p>Initialize is an empty function by default. Override it with your own
 initialization logic.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    initialize: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{},</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-175">
+
+
+        <li id="section-161">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-175">&#182;</a>
+                <a class="pilcrow" href="#section-161">&#182;</a>
               </div>
               <p>Manually bind a single named route to a callback. For example:</p>
 <pre><code><span class="hljs-keyword">this</span>.route(<span class="hljs-string">'search/:query/p:num'</span>, <span class="hljs-string">'search'</span>, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(query, num)</span> </span>{
@@ -3418,7 +3169,7 @@ initialization logic.</p>
 });
 </code></pre>
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    route: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(route, name, callback)</span> </span>{
       <span class="hljs-keyword">if</span> (!_.isRegExp(route)) route = <span class="hljs-keyword">this</span>._routeToRegExp(route);
       <span class="hljs-keyword">if</span> (_.isFunction(name)) {
@@ -3429,66 +3180,65 @@ initialization logic.</p>
       <span class="hljs-keyword">var</span> router = <span class="hljs-keyword">this</span>;
       Backbone.history.route(route, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(fragment)</span> </span>{
         <span class="hljs-keyword">var</span> args = router._extractParameters(route, fragment);
-        <span class="hljs-keyword">if</span> (router.execute(callback, args, name) !== <span class="hljs-literal">false</span>) {
-          router.trigger.apply(router, [<span class="hljs-string">'route:'</span> + name].concat(args));
-          router.trigger(<span class="hljs-string">'route'</span>, name, args);
-          Backbone.history.trigger(<span class="hljs-string">'route'</span>, router, name, args);
-        }
+        router.execute(callback, args);
+        router.trigger.apply(router, [<span class="hljs-string">'route:'</span> + name].concat(args));
+        router.trigger(<span class="hljs-string">'route'</span>, name, args);
+        Backbone.history.trigger(<span class="hljs-string">'route'</span>, router, name, args);
       });
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-176">
+
+
+        <li id="section-162">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-176">&#182;</a>
+                <a class="pilcrow" href="#section-162">&#182;</a>
               </div>
               <p>Execute a route handler with the provided parameters.  This is an
 excellent place to do pre-route setup or post-route cleanup.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    execute: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(callback, args, name)</span> </span>{
+
+            <div class="content"><div class='highlight'><pre>    execute: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(callback, args)</span> </span>{
       <span class="hljs-keyword">if</span> (callback) callback.apply(<span class="hljs-keyword">this</span>, args);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-177">
+
+
+        <li id="section-163">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-177">&#182;</a>
+                <a class="pilcrow" href="#section-163">&#182;</a>
               </div>
               <p>Simple proxy to <code>Backbone.history</code> to save a fragment into the history.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    navigate: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(fragment, options)</span> </span>{
       Backbone.history.navigate(fragment, options);
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-178">
+
+
+        <li id="section-164">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-178">&#182;</a>
+                <a class="pilcrow" href="#section-164">&#182;</a>
               </div>
               <p>Bind all defined routes to <code>Backbone.history</code>. We have to reverse the
 order of the routes here to support behavior where the most general
 routes can be defined at the bottom of the route map.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _bindRoutes: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
       <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>.routes) <span class="hljs-keyword">return</span>;
       <span class="hljs-keyword">this</span>.routes = _.result(<span class="hljs-keyword">this</span>, <span class="hljs-string">'routes'</span>);
@@ -3497,21 +3247,21 @@ routes can be defined at the bottom of the route map.</p>
         <span class="hljs-keyword">this</span>.route(route, <span class="hljs-keyword">this</span>.routes[route]);
       }
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-179">
+
+
+        <li id="section-165">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-179">&#182;</a>
+                <a class="pilcrow" href="#section-165">&#182;</a>
               </div>
               <p>Convert a route string into a regular expression, suitable for matching
 against the current location hash.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _routeToRegExp: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(route)</span> </span>{
       route = route.replace(escapeRegExp, <span class="hljs-string">'\\$&amp;'</span>)
                    .replace(optionalParam, <span class="hljs-string">'(?:$1)?'</span>)
@@ -3521,79 +3271,79 @@ against the current location hash.</p>
                    .replace(splatParam, <span class="hljs-string">'([^?]*?)'</span>);
       <span class="hljs-keyword">return</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">RegExp</span>(<span class="hljs-string">'^'</span> + route + <span class="hljs-string">'(?:\\?([\\s\\S]*))?$'</span>);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-180">
+
+
+        <li id="section-166">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-180">&#182;</a>
+                <a class="pilcrow" href="#section-166">&#182;</a>
               </div>
               <p>Given a route, and a URL fragment that it matches, return the array of
 extracted decoded parameters. Empty or unmatched parameters will be
 treated as <code>null</code> to normalize cross-browser behavior.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _extractParameters: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(route, fragment)</span> </span>{
       <span class="hljs-keyword">var</span> params = route.exec(fragment).slice(<span class="hljs-number">1</span>);
       <span class="hljs-keyword">return</span> _.map(params, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(param, i)</span> </span>{</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-181">
+
+
+        <li id="section-167">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-181">&#182;</a>
+                <a class="pilcrow" href="#section-167">&#182;</a>
               </div>
               <p>Don’t decode the search params.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> (i === params.length - <span class="hljs-number">1</span>) <span class="hljs-keyword">return</span> param || <span class="hljs-literal">null</span>;
         <span class="hljs-keyword">return</span> param ? <span class="hljs-built_in">decodeURIComponent</span>(param) : <span class="hljs-literal">null</span>;
       });
     }
 
   });</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-182">
+
+
+        <li id="section-168">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-182">&#182;</a>
+                <a class="pilcrow" href="#section-168">&#182;</a>
               </div>
               <h2 id="backbone-history">Backbone.History</h2>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-183">
+
+
+        <li id="section-169">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-183">&#182;</a>
+                <a class="pilcrow" href="#section-169">&#182;</a>
               </div>
-              
+
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-184">
+
+
+        <li id="section-170">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-184">&#182;</a>
+                <a class="pilcrow" href="#section-170">&#182;</a>
               </div>
               <p>Handles cross-browser history management, based on either
 <a href="http://diveintohtml5.info/history.html">pushState</a> and real URLs, or
@@ -3602,587 +3352,465 @@ and URL fragments. If the browser supports neither (old IE, natch),
 falls back to polling.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> History = Backbone.History = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
     <span class="hljs-keyword">this</span>.handlers = [];
     _.bindAll(<span class="hljs-keyword">this</span>, <span class="hljs-string">'checkUrl'</span>);</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-185">
+
+
+        <li id="section-171">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-185">&#182;</a>
+                <a class="pilcrow" href="#section-171">&#182;</a>
               </div>
               <p>Ensure that <code>History</code> can be used outside of the browser.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (<span class="hljs-keyword">typeof</span> <span class="hljs-built_in">window</span> !== <span class="hljs-string">'undefined'</span>) {
       <span class="hljs-keyword">this</span>.location = <span class="hljs-built_in">window</span>.location;
       <span class="hljs-keyword">this</span>.history = <span class="hljs-built_in">window</span>.history;
     }
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-186">
+
+
+        <li id="section-172">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-186">&#182;</a>
+                <a class="pilcrow" href="#section-172">&#182;</a>
               </div>
               <p>Cached regex for stripping a leading hash/slash and trailing space.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> routeStripper = <span class="hljs-regexp">/^[#\/]|\s+$/g</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-187">
+
+
+        <li id="section-173">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-187">&#182;</a>
+                <a class="pilcrow" href="#section-173">&#182;</a>
               </div>
               <p>Cached regex for stripping leading and trailing slashes.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> rootStripper = <span class="hljs-regexp">/^\/+|\/+$/g</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-188">
+
+
+        <li id="section-174">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-188">&#182;</a>
+                <a class="pilcrow" href="#section-174">&#182;</a>
+              </div>
+              <p>Cached regex for detecting MSIE.</p>
+
+            </div>
+
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> isExplorer = <span class="hljs-regexp">/msie [\w.]+/</span>;</pre></div></div>
+
+        </li>
+
+
+        <li id="section-175">
+            <div class="annotation">
+
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-175">&#182;</a>
+              </div>
+              <p>Cached regex for removing a trailing slash.</p>
+
+            </div>
+
+            <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> trailingSlash = <span class="hljs-regexp">/\/$/</span>;</pre></div></div>
+
+        </li>
+
+
+        <li id="section-176">
+            <div class="annotation">
+
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-176">&#182;</a>
               </div>
               <p>Cached regex for stripping urls of hash.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> pathStripper = <span class="hljs-regexp">/#.*$/</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-189">
+
+
+        <li id="section-177">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-189">&#182;</a>
+                <a class="pilcrow" href="#section-177">&#182;</a>
               </div>
               <p>Has the history handling already been started?</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  History.started = <span class="hljs-literal">false</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-190">
+
+
+        <li id="section-178">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-190">&#182;</a>
+                <a class="pilcrow" href="#section-178">&#182;</a>
               </div>
               <p>Set up all inheritable <strong>Backbone.History</strong> properties and methods.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  _.extend(History.prototype, Events, {</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-191">
+
+
+        <li id="section-179">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-191">&#182;</a>
+                <a class="pilcrow" href="#section-179">&#182;</a>
               </div>
               <p>The default interval to poll for hash changes, if necessary, is
 twenty times a second.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    interval: <span class="hljs-number">50</span>,</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-192">
+
+
+        <li id="section-180">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-192">&#182;</a>
+                <a class="pilcrow" href="#section-180">&#182;</a>
               </div>
               <p>Are we at the app root?</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    atRoot: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">var</span> path = <span class="hljs-keyword">this</span>.location.pathname.replace(<span class="hljs-regexp">/[^\/]$/</span>, <span class="hljs-string">'$&amp;/'</span>);
-      <span class="hljs-keyword">return</span> path === <span class="hljs-keyword">this</span>.root &amp;&amp; !<span class="hljs-keyword">this</span>.getSearch();
-    },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-193">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-193">&#182;</a>
-              </div>
-              <p>In IE6, the hash fragment and search params are incorrect if the
-fragment contains <code>?</code>.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    getSearch: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">var</span> match = <span class="hljs-keyword">this</span>.location.href.replace(<span class="hljs-regexp">/#.*/</span>, <span class="hljs-string">''</span>).match(<span class="hljs-regexp">/\?.+/</span>);
-      <span class="hljs-keyword">return</span> match ? match[<span class="hljs-number">0</span>] : <span class="hljs-string">''</span>;
+            <div class="content"><div class='highlight'><pre>    atRoot: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+      <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.location.pathname.replace(<span class="hljs-regexp">/[^\/]$/</span>, <span class="hljs-string">'$&amp;/'</span>) === <span class="hljs-keyword">this</span>.root;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-194">
+
+
+        <li id="section-181">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-194">&#182;</a>
+                <a class="pilcrow" href="#section-181">&#182;</a>
               </div>
               <p>Gets the true hash value. Cannot use location.hash directly due to bug
 in Firefox where location.hash will always be decoded.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    getHash: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(window)</span> </span>{
       <span class="hljs-keyword">var</span> match = (<span class="hljs-built_in">window</span> || <span class="hljs-keyword">this</span>).location.href.match(<span class="hljs-regexp">/#(.*)$/</span>);
       <span class="hljs-keyword">return</span> match ? match[<span class="hljs-number">1</span>] : <span class="hljs-string">''</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-195">
+
+
+        <li id="section-182">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-195">&#182;</a>
+                <a class="pilcrow" href="#section-182">&#182;</a>
               </div>
-              <p>Get the pathname and search params, without the root.</p>
+              <p>Get the cross-browser normalized URL fragment, either from the URL,
+the hash, or the override.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    getPath: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
-      <span class="hljs-keyword">var</span> path = <span class="hljs-built_in">decodeURI</span>(<span class="hljs-keyword">this</span>.location.pathname + <span class="hljs-keyword">this</span>.getSearch());
-      <span class="hljs-keyword">var</span> root = <span class="hljs-keyword">this</span>.root.slice(<span class="hljs-number">0</span>, -<span class="hljs-number">1</span>);
-      <span class="hljs-keyword">if</span> (!path.indexOf(root)) path = path.slice(root.length);
-      <span class="hljs-keyword">return</span> path.charAt(<span class="hljs-number">0</span>) === <span class="hljs-string">'/'</span> ? path.slice(<span class="hljs-number">1</span>) : path;
-    },</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-196">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-196">&#182;</a>
-              </div>
-              <p>Get the cross-browser normalized URL fragment from the path or hash.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>    getFragment: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(fragment)</span> </span>{
+            <div class="content"><div class='highlight'><pre>    getFragment: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(fragment, forcePushState)</span> </span>{
       <span class="hljs-keyword">if</span> (fragment == <span class="hljs-literal">null</span>) {
-        <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._hasPushState || !<span class="hljs-keyword">this</span>._wantsHashChange) {
-          fragment = <span class="hljs-keyword">this</span>.getPath();
+        <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._hasPushState || !<span class="hljs-keyword">this</span>._wantsHashChange || forcePushState) {
+          fragment = <span class="hljs-built_in">decodeURI</span>(<span class="hljs-keyword">this</span>.location.pathname + <span class="hljs-keyword">this</span>.location.search);
+          <span class="hljs-keyword">var</span> root = <span class="hljs-keyword">this</span>.root.replace(trailingSlash, <span class="hljs-string">''</span>);
+          <span class="hljs-keyword">if</span> (!fragment.indexOf(root)) fragment = fragment.slice(root.length);
         } <span class="hljs-keyword">else</span> {
           fragment = <span class="hljs-keyword">this</span>.getHash();
         }
       }
       <span class="hljs-keyword">return</span> fragment.replace(routeStripper, <span class="hljs-string">''</span>);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-197">
+
+
+        <li id="section-183">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-197">&#182;</a>
+                <a class="pilcrow" href="#section-183">&#182;</a>
               </div>
               <p>Start the hash change handling, returning <code>true</code> if the current URL matches
 an existing route, and <code>false</code> otherwise.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    start: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(options)</span> </span>{
-      <span class="hljs-keyword">if</span> (History.started) <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">'Backbone.history has already been started'</span>);
+      <span class="hljs-keyword">if</span> (History.started) <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">"Backbone.history has already been started"</span>);
       History.started = <span class="hljs-literal">true</span>;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-198">
+
+
+        <li id="section-184">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-198">&#182;</a>
+                <a class="pilcrow" href="#section-184">&#182;</a>
               </div>
               <p>Figure out the initial configuration. Do we need an iframe?
 Is pushState desired … is it available?</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">this</span>.options          = _.extend({root: <span class="hljs-string">'/'</span>}, <span class="hljs-keyword">this</span>.options, options);
       <span class="hljs-keyword">this</span>.root             = <span class="hljs-keyword">this</span>.options.root;
       <span class="hljs-keyword">this</span>._wantsHashChange = <span class="hljs-keyword">this</span>.options.hashChange !== <span class="hljs-literal">false</span>;
-      <span class="hljs-keyword">this</span>._hasHashChange   = <span class="hljs-string">'onhashchange'</span> <span class="hljs-keyword">in</span> <span class="hljs-built_in">window</span>;
       <span class="hljs-keyword">this</span>._wantsPushState  = !!<span class="hljs-keyword">this</span>.options.pushState;
       <span class="hljs-keyword">this</span>._hasPushState    = !!(<span class="hljs-keyword">this</span>.options.pushState &amp;&amp; <span class="hljs-keyword">this</span>.history &amp;&amp; <span class="hljs-keyword">this</span>.history.pushState);
-      <span class="hljs-keyword">this</span>.fragment         = <span class="hljs-keyword">this</span>.getFragment();</pre></div></div>
-            
+      <span class="hljs-keyword">var</span> fragment          = <span class="hljs-keyword">this</span>.getFragment();
+      <span class="hljs-keyword">var</span> docMode           = <span class="hljs-built_in">document</span>.documentMode;
+      <span class="hljs-keyword">var</span> oldIE             = (isExplorer.exec(navigator.userAgent.toLowerCase()) &amp;&amp; (!docMode || docMode &lt;= <span class="hljs-number">7</span>));</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-199">
+
+
+        <li id="section-185">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-199">&#182;</a>
+                <a class="pilcrow" href="#section-185">&#182;</a>
               </div>
               <p>Normalize root to always include a leading and trailing slash.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">this</span>.root = (<span class="hljs-string">'/'</span> + <span class="hljs-keyword">this</span>.root + <span class="hljs-string">'/'</span>).replace(rootStripper, <span class="hljs-string">'/'</span>);</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-200">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-200">&#182;</a>
-              </div>
-              <p>Transition from hashChange to pushState or vice versa if both are
-requested.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._wantsHashChange &amp;&amp; <span class="hljs-keyword">this</span>._wantsPushState) {</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-201">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-201">&#182;</a>
-              </div>
-              <p>If we’ve started off with a route from a <code>pushState</code>-enabled
-browser, but we’re currently in a browser that doesn’t support it…</p>
+            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">this</span>.root = (<span class="hljs-string">'/'</span> + <span class="hljs-keyword">this</span>.root + <span class="hljs-string">'/'</span>).replace(rootStripper, <span class="hljs-string">'/'</span>);
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>._hasPushState &amp;&amp; !<span class="hljs-keyword">this</span>.atRoot()) {
-          <span class="hljs-keyword">var</span> root = <span class="hljs-keyword">this</span>.root.slice(<span class="hljs-number">0</span>, -<span class="hljs-number">1</span>) || <span class="hljs-string">'/'</span>;
-          <span class="hljs-keyword">this</span>.location.replace(root + <span class="hljs-string">'#'</span> + <span class="hljs-keyword">this</span>.getPath());</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-202">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-202">&#182;</a>
-              </div>
-              <p>Return immediately as browser will do redirect to new url</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>          <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>;</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-203">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-203">&#182;</a>
-              </div>
-              <p>Or if we’ve started out with a hash-based route, but we’re currently
-in a browser where it could be <code>pushState</code>-based instead…</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>        } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._hasPushState &amp;&amp; <span class="hljs-keyword">this</span>.atRoot()) {
-          <span class="hljs-keyword">this</span>.navigate(<span class="hljs-keyword">this</span>.getHash(), {replace: <span class="hljs-literal">true</span>});
-        }
-
+      <span class="hljs-keyword">if</span> (oldIE &amp;&amp; <span class="hljs-keyword">this</span>._wantsHashChange) {
+        <span class="hljs-keyword">var</span> frame = Backbone.$(<span class="hljs-string">'&lt;iframe src="javascript:0" tabindex="-1"&gt;'</span>);
+        <span class="hljs-keyword">this</span>.iframe = frame.hide().appendTo(<span class="hljs-string">'body'</span>)[<span class="hljs-number">0</span>].contentWindow;
+        <span class="hljs-keyword">this</span>.navigate(fragment);
       }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-204">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-204">&#182;</a>
-              </div>
-              <p>Proxy an iframe to handle location events if the browser doesn’t
-support the <code>hashchange</code> event, HTML5 history, or the user wants
-<code>hashChange</code> but not <code>pushState</code>.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>._hasHashChange &amp;&amp; <span class="hljs-keyword">this</span>._wantsHashChange &amp;&amp; (!<span class="hljs-keyword">this</span>._wantsPushState || !<span class="hljs-keyword">this</span>._hasPushState)) {
-        <span class="hljs-keyword">var</span> iframe = <span class="hljs-built_in">document</span>.createElement(<span class="hljs-string">'iframe'</span>);
-        iframe.src = <span class="hljs-string">'javascript:0'</span>;
-        iframe.style.display = <span class="hljs-string">'none'</span>;
-        iframe.tabIndex = -<span class="hljs-number">1</span>;
-        <span class="hljs-keyword">var</span> body = <span class="hljs-built_in">document</span>.body;</pre></div></div>
-            
         </li>
-        
-        
-        <li id="section-205">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-205">&#182;</a>
-              </div>
-              <p>Using <code>appendChild</code> will throw on IE &lt; 9 if the document is not ready.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">this</span>.iframe = body.insertBefore(iframe, body.firstChild).contentWindow;
-        <span class="hljs-keyword">this</span>.iframe.document.open().close();
-        <span class="hljs-keyword">this</span>.iframe.location.hash = <span class="hljs-string">'#'</span> + <span class="hljs-keyword">this</span>.fragment;
-      }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-206">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-206">&#182;</a>
-              </div>
-              <p>Add a cross-platform <code>addEventListener</code> shim for older browsers.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">var</span> addEventListener = <span class="hljs-built_in">window</span>.addEventListener || <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(eventName, listener)</span> </span>{
-        <span class="hljs-keyword">return</span> attachEvent(<span class="hljs-string">'on'</span> + eventName, listener);
-      };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-207">
+        <li id="section-186">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-207">&#182;</a>
+                <a class="pilcrow" href="#section-186">&#182;</a>
               </div>
               <p>Depending on whether we’re using pushState or hashes, and whether
 ‘onhashchange’ is supported, determine how we check the URL state.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._hasPushState) {
-        addEventListener(<span class="hljs-string">'popstate'</span>, <span class="hljs-keyword">this</span>.checkUrl, <span class="hljs-literal">false</span>);
-      } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._wantsHashChange &amp;&amp; <span class="hljs-keyword">this</span>._hasHashChange &amp;&amp; !<span class="hljs-keyword">this</span>.iframe) {
-        addEventListener(<span class="hljs-string">'hashchange'</span>, <span class="hljs-keyword">this</span>.checkUrl, <span class="hljs-literal">false</span>);
+        Backbone.$(<span class="hljs-built_in">window</span>).on(<span class="hljs-string">'popstate'</span>, <span class="hljs-keyword">this</span>.checkUrl);
+      } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._wantsHashChange &amp;&amp; (<span class="hljs-string">'onhashchange'</span> <span class="hljs-keyword">in</span> <span class="hljs-built_in">window</span>) &amp;&amp; !oldIE) {
+        Backbone.$(<span class="hljs-built_in">window</span>).on(<span class="hljs-string">'hashchange'</span>, <span class="hljs-keyword">this</span>.checkUrl);
       } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._wantsHashChange) {
         <span class="hljs-keyword">this</span>._checkUrlInterval = setInterval(<span class="hljs-keyword">this</span>.checkUrl, <span class="hljs-keyword">this</span>.interval);
+      }</pre></div></div>
+
+        </li>
+
+
+        <li id="section-187">
+            <div class="annotation">
+
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-187">&#182;</a>
+              </div>
+              <p>Determine if we need to change the base url, for a pushState link
+opened by a non-pushState browser.</p>
+
+            </div>
+
+            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">this</span>.fragment = fragment;
+      <span class="hljs-keyword">var</span> loc = <span class="hljs-keyword">this</span>.location;</pre></div></div>
+
+        </li>
+
+
+        <li id="section-188">
+            <div class="annotation">
+
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-188">&#182;</a>
+              </div>
+              <p>Transition from hashChange to pushState or vice versa if both are
+requested.</p>
+
+            </div>
+
+            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._wantsHashChange &amp;&amp; <span class="hljs-keyword">this</span>._wantsPushState) {</pre></div></div>
+
+        </li>
+
+
+        <li id="section-189">
+            <div class="annotation">
+
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-189">&#182;</a>
+              </div>
+              <p>If we’ve started off with a route from a <code>pushState</code>-enabled
+browser, but we’re currently in a browser that doesn’t support it…</p>
+
+            </div>
+
+            <div class="content"><div class='highlight'><pre>        <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>._hasPushState &amp;&amp; !<span class="hljs-keyword">this</span>.atRoot()) {
+          <span class="hljs-keyword">this</span>.fragment = <span class="hljs-keyword">this</span>.getFragment(<span class="hljs-literal">null</span>, <span class="hljs-literal">true</span>);
+          <span class="hljs-keyword">this</span>.location.replace(<span class="hljs-keyword">this</span>.root + <span class="hljs-string">'#'</span> + <span class="hljs-keyword">this</span>.fragment);</pre></div></div>
+
+        </li>
+
+
+        <li id="section-190">
+            <div class="annotation">
+
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-190">&#182;</a>
+              </div>
+              <p>Return immediately as browser will do redirect to new url</p>
+
+            </div>
+
+            <div class="content"><div class='highlight'><pre>          <span class="hljs-keyword">return</span> <span class="hljs-literal">true</span>;</pre></div></div>
+
+        </li>
+
+
+        <li id="section-191">
+            <div class="annotation">
+
+              <div class="pilwrap ">
+                <a class="pilcrow" href="#section-191">&#182;</a>
+              </div>
+              <p>Or if we’ve started out with a hash-based route, but we’re currently
+in a browser where it could be <code>pushState</code>-based instead…</p>
+
+            </div>
+
+            <div class="content"><div class='highlight'><pre>        } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._hasPushState &amp;&amp; <span class="hljs-keyword">this</span>.atRoot() &amp;&amp; loc.hash) {
+          <span class="hljs-keyword">this</span>.fragment = <span class="hljs-keyword">this</span>.getHash().replace(routeStripper, <span class="hljs-string">''</span>);
+          <span class="hljs-keyword">this</span>.history.replaceState({}, <span class="hljs-built_in">document</span>.title, <span class="hljs-keyword">this</span>.root + <span class="hljs-keyword">this</span>.fragment);
+        }
+
       }
 
       <span class="hljs-keyword">if</span> (!<span class="hljs-keyword">this</span>.options.silent) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.loadUrl();
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-208">
+
+
+        <li id="section-192">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-208">&#182;</a>
+                <a class="pilcrow" href="#section-192">&#182;</a>
               </div>
               <p>Disable Backbone.history, perhaps temporarily. Not useful in a real app,
 but possibly useful for unit testing Routers.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>    stop: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-209">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-209">&#182;</a>
-              </div>
-              <p>Add a cross-platform <code>removeEventListener</code> shim for older browsers.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">var</span> removeEventListener = <span class="hljs-built_in">window</span>.removeEventListener || <span class="hljs-function"><span class="hljs-keyword">function</span> <span class="hljs-params">(eventName, listener)</span> </span>{
-        <span class="hljs-keyword">return</span> detachEvent(<span class="hljs-string">'on'</span> + eventName, listener);
-      };</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-210">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-210">&#182;</a>
-              </div>
-              <p>Remove window listeners.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._hasPushState) {
-        removeEventListener(<span class="hljs-string">'popstate'</span>, <span class="hljs-keyword">this</span>.checkUrl, <span class="hljs-literal">false</span>);
-      } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._wantsHashChange &amp;&amp; <span class="hljs-keyword">this</span>._hasHashChange &amp;&amp; !<span class="hljs-keyword">this</span>.iframe) {
-        removeEventListener(<span class="hljs-string">'hashchange'</span>, <span class="hljs-keyword">this</span>.checkUrl, <span class="hljs-literal">false</span>);
-      }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-211">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-211">&#182;</a>
-              </div>
-              <p>Clean up the iframe if necessary.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.iframe) {
-        <span class="hljs-built_in">document</span>.body.removeChild(<span class="hljs-keyword">this</span>.iframe.frameElement);
-        <span class="hljs-keyword">this</span>.iframe = <span class="hljs-literal">null</span>;
-      }</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-212">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-212">&#182;</a>
-              </div>
-              <p>Some environments will throw when clearing an undefined interval.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._checkUrlInterval) clearInterval(<span class="hljs-keyword">this</span>._checkUrlInterval);
+            <div class="content"><div class='highlight'><pre>    stop: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
+      Backbone.$(<span class="hljs-built_in">window</span>).off(<span class="hljs-string">'popstate'</span>, <span class="hljs-keyword">this</span>.checkUrl).off(<span class="hljs-string">'hashchange'</span>, <span class="hljs-keyword">this</span>.checkUrl);
+      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._checkUrlInterval) clearInterval(<span class="hljs-keyword">this</span>._checkUrlInterval);
       History.started = <span class="hljs-literal">false</span>;
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-213">
+
+
+        <li id="section-193">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-213">&#182;</a>
+                <a class="pilcrow" href="#section-193">&#182;</a>
               </div>
               <p>Add a route to be tested when the fragment changes. Routes added later
 may override previous routes.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    route: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(route, callback)</span> </span>{
       <span class="hljs-keyword">this</span>.handlers.unshift({route: route, callback: callback});
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-214">
+
+
+        <li id="section-194">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-214">&#182;</a>
+                <a class="pilcrow" href="#section-194">&#182;</a>
               </div>
               <p>Checks the current URL to see if it has changed, and if it has,
 calls <code>loadUrl</code>, normalizing across the hidden iframe.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    checkUrl: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(e)</span> </span>{
-      <span class="hljs-keyword">var</span> current = <span class="hljs-keyword">this</span>.getFragment();</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-215">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-215">&#182;</a>
-              </div>
-              <p>If the user pressed the back button, the iframe’s hash will have
-changed and we should use that for comparison.</p>
-
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (current === <span class="hljs-keyword">this</span>.fragment &amp;&amp; <span class="hljs-keyword">this</span>.iframe) {
-        current = <span class="hljs-keyword">this</span>.getHash(<span class="hljs-keyword">this</span>.iframe);
+      <span class="hljs-keyword">var</span> current = <span class="hljs-keyword">this</span>.getFragment();
+      <span class="hljs-keyword">if</span> (current === <span class="hljs-keyword">this</span>.fragment &amp;&amp; <span class="hljs-keyword">this</span>.iframe) {
+        current = <span class="hljs-keyword">this</span>.getFragment(<span class="hljs-keyword">this</span>.getHash(<span class="hljs-keyword">this</span>.iframe));
       }
-
       <span class="hljs-keyword">if</span> (current === <span class="hljs-keyword">this</span>.fragment) <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
       <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.iframe) <span class="hljs-keyword">this</span>.navigate(current);
       <span class="hljs-keyword">this</span>.loadUrl();
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-216">
+
+
+        <li id="section-195">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-216">&#182;</a>
+                <a class="pilcrow" href="#section-195">&#182;</a>
               </div>
               <p>Attempt to load the current URL fragment. If a route succeeds with a
 match, returns <code>true</code>. If no defined routes matches the fragment,
 returns <code>false</code>.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    loadUrl: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(fragment)</span> </span>{
       fragment = <span class="hljs-keyword">this</span>.fragment = <span class="hljs-keyword">this</span>.getFragment(fragment);
       <span class="hljs-keyword">return</span> _.any(<span class="hljs-keyword">this</span>.handlers, <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(handler)</span> </span>{
@@ -4192,15 +3820,15 @@ returns <code>false</code>.</p>
         }
       });
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-217">
+
+
+        <li id="section-196">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-217">&#182;</a>
+                <a class="pilcrow" href="#section-196">&#182;</a>
               </div>
               <p>Save a fragment into the hash history, or replace the URL state if the
 ‘replace’ option is passed. You are responsible for properly URL-encoding
@@ -4210,368 +3838,351 @@ route callback be fired (not usually desirable), or <code>replace: true</code>, 
 you wish to modify the current URL without adding an entry to the history.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    navigate: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(fragment, options)</span> </span>{
       <span class="hljs-keyword">if</span> (!History.started) <span class="hljs-keyword">return</span> <span class="hljs-literal">false</span>;
-      <span class="hljs-keyword">if</span> (!options || options === <span class="hljs-literal">true</span>) options = {trigger: !!options};</pre></div></div>
-            
+      <span class="hljs-keyword">if</span> (!options || options === <span class="hljs-literal">true</span>) options = {trigger: !!options};
+
+      <span class="hljs-keyword">var</span> url = <span class="hljs-keyword">this</span>.root + (fragment = <span class="hljs-keyword">this</span>.getFragment(fragment || <span class="hljs-string">''</span>));</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-218">
+
+
+        <li id="section-197">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-218">&#182;</a>
+                <a class="pilcrow" href="#section-197">&#182;</a>
               </div>
-              <p>Normalize the fragment.</p>
+              <p>Strip the hash for matching.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>      fragment = <span class="hljs-keyword">this</span>.getFragment(fragment || <span class="hljs-string">''</span>);</pre></div></div>
-            
+
+            <div class="content"><div class='highlight'><pre>      fragment = fragment.replace(pathStripper, <span class="hljs-string">''</span>);
+
+      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.fragment === fragment) <span class="hljs-keyword">return</span>;
+      <span class="hljs-keyword">this</span>.fragment = fragment;</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-219">
+
+
+        <li id="section-198">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-219">&#182;</a>
+                <a class="pilcrow" href="#section-198">&#182;</a>
               </div>
               <p>Don’t include a trailing slash on the root.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">var</span> root = <span class="hljs-keyword">this</span>.root;
-      <span class="hljs-keyword">if</span> (fragment === <span class="hljs-string">''</span> || fragment.charAt(<span class="hljs-number">0</span>) === <span class="hljs-string">'?'</span>) {
-        root = root.slice(<span class="hljs-number">0</span>, -<span class="hljs-number">1</span>) || <span class="hljs-string">'/'</span>;
-      }
-      <span class="hljs-keyword">var</span> url = root + fragment;</pre></div></div>
-            
-        </li>
-        
-        
-        <li id="section-220">
-            <div class="annotation">
-              
-              <div class="pilwrap ">
-                <a class="pilcrow" href="#section-220">&#182;</a>
-              </div>
-              <p>Strip the hash and decode for matching.</p>
 
-            </div>
-            
-            <div class="content"><div class='highlight'><pre>      fragment = <span class="hljs-built_in">decodeURI</span>(fragment.replace(pathStripper, <span class="hljs-string">''</span>));
+            <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (fragment === <span class="hljs-string">''</span> &amp;&amp; url !== <span class="hljs-string">'/'</span>) url = url.slice(<span class="hljs-number">0</span>, -<span class="hljs-number">1</span>);</pre></div></div>
 
-      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.fragment === fragment) <span class="hljs-keyword">return</span>;
-      <span class="hljs-keyword">this</span>.fragment = fragment;</pre></div></div>
-            
         </li>
-        
-        
-        <li id="section-221">
+
+
+        <li id="section-199">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-221">&#182;</a>
+                <a class="pilcrow" href="#section-199">&#182;</a>
               </div>
               <p>If pushState is available, we use it to set the fragment as a real URL.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._hasPushState) {
         <span class="hljs-keyword">this</span>.history[options.replace ? <span class="hljs-string">'replaceState'</span> : <span class="hljs-string">'pushState'</span>]({}, <span class="hljs-built_in">document</span>.title, url);</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-222">
+
+
+        <li id="section-200">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-222">&#182;</a>
+                <a class="pilcrow" href="#section-200">&#182;</a>
               </div>
               <p>If hash changes haven’t been explicitly disabled, update the hash
 fragment to store history.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      } <span class="hljs-keyword">else</span> <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>._wantsHashChange) {
         <span class="hljs-keyword">this</span>._updateHash(<span class="hljs-keyword">this</span>.location, fragment, options.replace);
-        <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.iframe &amp;&amp; (fragment !== <span class="hljs-keyword">this</span>.getHash(<span class="hljs-keyword">this</span>.iframe))) {</pre></div></div>
-            
+        <span class="hljs-keyword">if</span> (<span class="hljs-keyword">this</span>.iframe &amp;&amp; (fragment !== <span class="hljs-keyword">this</span>.getFragment(<span class="hljs-keyword">this</span>.getHash(<span class="hljs-keyword">this</span>.iframe)))) {</pre></div></div>
+
         </li>
-        
-        
-        <li id="section-223">
+
+
+        <li id="section-201">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-223">&#182;</a>
+                <a class="pilcrow" href="#section-201">&#182;</a>
               </div>
               <p>Opening and closing the iframe tricks IE7 and earlier to push a
 history entry on hash-tag change.  When replace is true, we don’t
 want this.</p>
 
             </div>
-            
-            <div class="content"><div class='highlight'><pre>          <span class="hljs-keyword">if</span> (!options.replace) <span class="hljs-keyword">this</span>.iframe.document.open().close();
+
+            <div class="content"><div class='highlight'><pre>          <span class="hljs-keyword">if</span>(!options.replace) <span class="hljs-keyword">this</span>.iframe.document.open().close();
           <span class="hljs-keyword">this</span>._updateHash(<span class="hljs-keyword">this</span>.iframe.location, fragment, options.replace);
         }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-224">
+
+
+        <li id="section-202">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-224">&#182;</a>
+                <a class="pilcrow" href="#section-202">&#182;</a>
               </div>
               <p>If you’ve told us that you explicitly don’t want fallback hashchange-
 based history, then <code>navigate</code> becomes a page refresh.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>      } <span class="hljs-keyword">else</span> {
         <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.location.assign(url);
       }
       <span class="hljs-keyword">if</span> (options.trigger) <span class="hljs-keyword">return</span> <span class="hljs-keyword">this</span>.loadUrl(fragment);
     },</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-225">
+
+
+        <li id="section-203">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-225">&#182;</a>
+                <a class="pilcrow" href="#section-203">&#182;</a>
               </div>
               <p>Update the hash location, either replacing the current entry, or adding
 a new one to the browser history.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _updateHash: <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(location, fragment, replace)</span> </span>{
       <span class="hljs-keyword">if</span> (replace) {
         <span class="hljs-keyword">var</span> href = location.href.replace(<span class="hljs-regexp">/(javascript:|#).*$/</span>, <span class="hljs-string">''</span>);
         location.replace(href + <span class="hljs-string">'#'</span> + fragment);
       } <span class="hljs-keyword">else</span> {</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-226">
+
+
+        <li id="section-204">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-226">&#182;</a>
+                <a class="pilcrow" href="#section-204">&#182;</a>
               </div>
               <p>Some browsers require that <code>hash</code> contains a leading #.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>        location.hash = <span class="hljs-string">'#'</span> + fragment;
       }
     }
 
   });</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-227">
+
+
+        <li id="section-205">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-227">&#182;</a>
+                <a class="pilcrow" href="#section-205">&#182;</a>
               </div>
               <p>Create the default Backbone.history.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Backbone.history = <span class="hljs-keyword">new</span> History;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-228">
+
+
+        <li id="section-206">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-228">&#182;</a>
+                <a class="pilcrow" href="#section-206">&#182;</a>
               </div>
               <h2 id="helpers">Helpers</h2>
 
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-229">
+
+
+        <li id="section-207">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-229">&#182;</a>
+                <a class="pilcrow" href="#section-207">&#182;</a>
               </div>
-              
+
             </div>
-            
+
         </li>
-        
-        
-        <li id="section-230">
+
+
+        <li id="section-208">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-230">&#182;</a>
+                <a class="pilcrow" href="#section-208">&#182;</a>
               </div>
               <p>Helper function to correctly set up the prototype chain, for subclasses.
 Similar to <code>goog.inherits</code>, but uses a hash of prototype properties and
 class properties to be extended.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> extend = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(protoProps, staticProps)</span> </span>{
     <span class="hljs-keyword">var</span> parent = <span class="hljs-keyword">this</span>;
     <span class="hljs-keyword">var</span> child;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-231">
+
+
+        <li id="section-209">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-231">&#182;</a>
+                <a class="pilcrow" href="#section-209">&#182;</a>
               </div>
               <p>The constructor function for the new subclass is either defined by you
 (the “constructor” property in your <code>extend</code> definition), or defaulted
 by us to simply call the parent’s constructor.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (protoProps &amp;&amp; _.has(protoProps, <span class="hljs-string">'constructor'</span>)) {
       child = protoProps.constructor;
     } <span class="hljs-keyword">else</span> {
       child = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{ <span class="hljs-keyword">return</span> parent.apply(<span class="hljs-keyword">this</span>, <span class="hljs-built_in">arguments</span>); };
     }</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-232">
+
+
+        <li id="section-210">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-232">&#182;</a>
+                <a class="pilcrow" href="#section-210">&#182;</a>
               </div>
               <p>Add static properties to the constructor function, if supplied.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    _.extend(child, parent, staticProps);</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-233">
+
+
+        <li id="section-211">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-233">&#182;</a>
+                <a class="pilcrow" href="#section-211">&#182;</a>
               </div>
               <p>Set the prototype chain to inherit from <code>parent</code>, without calling
 <code>parent</code>‘s constructor function.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">var</span> Surrogate = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span></span>{ <span class="hljs-keyword">this</span>.constructor = child; };
     Surrogate.prototype = parent.prototype;
     child.prototype = <span class="hljs-keyword">new</span> Surrogate;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-234">
+
+
+        <li id="section-212">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-234">&#182;</a>
+                <a class="pilcrow" href="#section-212">&#182;</a>
               </div>
               <p>Add prototype properties (instance properties) to the subclass,
 if supplied.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    <span class="hljs-keyword">if</span> (protoProps) _.extend(child.prototype, protoProps);</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-235">
+
+
+        <li id="section-213">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-235">&#182;</a>
+                <a class="pilcrow" href="#section-213">&#182;</a>
               </div>
               <p>Set a convenience property in case the parent’s prototype is needed
 later.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>    child.__super__ = parent.prototype;
 
     <span class="hljs-keyword">return</span> child;
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-236">
+
+
+        <li id="section-214">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-236">&#182;</a>
+                <a class="pilcrow" href="#section-214">&#182;</a>
               </div>
               <p>Set up inheritance for the model, collection, router, view and history.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  Model.extend = Collection.extend = Router.extend = View.extend = History.extend = extend;</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-237">
+
+
+        <li id="section-215">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-237">&#182;</a>
+                <a class="pilcrow" href="#section-215">&#182;</a>
               </div>
               <p>Throw an error when a URL is needed, and none is supplied.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> urlError = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">()</span> </span>{
     <span class="hljs-keyword">throw</span> <span class="hljs-keyword">new</span> <span class="hljs-built_in">Error</span>(<span class="hljs-string">'A "url" property or function must be specified'</span>);
   };</pre></div></div>
-            
+
         </li>
-        
-        
-        <li id="section-238">
+
+
+        <li id="section-216">
             <div class="annotation">
-              
+
               <div class="pilwrap ">
-                <a class="pilcrow" href="#section-238">&#182;</a>
+                <a class="pilcrow" href="#section-216">&#182;</a>
               </div>
               <p>Wrap an optional error callback with a fallback error event.</p>
 
             </div>
-            
+
             <div class="content"><div class='highlight'><pre>  <span class="hljs-keyword">var</span> wrapError = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(model, options)</span> </span>{
     <span class="hljs-keyword">var</span> error = options.error;
     options.error = <span class="hljs-function"><span class="hljs-keyword">function</span><span class="hljs-params">(resp)</span> </span>{
@@ -4583,9 +4194,9 @@ later.</p>
   <span class="hljs-keyword">return</span> Backbone;
 
 }));</pre></div></div>
-            
+
         </li>
-        
+
     </ul>
   </div>
 </body>

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "devDependencies": {
     "phantomjs": "1.9.0-1",
-    "docco": "0.6.1",
+    "docco": "0.7.0",
     "coffee-script": "1.6.1"
   },
   "scripts": {


### PR DESCRIPTION
Updated `docco` to 0.7.0 and ran against `backbone.js` from gh-pages branch, to revert `backbone.html` to the v1.1.2 tag.