### PR TITLE
Create with wait:true should not call collection.parse

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -614,10 +614,7 @@
 
       // After a successful server-side save, the client is (optionally)
       // updated with the server-side state.
-      if (options.parse === void 0) {
-        options.parse = true;
-        options.enabledParseForModel = true;
-      }
+      if (options.parse === void 0) options.parse = true;
       var model = this;
       var success = options.success;
       options.success = function(resp) {
@@ -797,7 +794,7 @@
     // the core operation for updating the data contained by the collection.
     set: function(models, options) {
       options = _.defaults({}, options, setOptions);
-      if (options.parse && !options.enabledParseForModel) models = this.parse(models, options);
+      if (options.parse) models = this.parse(models, options);
       var singular = !_.isArray(models);
       models = singular ? (models ? [models] : []) : models.slice();
       var id, model, attrs, existing, sort;

--- a/backbone.js
+++ b/backbone.js
@@ -594,7 +594,11 @@
         (attrs = {})[key] = val;
       }
 
-      options = _.extend({validate: true, parse: true}, options);
+      options = _.extend({
+        validate: true,
+        parse: true,
+        enabledParseForModel: !options || options.parse === void 0
+      }, options);
       var wait = options.wait;
 
       // If we're not waiting and attributes exist, save acts as
@@ -789,7 +793,7 @@
     // the core operation for updating the data contained by the collection.
     set: function(models, options) {
       options = _.defaults({}, options, setOptions);
-      if (options.parse) models = this.parse(models, options);
+      if (options.parse && !options.enabledParseForModel) models = this.parse(models, options);
       var singular = !_.isArray(models);
       models = singular ? (models ? [models] : []) : models.slice();
       var id, model, attrs, existing, sort;

--- a/backbone.js
+++ b/backbone.js
@@ -614,7 +614,10 @@
 
       // After a successful server-side save, the client is (optionally)
       // updated with the server-side state.
-      if (options.parse === void 0) options.parse = true;
+      if (options.parse === void 0) {
+        options.parse = true;
+        options.enabledParseForModel = true;
+      }
       var model = this;
       var success = options.success;
       options.success = function(resp) {
@@ -794,7 +797,7 @@
     // the core operation for updating the data contained by the collection.
     set: function(models, options) {
       options = _.defaults({}, options, setOptions);
-      if (options.parse) models = this.parse(models, options);
+      if (options.parse && !options.enabledParseForModel) models = this.parse(models, options);
       var singular = !_.isArray(models);
       models = singular ? (models ? [models] : []) : models.slice();
       var id, model, attrs, existing, sort;

--- a/test/collection.js
+++ b/test/collection.js
@@ -559,6 +559,34 @@
 
   });
 
+  test("create with wait:true should not call collection.parse", 1, function() {
+    var collectionParseCalled = false;
+
+    var Model = Backbone.Model.extend({
+      sync: function (method, model, options) {
+        _.extend(options, {specialSync: true});
+        return Backbone.Model.prototype.sync.call(this, method, model, options);
+      }
+    });
+
+    var Collection = Backbone.Collection.extend({
+      model: Model,
+      url: '/test',
+      parse: function () {
+        collectionParseCalled = true;
+      }
+    });
+
+    var collection = new Collection;
+
+    var success = function (model, response, options) {
+      equal(collectionParseCalled, false);
+    };
+
+    collection.create({}, {wait: true, success: success});
+    this.ajaxSettings.success();
+  });
+
   test("a failing create returns model with errors", function() {
     var ValidatingModel = Backbone.Model.extend({
       validate: function(attrs) {


### PR DESCRIPTION
This seems to be a regression of #2824 

`collection.create` calls `model.save` that sets `options.parse = true` and passes these options downwards `success` callback -> `collection.add` -> `collection.set` which then tries to call `collection.parse` with model as the first argument.

I've added a test case and an ugly fix (not sure if it can be done in a prettier way).

