### PR TITLE
Collection methods with model-attributes-style predicates

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -623,7 +623,7 @@
     equal(coll.findWhere({a: 4}), void 0);
   });
 
-  test("Underscore methods", 16, function() {
+  test("Underscore methods", 19, function() {
     equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
     equal(col.any(function(model){ return model.id === 100; }), false);
     equal(col.any(function(model){ return model.id === 0; }), true);
@@ -644,7 +644,42 @@
     deepEqual(col.difference([c, d]), [a, b]);
     ok(col.include(col.sample()));
     var first = col.first();
+    deepEqual(col.groupBy(function(model){ return model.id; })[first.id], [first]);
+    deepEqual(col.countBy(function(model){ return model.id; }), {0: 1, 1: 1, 2: 1, 3: 1});
+    deepEqual(col.sortBy(function(model){ return model.id; })[0], col.at(3));
     ok(col.indexBy('id')[first.id] === first);
+  });
+
+  test("Underscore methods with object-style and property-style iteratee", 22, function () {
+    var model = new Backbone.Model({a: 4, b: 1, e: 3});
+    var coll = new Backbone.Collection([
+      {a: 1, b: 1},
+      {a: 2, b: 1, c: 1},
+      {a: 3, b: 1},
+      model
+    ]);
+    equal(coll.find({a: 0}), undefined);
+    deepEqual(coll.find({a: 4}), model);
+    equal(coll.find('d'), undefined);
+    deepEqual(coll.find('e'), model);
+    equal(coll.filter({a: 0}), false);
+    deepEqual(coll.filter({a: 4}), [model]);
+    equal(coll.some({a: 0}), false);
+    equal(coll.some({a: 1}), true);
+    equal(coll.reject({a: 0}).length, 4);
+    deepEqual(coll.reject({a: 4}), _.without(coll.models, model));
+    equal(coll.every({a: 0}), false);
+    equal(coll.every({b: 1}), true);
+    deepEqual(coll.partition({a: 0})[0], []);
+    deepEqual(coll.partition({a: 0})[1], coll.models);
+    deepEqual(coll.partition({a: 4})[0], [model]);
+    deepEqual(coll.partition({a: 4})[1], _.without(coll.models, model));
+    deepEqual(coll.map({a: 2}), [false, true, false, false]);
+    deepEqual(coll.map('a'), [1, 2, 3, 4]);
+    deepEqual(coll.max('a'), model);
+    deepEqual(coll.min('e'), model);
+    deepEqual(coll.countBy({a: 4}), {false: 3, true: 1});
+    deepEqual(coll.countBy('d'), {undefined: 4});
   });
 
   test("reset", 16, function() {


### PR DESCRIPTION
As underscore provides it, a Backbone.Collection functional helper should be able to be called with a model-attributes-style predicate (in addition to function-style).

Example:
```js
this.collection.reject({user: 'guybrush'});
```

Methods concerned: find, detect, filter, select, reject, every, all, any, some, partition.
Compatible with underscore#1.7.0.