### PR TITLE
Add jquery dependency to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "keywords"      : ["model", "view", "controller", "router", "server", "client", "browser"],
   "author"        : "Jeremy Ashkenas <jeremy@documentcloud.org>",
   "dependencies"  : {
+    "jquery"      : "^2.1.4",
     "underscore"  : ">=1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
The new `require('jquery')` is great for using browserify, but it doesn't work because jquery is not listed as a dependency in `package.json`.