### PR TITLE
Allow #idAttribute as a constructor option

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -394,15 +394,18 @@
   var Model = Backbone.Model = function(attributes, options) {
     var attrs = attributes || {};
     options || (options = {});
-    this.cid = _.uniqueId(this.cidPrefix);
     this.attributes = {};
-    if (options.collection) this.collection = options.collection;
+    _.extend(this, _.pick(options, modelOptions));
+    this.cid = _.uniqueId(this.cidPrefix);
     if (options.parse) attrs = this.parse(attrs, options) || {};
     attrs = _.defaults({}, attrs, _.result(this, 'defaults'));
     this.set(attrs, options);
     this.changed = {};
     this.initialize.apply(this, arguments);
   };
+
+  // List of models options to be set as properties
+  var modelOptions = ['cidPrefix', 'idAttribute', 'collection'];
 
   // Attach all inheritable methods to the Model prototype.
   _.extend(Model.prototype, Events, {
@@ -704,7 +707,10 @@
 
     // Create a new model with identical attributes to this one.
     clone: function() {
-      return new this.constructor(this.attributes);
+      return new this.constructor(this.attributes, {
+        idAttribute: this.idAttribute,
+        cidPrefix: this.cidPrefix
+      });
     },
 
     // A model is new if it has never been saved to the server, and lacks an id.

--- a/backbone.js
+++ b/backbone.js
@@ -396,7 +396,7 @@
     options || (options = {});
     this.attributes = {};
     _.extend(this, _.pick(options, modelOptions));
-    this.cid = _.uniqueId(this.cidPrefix);
+    this.cid = _.uniqueId(_.result(this, 'cidPrefix'));
     if (options.parse) attrs = this.parse(attrs, options) || {};
     attrs = _.defaults({}, attrs, _.result(this, 'defaults'));
     this.set(attrs, options);
@@ -509,7 +509,7 @@
       }
 
       // Update the `id`.
-      this.id = this.get(this.idAttribute);
+      this.id = this.get(_.result(this, 'idAttribute'));
 
       // Trigger all relevant attribute changes.
       if (!silent) {
@@ -695,7 +695,7 @@
         _.result(this.collection, 'url') ||
         urlError();
       if (this.isNew()) return base;
-      var id = this.get(this.idAttribute);
+      var id = this.get(_.result(this, 'idAttribute'));
       return base.replace(/[^\/]$/, '$&/') + encodeURIComponent(id);
     },
 
@@ -715,7 +715,7 @@
 
     // A model is new if it has never been saved to the server, and lacks an id.
     isNew: function() {
-      return !this.has(this.idAttribute);
+      return !this.has(_.result(this, 'idAttribute'));
     },
 
     // Check if the model is currently in a valid state.
@@ -1054,7 +1054,8 @@
 
     // Define how to uniquely identify models in the collection.
     modelId: function (attrs) {
-      return attrs[this.model.prototype.idAttribute || 'id'];
+      var proto = this.model.prototype;
+      return attrs[_.result(proto, 'idAttribute') || 'id'];
     },
 
     // Private method to reset all internal state. Called when the collection

--- a/backbone.js
+++ b/backbone.js
@@ -404,7 +404,7 @@
     this.initialize.apply(this, arguments);
   };
 
-  // List of models options to be set as properties
+  // List of model options to be set as properties
   var modelOptions = ['cidPrefix', 'idAttribute', 'collection'];
 
   // Attach all inheritable methods to the Model prototype.
@@ -707,10 +707,7 @@
 
     // Create a new model with identical attributes to this one.
     clone: function() {
-      return new this.constructor(this.attributes, {
-        idAttribute: this.idAttribute,
-        cidPrefix: this.cidPrefix
-      });
+      return new this.constructor(this.attributes, _.pick(this, modelOptions));
     },
 
     // A model is new if it has never been saved to the server, and lacks an id.
@@ -758,9 +755,7 @@
   // If a `comparator` is specified, the Collection will maintain
   // its models in sort order, as they're added and removed.
   var Collection = Backbone.Collection = function(models, options) {
-    options || (options = {});
-    if (options.model) this.model = options.model;
-    if (options.comparator !== void 0) this.comparator = options.comparator;
+    _.extend(this, _.pick(options, collectionOptions));
     this._reset();
     this.initialize.apply(this, arguments);
     if (models) this.reset(models, _.extend({silent: true}, options));
@@ -769,6 +764,9 @@
   // Default options for `Collection#set`.
   var setOptions = {add: true, remove: true, merge: true};
   var addOptions = {add: true, remove: false};
+
+  // List of collection options to be set as properties
+  var collectionOptions = ['model', 'comparator'];
 
   // Define the Collection's inheritable methods.
   _.extend(Collection.prototype, Events, {
@@ -1046,10 +1044,7 @@
 
     // Create a new collection with an identical list of models as this one.
     clone: function() {
-      return new this.constructor(this.models, {
-        model: this.model,
-        comparator: this.comparator
-      });
+      return new this.constructor(this.models, _.pick(this, collectionOptions));
     },
 
     // Define how to uniquely identify models in the collection.

--- a/test/collection.js
+++ b/test/collection.js
@@ -865,7 +865,7 @@
     ok(col.comparator);
     ok(!colFalse.comparator);
     ok(!colNull.comparator);
-    ok(colUndefined.comparator);
+    ok(!colUndefined.comparator);
   });
 
   test("#1355 - `options` is passed to success callbacks", 2, function(){


### PR DESCRIPTION
Also allows `#idAttribute` to be a method like `View`'s constructor options.

This will ease ES6 class transition by allowing either:
- Constructor default overloading (https://github.com/jashkenas/backbone/issues/3560#user-content-default-options)
- Option method definitions (https://github.com/jashkenas/backbone/issues/3560#user-content-methods)

**Mildly Breaking**: Instantiating a Collection with an explicit `{ comparator: undefined }` will now disable sorting on the instance. Previously, only the other false-y values would disable.
