### PR TITLE
modelProperty doesn't need to check for null

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -80,7 +80,7 @@
   };
   var modelProperty = function(key) {
     return function(model) {
-      return model == null ? void 0 : model.get(key);
+      return model.get(key);
     };
   };
   var cb = function(iteratee, instance) {


### PR DESCRIPTION
Since `#models` is filled with only model instances, there's no need to check if model isn't `null`.

re: #3667.