### PR TITLE
Juggle context param with event maps

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -96,6 +96,7 @@
     var i = 0, names;
     if (name && typeof name === 'object') {
       // Handle event maps.
+      if (callback !== void 0 && 'context' in opts && opts.context === void 0) opts.context = callback;
       for (names = _.keys(name); i < names.length ; i++) {
         memo = iteratee(memo, names[i], name[names[i]], opts);
       }

--- a/test/events.js
+++ b/test/events.js
@@ -66,6 +66,24 @@
     equal(obj.counter, 5);
   });
 
+  test("binding and trigger with event maps context", 2, function() {
+    var obj = { counter: 0 };
+    var context = {};
+    _.extend(obj, Backbone.Events);
+
+    obj.on({
+        a: function() {
+            strictEqual(this, context, 'defaults `context` to `callback` param');
+        }
+    }, context).trigger('a');
+
+    obj.off().on({
+        a: function() {
+            strictEqual(this, context, 'will not override explicit `context` param');
+        }
+    }, this, context).trigger('a');
+  });
+
   test("listenTo and stopListening", 1, function() {
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);


### PR DESCRIPTION
When using event maps, it's a little nicer to specify the `context` parameter as the second argument. This keeps backwards compatibility with 1.1.2, though the feature wasn't documented.

```javascript
obj.on({
    a: method,
    b: other
}, context);
```

When you explicitly pass a `context`, we don't override.

```javascript
obj.on({
    a: function() { ok(this === context); },
}, otherContext, context);
```