### PR TITLE
Fix opening and closing iframe document in jsdom

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1647,14 +1647,15 @@
       // support the `hashchange` event, HTML5 history, or the user wants
       // `hashChange` but not `pushState`.
       if (!this._hasHashChange && this._wantsHashChange && !this._usePushState) {
-        var iframe = document.createElement('iframe');
-        iframe.src = 'javascript:0';
-        iframe.style.display = 'none';
-        iframe.tabIndex = -1;
+        this.iframeElement = document.createElement('iframe');
+        this.iframeElement.src = 'javascript:0';
+        this.iframeElement.style.display = 'none';
+        this.iframeElement.tabIndex = -1;
         var body = document.body;
         // Using `appendChild` will throw on IE < 9 if the document is not ready.
-        this.iframe = body.insertBefore(iframe, body.firstChild).contentWindow;
-        this.iframe.document.open().close();
+        this.iframe = body.insertBefore(this.iframeElement, body.firstChild).contentWindow;
+        this.iframe.document.open();
+        this.iframe.document.close();
         this.iframe.location.hash = '#' + this.fragment;
       }
 
@@ -1693,8 +1694,9 @@
 
       // Clean up the iframe if necessary.
       if (this.iframe) {
-        document.body.removeChild(this.iframe.frameElement);
+        document.body.removeChild(this.iframeElement);
         this.iframe = null;
+        this.iframeElement = null;
       }
 
       // Some environments will throw when clearing an undefined interval.
@@ -1778,7 +1780,11 @@
           // Opening and closing the iframe tricks IE7 and earlier to push a
           // history entry on hash-tag change.  When replace is true, we don't
           // want this.
-          if (!options.replace) this.iframe.document.open().close();
+          if (!options.replace) {
+            this.iframe.document.open();
+            this.iframe.document.close();
+          }
+          
           this._updateHash(this.iframe.location, fragment, options.replace);
         }
 

--- a/backbone.js
+++ b/backbone.js
@@ -1647,16 +1647,16 @@
       // support the `hashchange` event, HTML5 history, or the user wants
       // `hashChange` but not `pushState`.
       if (!this._hasHashChange && this._wantsHashChange && !this._usePushState) {
-        this.iframeElement = document.createElement('iframe');
-        this.iframeElement.src = 'javascript:0';
-        this.iframeElement.style.display = 'none';
-        this.iframeElement.tabIndex = -1;
+        this.iframe = document.createElement('iframe');
+        this.iframe.src = 'javascript:0';
+        this.iframe.style.display = 'none';
+        this.iframe.tabIndex = -1;
         var body = document.body;
         // Using `appendChild` will throw on IE < 9 if the document is not ready.
-        this.iframe = body.insertBefore(this.iframeElement, body.firstChild).contentWindow;
-        this.iframe.document.open();
-        this.iframe.document.close();
-        this.iframe.location.hash = '#' + this.fragment;
+        var iWindow = body.insertBefore(this.iframe, body.firstChild).contentWindow;
+        iWindow.document.open();
+        iWindow.document.close();
+        iWindow.location.hash = '#' + this.fragment;
       }
 
       // Add a cross-platform `addEventListener` shim for older browsers.
@@ -1694,9 +1694,8 @@
 
       // Clean up the iframe if necessary.
       if (this.iframe) {
-        document.body.removeChild(this.iframeElement);
+        document.body.removeChild(this.iframe);
         this.iframe = null;
-        this.iframeElement = null;
       }
 
       // Some environments will throw when clearing an undefined interval.
@@ -1718,7 +1717,7 @@
       // If the user pressed the back button, the iframe's hash will have
       // changed and we should use that for comparison.
       if (current === this.fragment && this.iframe) {
-        current = this.getHash(this.iframe);
+        current = this.getHash(this.iframe.contentWindow);
       }
 
       if (current === this.fragment) return false;
@@ -1776,16 +1775,18 @@
       // fragment to store history.
       } else if (this._wantsHashChange) {
         this._updateHash(this.location, fragment, options.replace);
-        if (this.iframe && (fragment !== this.getHash(this.iframe))) {
+        if (this.iframe && (fragment !== this.getHash(this.iframe.contentWindow))) {
+          var iWindow = this.iframe.contentWindow;
+          
           // Opening and closing the iframe tricks IE7 and earlier to push a
           // history entry on hash-tag change.  When replace is true, we don't
           // want this.
           if (!options.replace) {
-            this.iframe.document.open();
-            this.iframe.document.close();
+            iWindow.document.open();
+            iWindow.document.close();
           }
           
-          this._updateHash(this.iframe.location, fragment, options.replace);
+          this._updateHash(iWindow.location, fragment, options.replace);
         }
 
       // If you've told us that you explicitly don't want fallback hashchange-


### PR DESCRIPTION
Some of our tests were failing in Marionette due to jsDom not returning the `document` on `document.open()`. Also it seems that jsDom does not attach the `frameElement` property to `iframe.contentWindow`. I imagine other using jsDom may see similar issues.

Some small changes here, all tests still pass.