### PR TITLE
Backbone.Promise

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1415,21 +1415,22 @@
     throw new Error('Backbone does not provide a spec compliant Promise by default.');
   };
 
-  // A helper method that forces jQuery's first `then` callback to be
-  // executed asynchronously.
-  // This is used so we can guarantee our async return values execute
-  // callbacks async, not async sometimes and sync other times.
-  var asyncDeferred = function(method) {
-    return function(value) {
-      var deferred = Backbone.$.Deferred();
-      _.defer(deferred[method], value);
-      return deferred.promise();
-    };
-  };
-
   _.extend(Backbone.Promise, {
-    resolve: asyncDeferred('resolve'),
-    reject: asyncDeferred('reject')
+    // A wrapper around jQuery's normal resolve to force it to adopt a
+    // thenable's state, and execute then callbacks asynchronously.
+    resolve: function(value) {
+      var deferred = Backbone.$.Deferred();
+      _.defer(deferred.resolve);
+      return deferred.promise().then(_.constant(value));
+    },
+
+    // A wrapper around jQuery's normal reject to force it to execute
+    // then callbacks asynchronously.
+    reject: function(reason) {
+      var deferred = Backbone.$.Deferred();
+      _.defer(deferred.reject, reason);
+      return deferred.promise();
+    }
   });
 
   // Backbone.Router

--- a/test/index.html
+++ b/test/index.html
@@ -20,5 +20,6 @@
   <script src="router.js"></script>
   <script src="view.js"></script>
   <script src="sync.js"></script>
+  <script src="promise.js"></script>
 </body>
 </html>

--- a/test/promise.js
+++ b/test/promise.js
@@ -1,0 +1,56 @@
+(function() {
+
+  module("Backbone.Promise");
+
+  test("throws an error if invoked", 1, function() {
+    try {
+      Backbone.Promise();
+    } catch (e) {
+      ok(e);
+    }
+  });
+
+  asyncTest(".resolve to passed in value", 1, function() {
+    var value = {};
+    Backbone.Promise.resolve({}).then(function(val) {
+      strictEqual(val, value);
+      start();
+    });
+  });
+
+  asyncTest(".resolve adopts promise state", 1, function() {
+    var value = {};
+    var promise = Backbone.Promise.resolve(val);
+    Backbone.Promise.resolve(promise).then(function(val) {
+      strictEqual(val, value);
+      start();
+    });
+  });
+
+  asyncTest(".resolve executes then callback asynchronously", 1, function() {
+    var async = false;
+    Backbone.Promise.resolve().then(function() {
+      ok(async);
+      start();
+    });
+    async = true;
+  });
+
+  asyncTest(".reject to passed in value", 1, function() {
+    var value = {};
+    Backbone.Promise.reject({}).then(null, function(val) {
+      strictEqual(val, value);
+      start();
+    });
+  });
+
+  asyncTest(".reject executes then callback asynchronously", 1, function() {
+    var async = false;
+    Backbone.Promise.reject().then(null, function() {
+      ok(async);
+      start();
+    });
+    async = true;
+  });
+
+});


### PR DESCRIPTION
Competes with #2489.

Specifically, it implements `Backbone.Promise` instead of `Backbone.Deferred`, so it can be easily swapped with any ES6 compatible Promise library.

This is phase 1. Phase 2 would be:

- returning a `Backbone.Promise` from `Backbone.sync`.
- removing all the `options.success` and `options.error` callbacks in favor of chained promises.
  - That includes transitioning from `success` callbacks to rejected promises, ie. `Model#fetch` where validation fails with the server's attributes.