### PR TITLE
Use the public `on` method when listening

### DIFF
--- a/test/events.js
+++ b/test/events.js
@@ -585,4 +585,41 @@
     two.trigger('y', 2);
   });
 
+  test("#3611 - listenTo is compatible with non-Backbone event libraries", 1, function() {
+    var obj = _.extend({}, Backbone.Events);
+    var other = {
+      events: {},
+      on: function(name, callback) {
+        this.events[name] = callback;
+      },
+      trigger: function(name) {
+        this.events[name]();
+      }
+    };
+
+    obj.listenTo(other, 'test', function() { ok(true); });
+    other.trigger('test');
+  });
+
+  test("#3611 - stopListening is compatible with non-Backbone event libraries", 1, function() {
+    var obj = _.extend({}, Backbone.Events);
+    var other = {
+      events: {},
+      on: function(name, callback) {
+        this.events[name] = callback;
+      },
+      off: function() {
+        this.events = {};
+      },
+      trigger: function(name) {
+        var fn = this.events[name];
+        if (fn) fn();
+      }
+    };
+
+    obj.listenTo(other, 'test', function() { ok(false); });
+    obj.stopListening(other);
+    other.trigger('test');
+    equal(_.size(obj._listeningTo), 0);
+  });
 })();


### PR DESCRIPTION
Fixes https://github.com/jashkenas/backbone/issues/3611.

This uses a private `listening` var to share state between a Backbone
"listener" and "listenee", instead of using a private `internalOn()` to
share state. This allows `#listenTo` to use the public `#on` method and
keeps interop between Backbone and any other event library.

http://jsperf.com/internal-listening-public-on
