### PR TITLE
Reduce without initial value doesn't work

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -87,6 +87,9 @@
         return _[method](this[attribute], cb(iteratee, this), context);
       };
       case 4: return function(iteratee, defaultVal, context) {
+        if(arguments.length < 2) {
+          return _[method](this[attribute], cb(iteratee, this));
+        }
         return _[method](this[attribute], cb(iteratee, this), defaultVal, context);
       };
       default: return function() {

--- a/test/collection.js
+++ b/test/collection.js
@@ -631,10 +631,11 @@
     equal(coll.findWhere({a: 4}), void 0);
   });
 
-  test("Underscore methods", 19, function() {
+  test("Underscore methods", 20, function() {
     equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
     equal(col.some(function(model){ return model.id === 100; }), false);
     equal(col.some(function(model){ return model.id === 0; }), true);
+    equal(col.reduce(function(a, b) {return a.id > b.id ? a : b}).id, 3);
     equal(col.indexOf(b), 1);
     equal(col.size(), 4);
     equal(col.rest().length, 3);


### PR DESCRIPTION
Underscore's reduce as well as native Array.prototype.reduce can work without initial value.

See two similar calls:
```js
equal(_.reduce(col.models, function(a, b) {return a.id > b.id ? a : b}).id, 3); // works fine
equal(col.reduce(function(a, b) {return a.id > b.id ? a : b}).id, 3); // don't work
```

This behaviour seems to be broken since https://github.com/jashkenas/backbone/commit/7d646745618dc86ff74230a2063083963b7c343a, because this commit forces to call underscore with fixed number of arguments, but underscore detects this count and cannot switch to mode without initial value and starts with undefined.