### PR TITLE
Fixed missing closing b-tag in docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -3001,7 +3001,7 @@ var InputView = Backbone.View.extend({
     </p>
 
     <p>
-      A single-event version of <b>delegateEvents</p> is available as <tt>delegate</tt>.
+      A single-event version of <b>delegateEvents</b> is available as <tt>delegate</tt>.
       In fact, <b>delegateEvents</b> is simply a multi-event wrapper around <tt>delegate</tt>.
       A counterpart to <tt>undelegateEvents</tt> is available as <tt>undelegate</tt>.
     </p>


### PR DESCRIPTION
Half of the docs screamed at us in boldface due to this misspelled tag.