### PR TITLE
v2: Collection#remove immutable models

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -1671,4 +1671,14 @@
     collection.invoke('method', 1, 2, 3);
   });
 
+  test("#3534 - destroy models in each loop", 4, function() {
+    var collection = new Backbone.Collection([{id: 1}, {id: 2}, {id: 3}, {id: 4}]);
+    collection.each(function(model) {
+      notStrictEqual(model, undefined);
+      if (model !== undefined) {
+        model.destroy({url: function() {}});
+      }
+    });
+  });
+
 })();


### PR DESCRIPTION
**DO NOT MERGE, BREAKING CHANGE** This is for the next major, v2.
- Make `#models` immutable (follows #3648)
- Uses a O(k+n) algorithm instead of a O(k*lg(n)) algorithm

The trigger loop could be combined with the one above, but I wanted to
mirror `Collection#add` where `#length` and `#models` already reflect
all of the added models. This way, the 'remove' event already reflects the
removed models.

Fixes #3534.
