### PR TITLE
Collection set: when one model's cid == another model's id

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -953,7 +953,7 @@
       if (obj == null) return void 0;
       if (_.isObject(obj)) {
         var id = this.modelId(this._isModel(obj) ? obj.attributes : obj);
-	return this._byId[id] || this._byCid[obj.cid];
+        return this._byId[id] || this._byCid[obj.cid];
       }
       else {
         return this._byId[obj] || this._byCid[obj];

--- a/test/collection.js
+++ b/test/collection.js
@@ -1451,7 +1451,7 @@
         Backbone.Collection.prototype._addReference.apply(this, arguments);
         calls.add++;
         equal(model, this._byId[model.id]);
-        equal(model, this._byId[model.cid]);
+        equal(model, this._byCid[model.cid]);
         equal(model._events.all.length, 1);
       },
 
@@ -1459,7 +1459,7 @@
         Backbone.Collection.prototype._removeReference.apply(this, arguments);
         calls.remove++;
         equal(this._byId[model.id], void 0);
-        equal(this._byId[model.cid], void 0);
+        equal(this._byCid[model.cid], void 0);
         equal(model.collection, void 0);
         equal(model._events, void 0);
       }
@@ -1671,4 +1671,18 @@
     collection.invoke('method', 1, 2, 3);
   });
 
+  test("#3712 - Collection set: when one model's cid == another model's id", 3, function() {
+    var model1 = new Backbone.Model({
+      id: 'foo'
+    });
+    var model2 = new Backbone.Model({
+      id: model1.cid
+    });
+  
+    var collection = new Backbone.Collection([model1]);
+    collection.set([model1, model2]);
+    deepEqual(collection.models, [model1, model2]); 
+    equal(model1.id, 'foo');
+    equal(model2.id, model1.cid);
+  });
 })();


### PR DESCRIPTION
Given the following code:

```javascript
var model1 = new Backbone.Model({
  id: 'foo'
});
var model2 = new Backbone.Model({
  id: model1.cid
});

var collection = new Backbone.Collection([model1]);
collection.set([model1, model2]);
```

The result is that `collection` contains only `model1`. Also, oddly, `model1.id` is changed to its `cid`.