### PR TITLE
Allow tagName to use parameters passed to the constructor

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1170,8 +1170,8 @@
   var View = Backbone.View = function(options) {
     this.cid = _.uniqueId('view');
     _.extend(this, _.pick(options, viewOptions));
-    this._ensureElement();
     this.initialize.apply(this, arguments);
+    this._ensureElement();
   };
 
   // Cached regex to split keys for `delegate`.

--- a/test/view.js
+++ b/test/view.js
@@ -205,6 +205,22 @@
     ok(new View().$el.is('p'));
   });
 
+  test("tagName can be provided as a function and can use parameters passed to the constructor", 1, function() {
+    var View = Backbone.View.extend({
+      initialize: function(opts) {
+        this.myVar = opts.myVar;
+      },
+      tagName: function() {
+        if (this.myVar === '123')
+          return 'p';
+        else
+          return 'div';
+      }
+    });
+
+    ok(new View({myVar: '123'}).$el.is('p'));
+  });
+
   test("_ensureElement with DOM node el", 1, function() {
     var View = Backbone.View.extend({
       el: document.body


### PR DESCRIPTION
I recently wanted to define tagName as a function and I wanted the return value to vary based on parameters passed to the constructor, but I found that _ensureElement is called before initialize and so the constructor parameters were not available in tagName.

This PR simply reverses the order of initialize and _ensureElement. All tests pass, plus a new one added.