### PR TITLE
v2: Collection#parse

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -757,6 +757,7 @@
     if (options.comparator !== void 0) this.comparator = options.comparator;
     this._reset();
     this.initialize.apply(this, arguments);
+    if (models && options.parse) models = this.parse(models, options);
     if (models) this.reset(models, _.extend({silent: true}, options));
   };
 
@@ -809,7 +810,6 @@
     // the core operation for updating the data contained by the collection.
     set: function(models, options) {
       options = _.defaults({}, options, setOptions);
-      if (options.parse && !this._isModel(models)) models = this.parse(models, options);
       var singular = !_.isArray(models);
       models = singular ? (models ? [models] : []) : models.slice();
       var id, model, attrs, existing, sort;
@@ -1004,11 +1004,12 @@
     // data will be passed through the `reset` method instead of `set`.
     fetch: function(options) {
       options = _.extend({parse: true}, options);
-      var success = options.success;
       var collection = this;
+      var success = options.success;
       options.success = function(resp) {
         var method = options.reset ? 'reset' : 'set';
-        collection[method](resp, options);
+        var models = options.parse ? collection.parse(resp, options) : resp;
+        collection[method](models, options);
         if (success) success.call(options.context, collection, resp, options);
         collection.trigger('sync', collection, resp, options);
       };

--- a/test/collection.js
+++ b/test/collection.js
@@ -252,19 +252,6 @@
     equal(col.at(0).get('value'), 2);
   });
 
-  test("add with parse and merge", function() {
-    var collection = new Backbone.Collection();
-    collection.parse = function(attrs) {
-      return _.map(attrs, function(model) {
-        if (model.model) return model.model;
-        return model;
-      });
-    };
-    collection.add({id: 1});
-    collection.add({model: {id: 1, name: 'Alf'}}, {parse: true, merge: true});
-    equal(collection.first().get('name'), 'Alf');
-  });
-
   test("add model to collection with sort()-style comparator", 3, function() {
     var col = new Backbone.Collection;
     col.comparator = function(a, b) {
@@ -559,20 +546,6 @@
     collection.create({}, {success: success});
     this.ajaxSettings.success();
 
-  });
-
-  test("create with wait:true should not call collection.parse", 0, function() {
-    var Collection = Backbone.Collection.extend({
-      url: '/test',
-      parse: function () {
-        ok(false);
-      }
-    });
-
-    var collection = new Collection;
-
-    collection.create({}, {wait: true});
-    this.ajaxSettings.success();
   });
 
   test("a failing create returns model with errors", function() {
@@ -1029,29 +1002,6 @@
     equal(c.at(0).get('name'), 'test');
   });
 
-  test("#1407 parse option on reset parses collection and models", 2, function() {
-    var model = {
-      namespace : [{id: 1}, {id:2}]
-    };
-    var Collection = Backbone.Collection.extend({
-      model: Backbone.Model.extend({
-        parse: function(model) {
-          model.name = 'test';
-          return model;
-        }
-      }),
-      parse: function(model) {
-        return model.namespace;
-      }
-    });
-    var c = new Collection();
-        c.reset(model, {parse:true});
-
-    equal(c.length, 2);
-    equal(c.at(0).get('name'), 'test');
-  });
-
-
   test("Reset includes previous models in triggered event.", 1, function() {
     var model = new Backbone.Model();
     var collection = new Backbone.Collection([model])
@@ -1174,18 +1124,21 @@
   });
 
   test("`set` and model level `parse`", function() {
-    var Model = Backbone.Model.extend({});
+    var Model = Backbone.Model.extend({
+      parse: function(model) {
+        return model.model;
+      }
+    });
     var Collection = Backbone.Collection.extend({
-      model: Model,
-      parse: function (res) { return _.map(res.models, 'model'); }
+      model: Model
     });
     var model = new Model({id: 1});
     var collection = new Collection(model);
-    collection.set({models: [
-      {model: {id: 1}},
-      {model: {id: 2}}
-    ]}, {parse: true});
-    equal(collection.first(), model);
+    collection.set([
+      {model: {id: 1, attr: 'test'}},
+      {model: {id: 2, attr: 'test'}}
+    ], {parse: true});
+    deepEqual(collection.pluck('attr'), ['test', 'test']);
   });
 
   test("`set` data is only parsed once", function() {
@@ -1249,17 +1202,6 @@
       sort: function() { ok(false); }
     });
     new Collection().add({id: 1}, {sort: false});
-  });
-
-  test("#1915 - `parse` data in the right order in `set`", function() {
-    var collection = new (Backbone.Collection.extend({
-      parse: function (data) {
-        strictEqual(data.status, 'ok');
-        return data.data;
-      }
-    }));
-    var res = {status: 'ok', data:[{id: 1}]};
-    collection.set(res, {parse: true});
   });
 
   asyncTest("#1939 - `parse` is passed `options`", 1, function () {
@@ -1671,6 +1613,63 @@
     });
     var collection = new Collection([{id: 1}]);
     collection.invoke('method', 1, 2, 3);
+  });
+
+  test("set, add, and reset do not parse at collection level", 0, function() {
+    var Collection = Backbone.Collection.extend({
+      parse: function(models) {
+        ok(false);
+      }
+    });
+    var c = new Collection();
+    c.set({id: 1}, {parse: true});
+    c.add([{id: 2}, {id: 3}], {parse: true});
+    c.reset([{id: 4}, {id: 5}], {parse: true});
+  });
+
+  test("#3636 - create does not parse at collection level", 4, function() {
+    var Collection = Backbone.Collection.extend({
+      url: '/test',
+      model: Backbone.Model.extend({
+        parse: function(model) {
+          ok(true);
+          return model.model;
+        }
+      }),
+      parse: function(models) {
+        ok(false);
+      }
+    });
+    var c = new Collection();
+    c.create({}, {parse: true});
+    this.ajaxSettings.success({model: {id: 1}});
+    c.create(c.first(), {parse: true});
+    this.ajaxSettings.success({model: {attr: 'test'}});
+    equal(c.get(1).get('attr'), 'test');
+  });
+
+  test("fetch data is only parsed once", 3, function() {
+    var modelParse = 0;
+    var collectionParse = 0;
+    var Collection = Backbone.Collection.extend({
+      url: '/test',
+      model: Backbone.Model.extend({
+        parse: function(model) {
+          modelParse++;
+          return model.model;
+        }
+      }),
+      parse: function(models) {
+        collectionParse++;
+        return models.models;
+      }
+    });
+    var c = new Collection();
+    c.fetch();
+    this.ajaxSettings.success({models: [{model: {id: 1, attr: 'test'} }] });
+    equal(modelParse, 1);
+    equal(collectionParse, 1);
+    equal(c.get(1).get('attr'), 'test');
   });
 
 })();


### PR DESCRIPTION
**DO NOT MERGE, BREAKING CHANGE** This is for the next major, v2.

This is the revert of #3659 (which reverted #3644). So, really, it's just #3644 (which reverted #1407... reverts! :stuck_out_tongue:).

Why? To mirror `Model`. `Model#set` doesn’t parse for you, only instantiation, `#fetch`, and `#save` parse.
- We do it on instantiation because we have to have an instance to call `#parse` (you can't do it before hand because you don't have an instance)
- We do it on `#fetch` and `#save` because they return data from the server (the reason we have a `#parse`!)

If you need to parse your `Collection`'s data before `#set`, `#reset`, or `#add`, do it beforehand (you already have an instance):
- `collection.set(collection.parse(models));`
- `collection.reset(collection.parse(models));`
- `collection.add(collection.parse(models));`

Or, you can parse on instantiation if you don't have an instance, just like `Model`:
- `new Collection(models, { parse: true });`

And of course, `Collection#fetch` parses at the collection level like it always has.

---

Third times the charm? :stuck_out_tongue_winking_eye: 
