### PR TITLE
Add docs for View#events

### DIFF
--- a/index.html
+++ b/index.html
@@ -450,6 +450,7 @@
       <li>– <a href="#View-template">template</a></li>
       <li>– <a href="#View-render">render</a></li>
       <li>– <a href="#View-remove">remove</a></li>
+      <li>– <a href="#View-events">events</a></li>
       <li>– <a href="#View-delegateEvents">delegateEvents</a></li>
       <li>– <a href="#View-undelegateEvents">undelegateEvents</a></li>
     </ul>
@@ -2930,6 +2931,36 @@ var Bookmark = Backbone.View.extend({
       events that the view has <a href="#Events-listenTo">listenTo</a>'d.
     </p>
 
+    <p id="View-events">
+      <b class="header">events</b><code>view.events or view.events()</code>
+      <br />
+      The <b>events</b> hash (or method) can be used to specify a set of DOM
+      events that will be bound to methods on your View
+      through <a href="#View-delegateEvents">delegateEvents</a>.
+    </p>
+
+    <p>Backbone will automatically attach the event listeners at instantiation
+    time, right before invoking <a href="#View-constructor">initialize</a>.
+    </p>
+
+<pre>
+var InputView = Backbone.View.extend({
+
+  tagName: 'input',
+
+  events: {
+    "keydown" : "keyAction",
+  },
+
+  render: function(){ ... },
+
+  keyAction: function(e) {
+    var isEnterKey = e.which === 13;
+    if(isEnterKey){ this.collection.addEntry(this.$el.val()); }
+  }
+});
+</pre>
+
     <p id="View-delegateEvents">
       <b class="header">delegateEvents</b><code>delegateEvents([events])</code>
       <br />
@@ -4264,7 +4295,7 @@ ActiveRecord::Base.include_root_in_json = false
         in 1.2.0.
       </li>
     </ul>
-  
+
     <b class="header">1.2.0</b> &mdash; <small><i>May 13, 2015</i></small>
     &mdash; <a href="https://github.com/jashkenas/backbone/compare/1.1.2...1.2.0">Diff</a>
     &mdash; <a href="https://cdn.rawgit.com/jashkenas/backbone/1.2.0/index.html">Docs</a>
@@ -4287,7 +4318,7 @@ ActiveRecord::Base.include_root_in_json = false
       <li>
         Views now always delegate their events in <a href="#View-setElement">setElement</a>.
         You can no longer modify the events hash or your view's <tt>el</tt> property in
-        <tt>initialize</tt>. 
+        <tt>initialize</tt>.
       </li>
       <li>
         Added an <tt>"update"</tt> event that triggers after any amount of


### PR DESCRIPTION
Predefining the **events** hash in a Backbone View is pretty common, and it's not super obvious that **delegateEvents** is where one should look for information about the **events** hash itself.

For instance, Backbone calls delegateEvents before it runs the View's initialize method. If the user explicitly defines the **events** hash in the View itself, then there is a chance that the user never has to explicitly call delegateEvents at all. 

I think it stands to reason that the **events** hash property get its own section in the docs.

**1. Edit:** Cleaned up whitespace, wrapped long lines, corrected wording.
**2. Edit:** Used better wording suggested by @akre54.
**3. Edit:** Refactor example View code as suggested by @akre54 and @megawac.

![screen shot 2015-07-19 at 1 58 34 pm](https://cloud.githubusercontent.com/assets/4524175/8767833/6793f73e-2e1e-11e5-85bd-7224366ff8f6.png)

