### PR TITLE
Model events during "remove" do not trigger on Col

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1102,20 +1102,14 @@
         var index = this.indexOf(model);
         this.models.splice(index, 1);
         this.length--;
-
-        // Remove references before triggering 'remove' event to prevent an
-        // infinite loop. #3693
-        delete this._byId[model.cid];
-        var id = this.modelId(model.attributes);
-        if (id != null) delete this._byId[id];
+        this._removeReference(model, options);
+        removed.push(model);
 
         if (!options.silent) {
           options.index = index;
           model.trigger('remove', model, this, options);
+          this._onModelEvent('remove', model, this, options);
         }
-
-        removed.push(model);
-        this._removeReference(model, options);
       }
       return removed.length ? removed : false;
     },

--- a/test/collection.js
+++ b/test/collection.js
@@ -310,8 +310,12 @@
     var result = null;
     col.on('remove', function(model, col, options) {
       removed = model.get('label');
+      model.trigger('other');
       equal(options.index, 3);
       equal(col.get(model), undefined, '#3693: model cannot be fetched from collection');
+    });
+    col.on('other', function() {
+      ok(false, 'Events triggered on model during "remove" listener should not be triggered on collection');
     });
     result = col.remove(d);
     equal(removed, 'd');


### PR DESCRIPTION
**DO NOT MERGE, BREAKING CHANGE** This is for the next major, v2.

On the heels of #3803, this prevents events triggered on the model during the "remove" event listener from bubbling up to the collection.

Why? Because the model is "removed" from the collection. You can't `#get` it any more, there're no more references. The collection shouldn't know anything about the model once that event is fired.