### PR TITLE
Fix test for IE7/IE8 build

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -678,8 +678,8 @@
     deepEqual(coll.map('a'), [1, 2, 3, 4]);
     deepEqual(coll.max('a'), model);
     deepEqual(coll.min('e'), model);
-    deepEqual(coll.countBy({a: 4}), {false: 3, true: 1});
-    deepEqual(coll.countBy('d'), {undefined: 4});
+    deepEqual(coll.countBy({a: 4}), {'false': 3, 'true': 1});
+    deepEqual(coll.countBy('d'), {'undefined': 4});
   });
 
   test("reset", 16, function() {


### PR DESCRIPTION
Wrapping test object keys as string to avoid IE7/IE8 error (reserved identifiers).
Tests were added with #3667 : https://travis-ci.org/jashkenas/backbone/builds/66548299.