### PR TITLE
fix error when adding model to collection at an out of bounds index

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -766,6 +766,7 @@
 
   // Splices `insert` into `array` at index `at`.
   var splice = function(array, insert, at) {
+    at = Math.min(Math.max(at, 0), array.length);
     var tail = Array(array.length - at);
     var length = insert.length;
     for (var i = 0; i < tail.length; i++) tail[i] = array[i + at];

--- a/test/collection.js
+++ b/test/collection.js
@@ -187,6 +187,13 @@
     equal(col.pluck('id').join(' '), '3 1 2');
   });
 
+  test("add; at should add to the end if the index is out of bounds", 1, function() {
+    var col = new Backbone.Collection([{id: 2}, {id: 3}]);
+    col.add(new Backbone.Model({id: 1}), {at:   5});
+
+    equal(col.pluck('id').join(' '), '2 3 1');
+  });
+
   test("can't add model to collection twice", function() {
     var col = new Backbone.Collection([{id: 1}, {id: 2}, {id: 1}, {id: 2}, {id: 3}]);
     equal(col.pluck('id').join(' '), '1 2 3');
@@ -1626,7 +1633,8 @@
     var collection = new Backbone.Collection([{id: 1}]);
     collection.add([{id: 2}, {id: 3}], {at: -1});
     collection.add([{id: 2.5}], {at: -2});
-    equal(collection.pluck('id').join(','), "1,2,2.5,3");
+    collection.add([{id: 0.5}], {at: -6});
+    equal(collection.pluck('id').join(','), "0.5,1,2,2.5,3");
   });
 
   test("#set accepts options.at as a string", 1, function() {


### PR DESCRIPTION
@jridgewell 

Fixes an issue noticed when running Marionette tests against 1.2.2. Adding a model at index 5 to a collection with a length of 3 throws an error. Previously this would add to the end of the collection.