### PR TITLE
Refactor example code in View#events docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2957,7 +2957,9 @@ var InputView = Backbone.View.extend({
   render: function() { ... },
 
   keyAction: function(e) {
-    if (e.which === ENTER_KEY) this.collection.add({text: this.$el.val()});
+    if (e.which === ENTER_KEY) {
+      this.collection.add({text: this.$el.val()});
+    }
   }
 });
 </pre>


### PR DESCRIPTION
The most recent style clean up caused the example code block to run off into the margins.

**This:**

<img width="587" alt="screen shot 2015-07-20 at 12 53 54 pm" src="https://cloud.githubusercontent.com/assets/4524175/8785878/9ca29fcc-2edf-11e5-8111-5be6d41f0983.png">

**Becomes this:**

<img width="585" alt="screen shot 2015-07-20 at 1 02 21 pm" src="https://cloud.githubusercontent.com/assets/4524175/8785875/9943943a-2edf-11e5-8cee-b6b2448224f8.png">
