### PR TITLE
Router/History update

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1492,6 +1492,8 @@
 
     // Match a fragment with a registered handler
     matchFragment: function(fragment) {
+      // If the root doesn't match, no routes can match either.
+      if (!Backbone.history.matchRoot()) return false;
       return _.find(Router.handlers, function(handler) {
         return handler.route.test(fragment);
       });

--- a/backbone.js
+++ b/backbone.js
@@ -1473,8 +1473,6 @@
 
     // Simple proxy to `Backbone.history` to save a fragment into the history.
     navigate: function(fragment, options) {
-      if (options === void 0) options = {silent: true};
-      if (options === false) options = {silent: false};
       Backbone.history.navigate(fragment, options);
       return this;
     },
@@ -1759,7 +1757,8 @@
     // you wish to modify the current URL without adding an entry to the history.
     navigate: function(fragment, options) {
       if (!History.started) return false;
-      if (!options || options === true) options = {trigger: !!options};
+      if (options === void 0) options = {silent: true};
+      if (options === false) options = {silent: false};
 
       // Normalize the fragment.
       fragment = this.getFragment(fragment || '');

--- a/backbone.js
+++ b/backbone.js
@@ -1438,12 +1438,6 @@
     // initialization logic.
     initialize: function(){},
 
-    // Simple proxy to `Backbone.history` to save a fragment into the history.
-    navigate: function(fragment, options) {
-      Backbone.history.navigate(fragment, options);
-      return this;
-    },
-
     // Listen to when a modular History interface, like Backbone.history,
     // updates the URL.
     bindNavigationListener: function() {
@@ -1475,6 +1469,12 @@
     // excellent place to do pre-route setup or post-route cleanup.
     execute: function(callback, args, name) {
       if (callback) callback.apply(this, args);
+    },
+
+    // Simple proxy to `Backbone.history` to save a fragment into the history.
+    navigate: function(fragment, options) {
+      Backbone.history.navigate(fragment, options);
+      return this;
     },
 
     // Determine if a registered handler matches the fragment when

--- a/backbone.js
+++ b/backbone.js
@@ -1473,6 +1473,8 @@
 
     // Simple proxy to `Backbone.history` to save a fragment into the history.
     navigate: function(fragment, options) {
+      if (options === void 0) options = {silent: true};
+      if (options === false) options = {silent: false};
       Backbone.history.navigate(fragment, options);
       return this;
     },

--- a/backbone.js
+++ b/backbone.js
@@ -1457,23 +1457,18 @@
     //     });
     //
     route: function(route, name, callback) {
-      var handler = this.getHandler(route, name, callback);
-      Router.handlers.push(handler);
-    },
-
-    // Return a handler object from a route, name, and callback
-    getHandler: function(route, name, callback) {
       if (!_.isRegExp(route)) route = this._routeToRegExp(route);
       if (_.isFunction(name)) {
         callback = name;
         name = '';
       }
       if (!callback) callback = this[name];
-      return {
+      var handler = {
         route: route,
         callback: callback,
         name: name
       };
+      Router.handlers.push(handler);
     },
 
     // Execute a route handler with the provided parameters.  This is an
@@ -1482,6 +1477,8 @@
       if (callback) callback.apply(this, args);
     },
 
+    // Determine if a registered handler matches the fragment when
+    // History emits a navigate event.
     onNavigate: function(fragment) {
       var matchedRoute = this.matchFragment(fragment);
       if (!matchedRoute) return this;

--- a/backbone.js
+++ b/backbone.js
@@ -1416,7 +1416,6 @@
   var Router = Backbone.Router = function(options) {
     options || (options = {});
     if (options.routes) this.routes = options.routes;
-    this.handlers = [];
     this.bindNavigationListener();
     this._bindRoutes();
     this.initialize.apply(this, arguments);
@@ -1428,6 +1427,9 @@
   var namedParam    = /(\(\?)?:\w+/g;
   var splatParam    = /\*\w+/g;
   var escapeRegExp  = /[\-{}\[\]+?.,\\\^$|#\s]/g;
+
+  // Route handlers registered through Router instances are stored here.
+  Router.handlers = [];
 
   // Set up all inheritable **Backbone.Router** properties and methods.
   _.extend(Router.prototype, Events, {
@@ -1456,7 +1458,7 @@
     //
     route: function(route, name, callback) {
       var handler = this.getHandler(route, name, callback);
-      this.handlers.push(handler);
+      Router.handlers.push(handler);
     },
 
     // Return a handler object from a route, name, and callback
@@ -1493,7 +1495,7 @@
 
     // Match a fragment with a registered handler
     matchFragment: function(fragment) {
-      return _.find(this.handlers, function(handler) {
+      return _.find(Router.handlers, function(handler) {
         return handler.route.test(fragment);
       });
     },


### PR DESCRIPTION
This is a proof of concept of some of the changes discussed in https://github.com/jashkenas/backbone/issues/3653.

There are two types of changes here. The first is providing more hooks for users who may wish to change the behavior of the Router. @jridgewell described them well, I think, when he said that they are similar to the hooks provided in Views. The other type of change is more clearly separating the role of the Router and History. History now does one thing: interfaces with whatever browser APIs are necessary to update the URL. The Router handles everything that relates to the 'route handlers.'

There is more work to do, o' course. I haven't changed the unit tests, for instance.

The API exposed to the user _should_ be mostly backwards compatible. An repo with an example [is here](https://github.com/jmeas/backbone.routing-v2).
# 

The biggest backwards incompatible change so far is the removal of the `trigger` option. It has been replaced with a `silent` option, which effectively does the same thing. It's also `true` by default, which means that route callbacks won't be executed when history updates the URL.
