### PR TITLE
Fix failing IE6 test

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -918,7 +918,7 @@
 
   test('#3358 - pushState to hashChange transition with search params', 1, function() {
     Backbone.history.stop();
-    location.replace('/root?foo=bar');
+    location.replace('http://example.com/root?foo=bar');
     location.replace = function(url) {
       strictEqual(url, '/root#?foo=bar');
     };


### PR DESCRIPTION
It was a false positive. Our “location” parsing uses an A tag, which doesn’t always work the way the real location parsing does.