### PR TITLE
Set up subclassing using Object.create

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1857,9 +1857,8 @@
 
     // Set the prototype chain to inherit from `parent`, without calling
     // `parent` constructor function.
-    var Surrogate = function(){ this.constructor = child; };
-    Surrogate.prototype = parent.prototype;
-    child.prototype = new Surrogate;
+    child.prototype = Object.create(parent.prototype);
+    child.prototype.constructor = child;
 
     // Add prototype properties (instance properties) to the subclass,
     // if supplied.


### PR DESCRIPTION
This change eliminates having to define and invoke a Surrogate function, makes the source code more readable, and reduces the size of the backbone.js framework. 

Object.create sets up the prototype delegation relationship without calling the "parent" constructor function. This is more straight forward than using a Surrogate constructor function just for the sake of setting up subclassing.