### PR TITLE
Collection#set Style

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -857,7 +857,7 @@
 
       // See if sorting is needed, update `length` and splice in new models.
       var orderChanged = false;
-      if (!sortable && add && remove) {
+      if (set.length && !sortable && add && remove) {
         orderChanged = set.length != this.length || _.any(this.models, function(model, index) {
           return model !== set[index];
         });

--- a/backbone.js
+++ b/backbone.js
@@ -788,6 +788,8 @@
     // already exist in the collection, as necessary. Similar to **Model#set**,
     // the core operation for updating the data contained by the collection.
     set: function(models, options) {
+      if (models == null) return;
+
       options = _.defaults({}, options, setOptions);
       if (options.parse) models = this.parse(models, options);
       var singular = !_.isArray(models);

--- a/backbone.js
+++ b/backbone.js
@@ -865,16 +865,13 @@
         this.length = set.length;
       } else if (toAdd.length) {
         if (sortable) sort = true;
-        this.length += toAdd.length;
+        models = this.models;
         if (at == null) {
-          for (i = 0; i < toAdd.length; i++) {
-            this.models.push(toAdd[i]);
-          }
+          this.models = models.concat(toAdd);
         } else {
-          for (i = 0; i < toAdd.length; i++) {
-            this.models.splice(at + i, 0, toAdd[i]);
-          }
+          this.models = models.slice(0, at).concat(toAdd).concat(models.slice(at, this.length));
         }
+        this.length += toAdd.length;
       }
 
       // Silently sort the collection if appropriate.

--- a/backbone.js
+++ b/backbone.js
@@ -792,30 +792,42 @@
 
       options = _.defaults({}, options, setOptions);
       if (options.parse) models = this.parse(models, options);
+
       var singular = !_.isArray(models);
       models = singular ? (models ? [models] : []) : models.slice();
-      var id, model, attrs, existing, sort;
+
       var at = options.at;
       if (at != null) at = +at;
       if (at < 0) at += this.length + 1;
+
+      var toAdd = [];
+      var toRemove = [];
+      var modelMap = {};
+
+      var add = options.add;
+      var merge = options.merge;
+      var remove = options.remove;
+
+      var sort = false;
       var sortable = this.comparator && (at == null) && options.sort !== false;
       var sortAttr = _.isString(this.comparator) ? this.comparator : null;
-      var toAdd = [], toRemove = [], modelMap = {};
-      var add = options.add, merge = options.merge, remove = options.remove;
+
       var order = !sortable && add && remove ? [] : false;
       var orderChanged = false;
 
       // Turn bare objects into model references, and prevent invalid models
       // from being added.
+      var model;
       for (var i = 0; i < models.length; i++) {
-        attrs = models[i];
+        model = models[i];
 
         // If a duplicate is found, prevent it from being added and
         // optionally merge it into the existing model.
-        if (existing = this.get(attrs)) {
+        var existing;
+        if (existing = this.get(model)) {
           if (remove) modelMap[existing.cid] = true;
-          if (merge && attrs !== existing) {
-            attrs = this._isModel(attrs) ? attrs.attributes : attrs;
+          if (merge && model !== existing) {
+            var attrs = this._isModel(model) ? model.attributes : model;
             if (options.parse) attrs = existing.parse(attrs, options);
             existing.set(attrs, options);
             if (sortable && !sort && existing.hasChanged(sortAttr)) sort = true;
@@ -824,7 +836,7 @@
 
         // If this is a new, valid model, push it to the `toAdd` list.
         } else if (add) {
-          model = models[i] = this._prepareModel(attrs, options);
+          model = models[i] = this._prepareModel(model, options);
           if (!model) continue;
           toAdd.push(model);
           this._addReference(model, options);
@@ -833,7 +845,7 @@
         // Do not add multiple models with the same `id`.
         model = existing || model;
         if (!model) continue;
-        id = this.modelId(model.attributes);
+        var id = this.modelId(model.attributes);
         if (order && (model.isNew() || !modelMap[id])) {
           order.push(model);
 
@@ -846,7 +858,7 @@
 
       // Remove nonexistent models if appropriate.
       if (remove) {
-        for (var i = 0; i < this.length; i++) {
+        for (i = 0; i < this.length; i++) {
           if (!modelMap[(model = this.models[i]).cid]) toRemove.push(model);
         }
         if (toRemove.length) this._removeModels(toRemove, options);
@@ -857,13 +869,13 @@
         if (sortable) sort = true;
         this.length += toAdd.length;
         if (at != null) {
-          for (var i = 0; i < toAdd.length; i++) {
+          for (i = 0; i < toAdd.length; i++) {
             this.models.splice(at + i, 0, toAdd[i]);
           }
         } else {
           if (order) this.models.length = 0;
           var orderedModels = order || toAdd;
-          for (var i = 0; i < orderedModels.length; i++) {
+          for (i = 0; i < orderedModels.length; i++) {
             this.models.push(orderedModels[i]);
           }
         }
@@ -875,7 +887,7 @@
       // Unless silenced, it's time to fire all appropriate add/sort events.
       if (!options.silent) {
         var addOpts = at != null ? _.clone(options) : options;
-        for (var i = 0; i < toAdd.length; i++) {
+        for (i = 0; i < toAdd.length; i++) {
           if (at != null) addOpts.index = at + i;
           (model = toAdd[i]).trigger('add', model, this, addOpts);
         }

--- a/backbone.js
+++ b/backbone.js
@@ -887,7 +887,7 @@
 
       // Unless silenced, it's time to fire all appropriate add/sort events.
       if (!options.silent) {
-        var addOpts = at != null ? _.clone(options) : options;
+        var addOpts = at == null ? options : _.clone(options);
         for (i = 0; i < toAdd.length; i++) {
           model = toAdd[i];
           if (at != null) addOpts.index = at + i;

--- a/backbone.js
+++ b/backbone.js
@@ -823,8 +823,8 @@
 
         // If a duplicate is found, prevent it from being added and
         // optionally merge it into the existing model.
-        var existing;
-        if (existing = this.get(model)) {
+        var existing = this.get(model);
+        if (existing) {
           if (remove) modelMap[existing.cid] = true;
           if (merge && model !== existing) {
             var attrs = this._isModel(model) ? model.attributes : model;
@@ -859,7 +859,8 @@
       // Remove nonexistent models if appropriate.
       if (remove) {
         for (i = 0; i < this.length; i++) {
-          if (!modelMap[(model = this.models[i]).cid]) toRemove.push(model);
+          model = this.models[i];
+          if (!modelMap[model.cid]) toRemove.push(model);
         }
         if (toRemove.length) this._removeModels(toRemove, options);
       }
@@ -888,8 +889,9 @@
       if (!options.silent) {
         var addOpts = at != null ? _.clone(options) : options;
         for (i = 0; i < toAdd.length; i++) {
+          model = toAdd[i];
           if (at != null) addOpts.index = at + i;
-          (model = toAdd[i]).trigger('add', model, this, addOpts);
+          model.trigger('add', model, this, addOpts);
         }
         if (sort || orderChanged) this.trigger('sort', this, options);
         if (toAdd.length || toRemove.length) this.trigger('update', this, options);

--- a/backbone.js
+++ b/backbone.js
@@ -879,11 +879,10 @@
 
       // Unless silenced, it's time to fire all appropriate add/sort events.
       if (!options.silent) {
-        var addOpts = at == null ? options : _.clone(options);
         for (i = 0; i < toAdd.length; i++) {
+          if (at != null) options.index = at + i;
           model = toAdd[i];
-          if (at != null) addOpts.index = at + i;
-          model.trigger('add', model, this, addOpts);
+          model.trigger('add', model, this, options);
         }
         if (sort || orderChanged) this.trigger('sort', this, options);
         if (toAdd.length || toRemove.length) this.trigger('update', this, options);

--- a/backbone.js
+++ b/backbone.js
@@ -830,7 +830,7 @@
             var attrs = this._isModel(model) ? model.attributes : model;
             if (options.parse) attrs = existing.parse(attrs, options);
             existing.set(attrs, options);
-            if (sortable && !sort && existing.hasChanged(sortAttr)) sort = true;
+            if (sortable && !sort) sort = existing.hasChanged(sortAttr);
           }
           models[i] = existing;
 

--- a/backbone.js
+++ b/backbone.js
@@ -794,12 +794,13 @@
       if (options.parse) models = this.parse(models, options);
 
       var singular = !_.isArray(models);
-      models = singular ? (models ? [models] : []) : models.slice();
+      models = singular ? [models] : models;
 
       var at = options.at;
       if (at != null) at = +at;
       if (at < 0) at += this.length + 1;
 
+      var set = [];
       var toAdd = [];
       var toRemove = [];
       var modelMap = {};
@@ -812,9 +813,6 @@
       var sortable = this.comparator && (at == null) && options.sort !== false;
       var sortAttr = _.isString(this.comparator) ? this.comparator : null;
 
-      var order = !sortable && add && remove ? [] : false;
-      var orderChanged = false;
-
       // Turn bare objects into model references, and prevent invalid models
       // from being added.
       var model;
@@ -825,35 +823,27 @@
         // optionally merge it into the existing model.
         var existing = this.get(model);
         if (existing) {
-          if (remove) modelMap[existing.cid] = true;
           if (merge && model !== existing) {
             var attrs = this._isModel(model) ? model.attributes : model;
             if (options.parse) attrs = existing.parse(attrs, options);
             existing.set(attrs, options);
             if (sortable && !sort) sort = existing.hasChanged(sortAttr);
           }
-          models[i] = existing;
+          if (!modelMap[existing.cid]) {
+            modelMap[existing.cid] = true;
+            set.push(existing);
+          }
 
         // If this is a new, valid model, push it to the `toAdd` list.
         } else if (add) {
-          model = models[i] = this._prepareModel(model, options);
-          if (!model) continue;
-          toAdd.push(model);
-          this._addReference(model, options);
+          model = this._prepareModel(model, options);
+          if (model) {
+            toAdd.push(model);
+            this._addReference(model, options);
+            modelMap[model.cid] = true;
+            set.push(model);
+          }
         }
-
-        // Do not add multiple models with the same `id`.
-        model = existing || model;
-        if (!model) continue;
-        var id = this.modelId(model.attributes);
-        if (order && (model.isNew() || !modelMap[id])) {
-          order.push(model);
-
-          // Check to see if this is actually a new model at this index.
-          orderChanged = orderChanged || !this.models[i] || model.cid !== this.models[i].cid;
-        }
-
-        modelMap[id] = true;
       }
 
       // Remove nonexistent models if appropriate.
@@ -866,14 +856,19 @@
       }
 
       // See if sorting is needed, update `length` and splice in new models.
-      if (toAdd.length || orderChanged) {
+      var orderChanged = false;
+      if (!sortable && add && remove) {
+        orderChanged = set.length != this.length || _.any(this.models, function(model, index) {
+          return model !== set[index];
+        });
+        this.models = set.slice();
+        this.length = set.length;
+      } else if (toAdd.length) {
         if (sortable) sort = true;
         this.length += toAdd.length;
         if (at == null) {
-          if (order) this.models.length = 0;
-          var orderedModels = order || toAdd;
-          for (i = 0; i < orderedModels.length; i++) {
-            this.models.push(orderedModels[i]);
+          for (i = 0; i < toAdd.length; i++) {
+            this.models.push(toAdd[i]);
           }
         } else {
           for (i = 0; i < toAdd.length; i++) {
@@ -898,7 +893,7 @@
       }
 
       // Return the added (or merged) model (or models).
-      return singular ? models[0] : models;
+      return singular ? set[0] : set;
     },
 
     // When you have more items than you want to add or remove individually,

--- a/backbone.js
+++ b/backbone.js
@@ -41,8 +41,15 @@
   var previousBackbone = root.Backbone;
 
   // Create local references to array methods we'll want to use later.
-  var array = [];
-  var slice = array.slice;
+  var slice = Array.prototype.slice;
+  var splice = function(array, insert, at) {
+    var length = insert.length;
+    var result = Array(array.length + length);
+    for (var i = 0; i < at; i++) result[i] = array[i];
+    for (i = 0; i < length; i++) result[i + at] = insert[i];
+    for (i = at; i < array.length; i++) result[i + length] = array[i];
+    return result;
+  };
 
   // Current version of the library. Keep in sync with `package.json`.
   Backbone.VERSION = '1.2.0';
@@ -865,12 +872,7 @@
         this.length = set.length;
       } else if (toAdd.length) {
         if (sortable) sort = true;
-        models = this.models;
-        if (at == null) {
-          this.models = models.concat(toAdd);
-        } else {
-          this.models = models.slice(0, at).concat(toAdd).concat(models.slice(at, this.length));
-        }
+        this.models = splice(this.models, toAdd, at == null ? this.length : at);
         this.length += toAdd.length;
       }
 

--- a/backbone.js
+++ b/backbone.js
@@ -869,15 +869,15 @@
       if (toAdd.length || orderChanged) {
         if (sortable) sort = true;
         this.length += toAdd.length;
-        if (at != null) {
-          for (i = 0; i < toAdd.length; i++) {
-            this.models.splice(at + i, 0, toAdd[i]);
-          }
-        } else {
+        if (at == null) {
           if (order) this.models.length = 0;
           var orderedModels = order || toAdd;
           for (i = 0; i < orderedModels.length; i++) {
             this.models.push(orderedModels[i]);
+          }
+        } else {
+          for (i = 0; i < toAdd.length; i++) {
+            this.models.splice(at + i, 0, toAdd[i]);
           }
         }
       }

--- a/test/collection.js
+++ b/test/collection.js
@@ -506,7 +506,7 @@
     };
     collection.url = '/test';
     collection.fetch();
-    this.syncArgs.options.success();
+    this.syncArgs.options.success([]);
     equal(counter, 1);
   });
 
@@ -1221,7 +1221,7 @@
     }));
     var ajax = Backbone.ajax;
     Backbone.ajax = function (params) {
-      _.defer(params.success);
+      _.defer(params.success, []);
       return {someHeader: 'headerValue'};
     };
     collection.fetch({

--- a/test/collection.js
+++ b/test/collection.js
@@ -339,11 +339,11 @@
 
     list = col.add([{id: 3}, {id: 6}], {validate: true});
     equal(col.length, 3);
-    equal(list[0], false);
-    equal(list[1].get('id'), 6);
+    equal(list.length, 1);
+    equal(list[0].get('id'), 6);
 
     var result = col.add({id: 6});
-    equal(result.cid, list[1].cid);
+    equal(result.cid, list[0].cid);
 
     result = col.remove({id: 6});
     equal(col.length, 2);


### PR DESCRIPTION
- Declares variables where they are needed (and removes duplicate `var i` declarations)
- Exits early when `models` is nullish
- Makes the "merge" and "add" loop easier to follow
- Does not mutate `#models` array when adding
  - This is to keep adding consistent (ie. `!sortable && add && remove` path doesn't mutate, so the normal add path shouldn't)
- Makes inserting models with `at` an order of magnitude faster
  - [Base case (`#unshift`)](http://jsperf.com/insert-array-into-another-array/6)
  - [Base case (`#push`)](http://jsperf.com/insert-array-into-another-array/9)
  - ["Normal" collection size](http://jsperf.com/insert-array-into-another-array/8)
  - [Large collection](http://jsperf.com/insert-array-into-another-array/7)

**Breaking change**: Returns only unique added or merged models. Before, we would return false for models that had a validation error, and potentially multiple of the same model (`col.set({id: 1}, {id: 1}); => [Model1, Model1]`). This change mirrors #3512, which only returns (unique) removed models.