### PR TITLE
Fix manually triggering "change" on model belonging to a collection

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1126,7 +1126,7 @@
     _onModelEvent: function(event, model, collection, options) {
       if ((event === 'add' || event === 'remove') && collection !== this) return;
       if (event === 'destroy') this.remove(model, options);
-      if (event === 'change') {
+      if (model && event === 'change') {
         var prevId = this.modelId(model.previousAttributes());
         var id = this.modelId(model.attributes);
         if (prevId !== id) {

--- a/test/collection.js
+++ b/test/collection.js
@@ -757,6 +757,13 @@
     equal(fired, true);
   });
 
+  test("trigger 'change' events on models", 1, function() {
+    var fired = null;
+    a.on("change", function() { fired = true; });
+    a.trigger("change");
+    equal(fired, true);
+  });
+
   test("add does not alter arguments", 2, function(){
     var attrs = {};
     var models = [attrs];


### PR DESCRIPTION
Since 4e2d209 there would always be an error when doing `model.trigger('change')` when `model` was part of a collection.