### PR TITLE
add storehouse for intentionally stored models

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -367,23 +367,30 @@
   // Backbone.Model
   // --------------
 
+  // A storehouse to retrieve models explicitly stored via a custom cid.
+  var modelStore = {};
+
   // Backbone **Models** are the basic data object in the framework --
   // frequently representing a row in a table in a database on your server.
   // A discrete chunk of data and a bunch of useful, related methods for
   // performing computations and transformations on that data.
 
-  // Create a new model with the specified attributes. A client id (`cid`)
-  // is automatically generated and assigned for you.
+  // Create a new model with the specified attributes, or retrieve an existing
+  // model by passing its client id (`cid`). If a new model is created, and no
+  // cid is passed in, one is automatically generated and assigned for you.
   var Model = Backbone.Model = function(attributes, options) {
     var attrs = attributes || {};
     options || (options = {});
-    this.cid = _.uniqueId(this.cidPrefix);
-    this.attributes = {};
-    if (options.collection) this.collection = options.collection;
-    if (options.parse) attrs = this.parse(attrs, options) || {};
+    var obj = modelStore.hasOwnProperty(options.cid) ? modelStore[options.cid] : this;
+    obj.cid = options.cid || _.uniqueId(obj.cidPrefix);
+    obj.attributes = obj.attributes || {};
+    if (options.collection) obj.collection = options.collection;
+    if (options.parse) attrs = obj.parse(attrs, options) || {};
+    if (modelStore.hasOwnProperty(options.cid)) return obj.set(attrs, options);
     attrs = _.defaults({}, attrs, _.result(this, 'defaults'));
     this.set(attrs, options);
     this.changed = {};
+    options.cid && (modelStore[options.cid] = this);
     this.initialize.apply(this, arguments);
   };
 

--- a/test/model.js
+++ b/test/model.js
@@ -66,6 +66,66 @@
     equal(model.get('last_name'), 'Unknown');
   });
 
+  test("initialize and retrieve same model", 6, function() {
+    var Model = Backbone.Model.extend({
+      initialize: function() {
+        this.one = 1;
+        equal(this.collection, collection);
+      }
+    });
+    var model = new Model({}, {cid: 'test', collection: collection});
+    equal(model.one, 1);
+    equal(model.collection, collection);
+    var modelSame = new Model({}, {cid: 'test'});
+    equal(modelSame.one, 1);
+    equal(modelSame.collection, collection);
+    equal(model, modelSame);
+  });
+
+  test("initialize and retrieve same model with options", 3, function() {
+    var Model = Backbone.Model.extend({
+      initialize: function(attributes, options) {
+        this.one = options.one;
+      }
+    });
+    var model = new Model({}, {cid: 'test', one: 1});
+    equal(model.one, 1);
+    var modelSame = new Model({}, {cid: 'test'});
+    equal(modelSame.one, 1);
+    equal(model, modelSame);
+  });
+
+  test("initialize and retrieve same model with parsed attributes", 3, function() {
+    var Model = Backbone.Model.extend({
+      parse: function(attrs) {
+        attrs.value += 1;
+        return attrs;
+      }
+    });
+    var model = new Model({value: 1}, {cid: 'test1', parse: true});
+    equal(model.get('value'), 2);
+    var modelSame = new Model({value: 1}, {cid: 'test1', parse: true});
+    equal(modelSame.get('value'), 2);
+    equal(model, modelSame);
+  });
+
+  test("initialize and and retrieve same model with defaults", 5, function() {
+    var Model = Backbone.Model.extend({
+      defaults: {
+        first_name: 'Unknown',
+        last_name: 'Unknown'
+      }
+    });
+    var model = new Model({first_name: 'John'}, {cid: 'test2'});
+    equal(model.get('first_name'), 'John');
+    equal(model.get('last_name'), 'Unknown');
+    var modelSame = new Model({last_name: 'Chapman'}, {cid: 'test2'});
+    equal(model.get('first_name'), 'John');
+    equal(model.get('last_name'), 'Chapman');
+    equal(model, modelSame);
+  });
+
+
   test("parse can return null", 1, function() {
     var Model = Backbone.Model.extend({
       parse: function(attrs) {


### PR DESCRIPTION
It is common for multiple components to need access to the same data. In this case, either a view is conflated so that the same model can be accessed in its different facets, the model is passed around to each view, multiple models are used with logic to keep them in sync, or a global model is used. All of these have deficiencies: non-atomic/componentized views, a fragile hierarchy, state issues, or encapsulation breakdowns. 

This pull request proposes a storehouse into which explicitly decided models are saved, and from which can be explicitly drawn. If a model is created with a custom `cid` passed in, the reference returned will be from the storehouse if one exists, or else to the newly create model (whose reference is saved to the storehouse). In this way, using the `cid` from options, there will be no memory hit for how backbone is being used currently.

As proposed then, a view can be sanely small, atomic, componentized, and encapsulated with a model whether it has the only reference to it, or whether there are dozens more, the view does not know and the creation and experience is as desired. When any view changes the model's state, all views update accordingly. If all but the original model remain, or if dozens of new references emerge, each view has the same desired behavior for its model without knowing or caring if other views have the same model.

There are way more lines here than the pull request, as this is more of adding a new philosophic option than it is code (it weighs in with 5 new lines of code, and 4 changed lines). If there is an optimal way to achieve this, or more tests are desired, please let me know!