### PR TITLE
adding feedback to update event of collection

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -819,7 +819,7 @@
       if (at < 0) at += this.length + 1;
       var sortable = this.comparator && (at == null) && options.sort !== false;
       var sortAttr = _.isString(this.comparator) ? this.comparator : null;
-      var toAdd = [], toRemove = [], modelMap = {};
+      var toAdd = [], toRemove = [], toMerge = [], modelMap = {};
       var add = options.add, merge = options.merge, remove = options.remove;
       var order = !sortable && add && remove ? [] : false;
       var orderChanged = false;
@@ -837,6 +837,7 @@
             attrs = this._isModel(attrs) ? attrs.attributes : attrs;
             if (options.parse) attrs = existing.parse(attrs, options);
             existing.set(attrs, options);
+            toMerge.push(existing);
             if (sortable && !sort && existing.hasChanged(sortAttr)) sort = true;
           }
           models[i] = existing;
@@ -900,8 +901,10 @@
         }
 
         // Create arrays of the models which were added and removed.
-        options.addedModels = toAdd;
-        options.removedModels = toRemove;
+        options.changes = {};
+        options.changes.added = toAdd;
+        options.changes.removed = toRemove;
+        options.changes.merged = toMerge;
 
         // Only trigger if there were models added or removed.
         if (toAdd.length || toRemove.length) {

--- a/backbone.js
+++ b/backbone.js
@@ -808,8 +808,10 @@
       var singular = !_.isArray(models);
       models = singular ? [models] : _.clone(models);
       var removed = this._removeModels(models, options);
-      options.removedModels = removed;
-      if (!options.silent && removed) this.trigger('update', this, options);
+      if (!options.silent && removed) {
+        options.removedModels = removed;
+        this.trigger('update', this, options);
+      }
       return singular ? removed[0] : removed;
     },
 

--- a/backbone.js
+++ b/backbone.js
@@ -907,7 +907,7 @@
         options.changes.merged = toMerge;
 
         // Only trigger if there were models added or removed.
-        if (toAdd.length || toRemove.length) {
+        if (toAdd.length || toRemove.length || toMerge.length) {
           this.trigger('update', this, options);
         }
         if (sort || orderChanged) this.trigger('sort', this, options);

--- a/test/collection.js
+++ b/test/collection.js
@@ -1671,4 +1671,98 @@
     collection.invoke('method', 1, 2, 3);
   });
 
+  test("#3711 - remove's `update` event returns one removed model", function() {
+    var model = new Backbone.Model({id: 1, title: 'First Post'});
+    var collection = new Backbone.Collection([model]);
+    collection.on('update', function(context, options) {
+      if (options.removedModels[0] !== model) {
+        ok(false);
+      } else {
+        ok(true);
+      }
+    });
+    collection.remove(model);
+  });
+
+  test("#3711 - remove's `update` event returns multiple removed models", function() {
+    var model = new Backbone.Model({id: 1, title: 'First Post'});
+    var model2 = new Backbone.Model({id: 2, title: 'Second Post'});
+    var collection = new Backbone.Collection([model, model2]);
+    collection.on('update', function(context, options) {
+      var removedModels = options.removedModels;
+      if (!removedModels || removedModels.length !== 2) ok(false);
+      if (removedModels.indexOf(model) > -1 && removedModels.indexOf(model2) > -1) {
+        ok(true);
+      } else {
+        ok(false);
+      }
+    });
+    collection.remove([model, model2]);
+  });
+
+  test("#3711 - set's `update` event returns one added model", function() {
+    var model = new Backbone.Model({ id: 1, title: 'First Post'});
+    var collection = new Backbone.Collection();
+    collection.on('update', function(context, options) {
+      var addedModels = options.addedModels;
+      if (!addedModels || addedModels.length !== 1) ok(false);
+      if (addedModels[0] === model) {
+        ok(true);
+      } else {
+        ok(false);
+      }
+    });
+    collection.set(model);
+  });
+
+  test("#3711 - set's `update` event returns multiple added models", function() {
+    var model = new Backbone.Model({ id: 1, title: 'First Post'});
+    var model2 = new Backbone.Model({id: 2, title: 'Second Post'});
+    var collection = new Backbone.Collection();
+    collection.on('update', function(context, options) {
+      var addedModels = options.addedModels;
+      if (!addedModels || addedModels.length !== 2) ok(false);
+      if (addedModels[0] === model && addedModels[1] === model2) {
+        ok(true);
+      } else {
+        ok(false);
+      }
+    });
+    collection.set([model, model2]);
+  });
+
+  test("#3711 - set's `update` event returns one removed model", function() {
+    var model = new Backbone.Model({ id: 1, title: 'First Post'});
+    var model2 = new Backbone.Model({id: 2, title: 'Second Post'});
+    var model3 = new Backbone.Model({id: 3, title: 'My Last Post'});
+    var collection = new Backbone.Collection([model]);
+    collection.on('update', function(context, options) {
+      var removedModels = options.previousModels;
+      if (!removedModels || removedModels.length !== 1) ok(false);
+      if (removedModels[0] === model) {
+        ok(true);
+      } else {
+        ok(false);
+      }
+    });
+    collection.set([model2, model3]);
+  });
+
+  test("#3711 - set's `update` event returns multiple removed models", function() {
+    var model = new Backbone.Model({ id: 1, title: 'First Post'});
+    var model2 = new Backbone.Model({id: 2, title: 'Second Post'});
+    var model3 = new Backbone.Model({id: 3, title: 'My Last Post'});
+    var collection = new Backbone.Collection([model, model2]);
+    collection.on('update', function(context, options) {
+      var removedModels = options.previousModels;
+      if (!removedModels || removedModels.length !== 2) ok(false);
+      if (removedModels[0] === model && removedModels[1] === model2) {
+        ok(true);
+      } else {
+        ok(false);
+      }
+    });
+    collection.set([model3]);
+  });
+
 })();

--- a/test/collection.js
+++ b/test/collection.js
@@ -1737,7 +1737,7 @@
     var model3 = new Backbone.Model({id: 3, title: 'My Last Post'});
     var collection = new Backbone.Collection([model]);
     collection.on('update', function(context, options) {
-      var removedModels = options.previousModels;
+      var removedModels = options.removedModels;
       if (!removedModels || removedModels.length !== 1) ok(false);
       if (removedModels[0] === model) {
         ok(true);
@@ -1754,7 +1754,7 @@
     var model3 = new Backbone.Model({id: 3, title: 'My Last Post'});
     var collection = new Backbone.Collection([model, model2]);
     collection.on('update', function(context, options) {
-      var removedModels = options.previousModels;
+      var removedModels = options.removedModels;
       if (!removedModels || removedModels.length !== 2) ok(false);
       if (removedModels[0] === model && removedModels[1] === model2) {
         ok(true);

--- a/test/collection.js
+++ b/test/collection.js
@@ -1675,11 +1675,7 @@
     var model = new Backbone.Model({id: 1, title: 'First Post'});
     var collection = new Backbone.Collection([model]);
     collection.on('update', function(context, options) {
-      if (options.removedModels[0] !== model) {
-        ok(false);
-      } else {
-        ok(true);
-      }
+      strictEqual(options.removedModels[0], model);
     });
     collection.remove(model);
   });

--- a/test/collection.js
+++ b/test/collection.js
@@ -1783,4 +1783,15 @@
     collection.set([model2_v2, model_v2]);
   });
 
+  test("#3711 - set's `update` event should not be triggered adding a model which already exists exactly alike", function() {
+    var fired = false;
+    var model = new Backbone.Model({ id: 1, title: 'First Post'});
+    var collection = new Backbone.Collection([model]);
+    collection.on('update', function(context, options) {
+      fired = true;
+    });
+    collection.set([model]);
+    equal(fired, false);
+  });
+
 })();

--- a/test/collection.js
+++ b/test/collection.js
@@ -1638,19 +1638,19 @@
     collection.remove([{id: 1}, {id: 2}]);
   });
 
-  test("remove does not trigger `set` when nothing removed", 0, function() {
+  test("remove does not trigger `update` when nothing removed", 0, function() {
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
     collection.on('update', function() { ok(false); });
     collection.remove([{id: 3}]);
   });
 
-  test("set triggers `set` event once", 1, function() {
+  test("set triggers `update` event once", 1, function() {
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
     collection.on('update', function() { ok(true); });
     collection.set([{id: 1}, {id: 3}]);
   });
 
-  test("set does not trigger `set` event when nothing added nor removed", 0, function() {
+  test("set does not trigger `update` event when nothing added nor removed", 0, function() {
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
     collection.on('update', function() { ok(false); });
     collection.set([{id: 1}, {id: 2}]);

--- a/test/collection.js
+++ b/test/collection.js
@@ -1755,4 +1755,32 @@
     collection.set([model3]);
   });
 
+  test("#3711 - set's `update` event returns one merged model", function() {
+    var model = new Backbone.Model({ id: 1, title: 'First Post'});
+    var model2 = new Backbone.Model({ id: 2, title: 'Second Post' });
+    var model2_v2 = new Backbone.Model({ id: 2, title: 'Second Post V2'});
+    var collection = new Backbone.Collection([model, model2]);
+    collection.on('update', function(context, options) {
+      var mergedModels = options.changes.merged;
+      if (!mergedModels || mergedModels.length !== 1) ok(false);
+      strictEqual(mergedModels[0].get('title'), model2_v2.get('title'));
+    });
+    collection.set([model2_v2]);
+  });
+
+  test("#3711 - set's `update` event returns multiple merged models", function() {
+    var model = new Backbone.Model({ id: 1, title: 'First Post'});
+    var model_v2 = new Backbone.Model({ id: 1, title: 'First Post V2'});
+    var model2 = new Backbone.Model({ id: 2, title: 'Second Post' });
+    var model2_v2 = new Backbone.Model({ id: 2, title: 'Second Post V2'});
+    var collection = new Backbone.Collection([model, model2]);
+    collection.on('update', function(context, options) {
+      var mergedModels = options.changes.merged;
+      if (!mergedModels || mergedModels.length !== 2) ok(false);
+      strictEqual(mergedModels[0].get('title'), model2_v2.get('title'));
+      strictEqual(mergedModels[1].get('title'), model_v2.get('title'));
+    });
+    collection.set([model2_v2, model_v2]);
+  });
+
 })();

--- a/test/collection.js
+++ b/test/collection.js
@@ -1658,9 +1658,9 @@
     collection.set([{id: 1}, {id: 3}]);
   });
 
-  test("set does not trigger `update` event when nothing added nor removed", 0, function() {
+  test("set triggers `update` event when models get merged", 1, function() {
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
-    collection.on('update', function() { ok(false); });
+    collection.on('update', function() { ok(true); });
     collection.set([{id: 1}, {id: 2}]);
   });
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -1702,11 +1702,7 @@
     collection.on('update', function(context, options) {
       var addedModels = options.addedModels;
       if (!addedModels || addedModels.length !== 1) ok(false);
-      if (addedModels[0] === model) {
-        ok(true);
-      } else {
-        ok(false);
-      }
+      strictEqual(addedModels[0], model);
     });
     collection.set(model);
   });
@@ -1718,11 +1714,8 @@
     collection.on('update', function(context, options) {
       var addedModels = options.addedModels;
       if (!addedModels || addedModels.length !== 2) ok(false);
-      if (addedModels[0] === model && addedModels[1] === model2) {
-        ok(true);
-      } else {
-        ok(false);
-      }
+      strictEqual(addedModels[0], model);
+      strictEqual(addedModels[1], model2);
     });
     collection.set([model, model2]);
   });
@@ -1735,11 +1728,7 @@
     collection.on('update', function(context, options) {
       var removedModels = options.removedModels;
       if (!removedModels || removedModels.length !== 1) ok(false);
-      if (removedModels[0] === model) {
-        ok(true);
-      } else {
-        ok(false);
-      }
+      strictEqual(removedModels[0], model);
     });
     collection.set([model2, model3]);
   });
@@ -1752,11 +1741,8 @@
     collection.on('update', function(context, options) {
       var removedModels = options.removedModels;
       if (!removedModels || removedModels.length !== 2) ok(false);
-      if (removedModels[0] === model && removedModels[1] === model2) {
-        ok(true);
-      } else {
-        ok(false);
-      }
+      strictEqual(removedModels[0], model);
+      strictEqual(removedModels[1], model2);
     });
     collection.set([model3]);
   });

--- a/test/collection.js
+++ b/test/collection.js
@@ -1700,7 +1700,7 @@
     var model = new Backbone.Model({ id: 1, title: 'First Post'});
     var collection = new Backbone.Collection();
     collection.on('update', function(context, options) {
-      var addedModels = options.addedModels;
+      var addedModels = options.changes.added;
       if (!addedModels || addedModels.length !== 1) ok(false);
       strictEqual(addedModels[0], model);
     });
@@ -1712,7 +1712,7 @@
     var model2 = new Backbone.Model({id: 2, title: 'Second Post'});
     var collection = new Backbone.Collection();
     collection.on('update', function(context, options) {
-      var addedModels = options.addedModels;
+      var addedModels = options.changes.added;
       if (!addedModels || addedModels.length !== 2) ok(false);
       strictEqual(addedModels[0], model);
       strictEqual(addedModels[1], model2);
@@ -1726,7 +1726,7 @@
     var model3 = new Backbone.Model({id: 3, title: 'My Last Post'});
     var collection = new Backbone.Collection([model]);
     collection.on('update', function(context, options) {
-      var removedModels = options.removedModels;
+      var removedModels = options.changes.removed;
       if (!removedModels || removedModels.length !== 1) ok(false);
       strictEqual(removedModels[0], model);
     });
@@ -1739,7 +1739,7 @@
     var model3 = new Backbone.Model({id: 3, title: 'My Last Post'});
     var collection = new Backbone.Collection([model, model2]);
     collection.on('update', function(context, options) {
-      var removedModels = options.removedModels;
+      var removedModels = options.changes.removed;
       if (!removedModels || removedModels.length !== 2) ok(false);
       strictEqual(removedModels[0], model);
       strictEqual(removedModels[1], model2);


### PR DESCRIPTION
collection's update event receives 2 additional attributes, in case of removal of existing models, previousModels is an array containing the removed models which where referenced to the collection before .set was called. The second attribute, addedModels contains an array of models which were added to the collection calling the .set method.

Fixes #3700