### PR TITLE
Use `_.bind` instead of `context` param of `_.sortBy`.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -977,16 +977,19 @@
     // normal circumstances, as the set will maintain sort order as each item
     // is added.
     sort: function(options) {
-      if (!this.comparator) throw new Error('Cannot sort a set without a comparator');
+      var comparator = this.comparator;
+      if (!comparator) throw new Error('Cannot sort a set without a comparator');
       options || (options = {});
 
-      // Run sort based on type of `comparator`.
-      if (_.isString(this.comparator) || this.comparator.length === 1) {
-        this.models = this.sortBy(this.comparator, this);
-      } else {
-        this.models.sort(_.bind(this.comparator, this));
-      }
+      var length = comparator.length;
+      if (_.isFunction(comparator)) comparator = _.bind(comparator, this);
 
+      // Run sort based on type of `comparator`.
+      if (length === 1 || _.isString(comparator)) {
+        this.models = this.sortBy(comparator);
+      } else {
+        this.models.sort(comparator);
+      }
       if (!options.silent) this.trigger('sort', this, options);
       return this;
     },


### PR DESCRIPTION
Since lodash v4 [will be removing](https://github.com/underdash/underdash/issues/4#issuecomment-118974230) the `context` param of methods Backbone can avoid a minor compat issue by deferring to `_.bind` for both cases in `sort`.