### PR TITLE
Fix initialization of views with undefined arguments

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1166,6 +1166,7 @@
   // if an existing element is not provided...
   var View = Backbone.View = function(options) {
     this.cid = _.uniqueId('view');
+    options = typeof options !== 'undefined' ? options : {};
     _.extend(this, _.pick(options, viewOptions));
     this._ensureElement();
     this.initialize.apply(this, arguments);

--- a/test/view.js
+++ b/test/view.js
@@ -48,6 +48,12 @@
     strictEqual(new View().one, 1);
   });
 
+  test("initialize works with undefined arguments", 1, function() {
+    var view = new Backbone.View();
+
+    ok(view);
+  });
+
   test("render", 1, function() {
     var view = new Backbone.View;
     equal(view.render(), view, '#render returns the view instance');


### PR DESCRIPTION
![Fix-It Felix strolling in](https://38.media.tumblr.com/3f39d9474db2d82dbb6fb5dd888f0394/tumblr_inline_mq4wnzRCkf1qz4rgp.gif)
[A recent commit](https://github.com/jashkenas/backbone/commit/51eed189bf4d25877be4acdf51e0a4c6039583c5#comments) caused view initialization to fail if the view is initialized without arguments. This may be an edge case, but in my opinion `new Backbone.View()` shouldn't be something that breaks like this (and a few others on the comment thread for that commit share my opinion).