### PR TITLE
Event maps should support multiple event syntax

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -126,10 +126,10 @@
       // Handle event maps.
       if (callback !== void 0 && 'context' in opts && opts.context === void 0) opts.context = callback;
       for (names = _.keys(name); i < names.length ; i++) {
-        events = iteratee(events, names[i], name[names[i]], opts);
+        events = eventsApi(iteratee, events, names[i], name[names[i]], opts);
       }
     } else if (name && eventSplitter.test(name)) {
-      // Handle space separated event names.
+      // Handle space separated event names by delegating them individually.
       for (names = name.split(eventSplitter); i < names.length; i++) {
         events = iteratee(events, names[i], callback, opts);
       }

--- a/test/events.js
+++ b/test/events.js
@@ -66,6 +66,34 @@
     equal(obj.counter, 5);
   });
 
+  test("binding and triggering multiple event names with event maps", function() {
+    var obj = { counter: 0 };
+    _.extend(obj, Backbone.Events);
+
+    var increment = function() {
+      this.counter += 1;
+    };
+
+    obj.on({
+      'a b c': increment
+    });
+
+    obj.trigger('a');
+    equal(obj.counter, 1);
+
+    obj.trigger('a b');
+    equal(obj.counter, 3);
+
+    obj.trigger('c');
+    equal(obj.counter, 4);
+
+    obj.off({
+      'a c': increment
+    });
+    obj.trigger('a b c');
+    equal(obj.counter, 5);
+  });
+
   test("binding and trigger with event maps context", 2, function() {
     var obj = { counter: 0 };
     var context = {};


### PR DESCRIPTION
Edge case, but `obj.on({'a b c': increment})` should work the same as `obj.on('a b c', increment)`.