### PR TITLE
Setup DOM for every view test

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "docco": "0.7.0",
     "karma": "^0.12.31",
     "karma-phantomjs-launcher": "^0.1.4",
-    "karma-qunit": "^0.1.4",
+    "karma-qunit": "^0.1.5",
     "qunitjs": "^1.18.0",
     "uglify-js": "^2.4.17"
   },

--- a/test/setup/dom-setup.js
+++ b/test/setup/dom-setup.js
@@ -1,6 +1,4 @@
 $('body').append(
     '<div id="qunit"></div>' +
-    '<div id="qunit-fixture">' +
-        '<div id="testElement"><h1>Test</h1></div>' +
-    '</div>'
+    '<div id="qunit-fixture"></div>'
 );

--- a/test/view.js
+++ b/test/view.js
@@ -5,6 +5,10 @@
   module("Backbone.View", {
 
     setup: function() {
+      $('#qunit-fixture').append(
+        '<div id="testElement"><h1>Test</h1></div>'
+      );
+
       view = new Backbone.View({
         id        : 'test-view',
         className : 'test-view',


### PR DESCRIPTION
Karma QUnit v0.1.5 now removes and reinserts the `#qunit-fixture` element before every test.

Ping https://github.com/karma-runner/karma-qunit/issues/28 and https://github.com/jashkenas/backbone/pull/3742.