### PR TITLE
Migrated tests to QUnit 2.0 syntax.

### DIFF
--- a/test/collection.js
+++ b/test/collection.js
@@ -2,9 +2,9 @@
 
   var a, b, c, d, e, col, otherCol;
 
-  module("Backbone.Collection", {
+  QUnit.module("Backbone.Collection", {
 
-    setup: function() {
+    beforeEach: function(assert) {
       a         = new Backbone.Model({id: 3, label: 'a'});
       b         = new Backbone.Model({id: 2, label: 'b'});
       c         = new Backbone.Model({id: 1, label: 'c'});
@@ -16,33 +16,36 @@
 
   });
 
-  test("new and sort", 6, function() {
+  QUnit.test("new and sort", function(assert) {
+    assert.expect(6);
     var counter = 0;
     col.on('sort', function(){ counter++; });
-    deepEqual(col.pluck('label'), ['a', 'b', 'c', 'd']);
+    assert.deepEqual(col.pluck('label'), ['a', 'b', 'c', 'd']);
     col.comparator = function(a, b) {
       return a.id > b.id ? -1 : 1;
     };
     col.sort();
-    equal(counter, 1);
-    deepEqual(col.pluck('label'), ['a', 'b', 'c', 'd']);
+    assert.equal(counter, 1);
+    assert.deepEqual(col.pluck('label'), ['a', 'b', 'c', 'd']);
     col.comparator = function(model) { return model.id; };
     col.sort();
-    equal(counter, 2);
-    deepEqual(col.pluck('label'), ['d', 'c', 'b', 'a']);
-    equal(col.length, 4);
+    assert.equal(counter, 2);
+    assert.deepEqual(col.pluck('label'), ['d', 'c', 'b', 'a']);
+    assert.equal(col.length, 4);
   });
 
-  test("String comparator.", 1, function() {
+  QUnit.test("String comparator.", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection([
       {id: 3},
       {id: 1},
       {id: 2}
     ], {comparator: 'id'});
-    deepEqual(collection.pluck('id'), [1, 2, 3]);
+    assert.deepEqual(collection.pluck('id'), [1, 2, 3]);
   });
 
-  test("new and parse", 3, function() {
+  QUnit.test("new and parse", function(assert) {
+    assert.expect(3);
     var Collection = Backbone.Collection.extend({
       parse : function(data) {
         return _.filter(data, function(datum) {
@@ -52,12 +55,13 @@
     });
     var models = [{a: 1}, {a: 2}, {a: 3}, {a: 4}];
     var collection = new Collection(models, {parse: true});
-    strictEqual(collection.length, 2);
-    strictEqual(collection.first().get('a'), 2);
-    strictEqual(collection.last().get('a'), 4);
+    assert.strictEqual(collection.length, 2);
+    assert.strictEqual(collection.first().get('a'), 2);
+    assert.strictEqual(collection.last().get('a'), 4);
   });
 
-  test("clone preserves model and comparator", 3, function() {
+  QUnit.test("clone preserves model and comparator", function(assert) {
+    assert.expect(3);
     var Model = Backbone.Model.extend();
     var comparator = function(model){ return model.id; };
 
@@ -66,64 +70,70 @@
       comparator: comparator
     }).clone();
     collection.add({id: 2});
-    ok(collection.at(0) instanceof Model);
-    ok(collection.at(1) instanceof Model);
-    strictEqual(collection.comparator, comparator);
+    assert.ok(collection.at(0) instanceof Model);
+    assert.ok(collection.at(1) instanceof Model);
+    assert.strictEqual(collection.comparator, comparator);
   });
 
-  test("get", 6, function() {
-    equal(col.get(0), d);
-    equal(col.get(d.clone()), d);
-    equal(col.get(2), b);
-    equal(col.get({id: 1}), c);
-    equal(col.get(c.clone()), c);
-    equal(col.get(col.first().cid), col.first());
+  QUnit.test("get", function(assert) {
+    assert.expect(6);
+    assert.equal(col.get(0), d);
+    assert.equal(col.get(d.clone()), d);
+    assert.equal(col.get(2), b);
+    assert.equal(col.get({id: 1}), c);
+    assert.equal(col.get(c.clone()), c);
+    assert.equal(col.get(col.first().cid), col.first());
   });
 
-  test("get with non-default ids", 5, function() {
+  QUnit.test("get with non-default ids", function(assert) {
+    assert.expect(5);
     var MongoModel = Backbone.Model.extend({idAttribute: '_id'});
     var model = new MongoModel({_id: 100});
     var col = new Backbone.Collection([model], {model: MongoModel});
-    equal(col.get(100), model);
-    equal(col.get(model.cid), model);
-    equal(col.get(model), model);
-    equal(col.get(101), void 0);
+    assert.equal(col.get(100), model);
+    assert.equal(col.get(model.cid), model);
+    assert.equal(col.get(model), model);
+    assert.equal(col.get(101), void 0);
 
     var col2 = new Backbone.Collection();
     col2.model = MongoModel;
     col2.add(model.attributes);
-    equal(col2.get(model.clone()), col2.first());
+    assert.equal(col2.get(model.clone()), col2.first());
   });
 
-  test('get with "undefined" id', function() {
+  QUnit.test('get with "undefined" id', function(assert) {
     var collection = new Backbone.Collection([{id: 1}, {id: 'undefined'}]);
-    equal(collection.get(1).id, 1);
+    assert.equal(collection.get(1).id, 1);
   });
 
-  test("update index when id changes", 4, function() {
+  QUnit.test("update index when id changes", function(assert) {
+    assert.expect(4);
     var col = new Backbone.Collection();
     col.add([
       {id : 0, name : 'one'},
       {id : 1, name : 'two'}
     ]);
     var one = col.get(0);
-    equal(one.get('name'), 'one');
-    col.on('change:name', function (model) { ok(this.get(model)); });
+    assert.equal(one.get('name'), 'one');
+    col.on('change:name', function (model) { assert.ok(this.get(model)); });
     one.set({name: 'dalmatians', id : 101});
-    equal(col.get(0), null);
-    equal(col.get(101).get('name'), 'dalmatians');
+    assert.equal(col.get(0), null);
+    assert.equal(col.get(101).get('name'), 'dalmatians');
   });
 
-  test("at", 2, function() {
-    equal(col.at(2), c);
-    equal(col.at(-2), c);
+  QUnit.test("at", function(assert) {
+    assert.expect(2);
+    assert.equal(col.at(2), c);
+    assert.equal(col.at(-2), c);
   });
 
-  test("pluck", 1, function() {
-    equal(col.pluck('label').join(' '), 'a b c d');
+  QUnit.test("pluck", function(assert) {
+    assert.expect(1);
+    assert.equal(col.pluck('label').join(' '), 'a b c d');
   });
 
-  test("add", 14, function() {
+  QUnit.test("add", function(assert) {
+    assert.expect(14);
     var added, opts, secondAdded;
     added = opts = secondAdded = null;
     e = new Backbone.Model({id: 10, label : 'e'});
@@ -136,45 +146,47 @@
       opts = options;
     });
     col.add(e, {amazing: true});
-    equal(added, 'e');
-    equal(col.length, 5);
-    equal(col.last(), e);
-    equal(otherCol.length, 1);
-    equal(secondAdded, null);
-    ok(opts.amazing);
+    assert.equal(added, 'e');
+    assert.equal(col.length, 5);
+    assert.equal(col.last(), e);
+    assert.equal(otherCol.length, 1);
+    assert.equal(secondAdded, null);
+    assert.ok(opts.amazing);
 
     var f = new Backbone.Model({id: 20, label : 'f'});
     var g = new Backbone.Model({id: 21, label : 'g'});
     var h = new Backbone.Model({id: 22, label : 'h'});
     var atCol = new Backbone.Collection([f, g, h]);
-    equal(atCol.length, 3);
+    assert.equal(atCol.length, 3);
     atCol.add(e, {at: 1});
-    equal(atCol.length, 4);
-    equal(atCol.at(1), e);
-    equal(atCol.last(), h);
+    assert.equal(atCol.length, 4);
+    assert.equal(atCol.at(1), e);
+    assert.equal(atCol.last(), h);
 
     var coll = new Backbone.Collection(new Array(2));
     var addCount = 0;
     coll.on('add', function(){
-        addCount += 1;
+      addCount += 1;
     });
     coll.add([undefined, f, g]);
-    equal(coll.length, 5);
-    equal(addCount, 3);
+    assert.equal(coll.length, 5);
+    assert.equal(addCount, 3);
     coll.add(new Array(4));
-    equal(coll.length, 9);
-    equal(addCount, 7);
+    assert.equal(coll.length, 9);
+    assert.equal(addCount, 7);
   });
 
-  test("add multiple models", 6, function() {
+  QUnit.test("add multiple models", function(assert) {
+    assert.expect(6);
     var col = new Backbone.Collection([{at: 0}, {at: 1}, {at: 9}]);
     col.add([{at: 2}, {at: 3}, {at: 4}, {at: 5}, {at: 6}, {at: 7}, {at: 8}], {at: 2});
     for (var i = 0; i <= 5; i++) {
-      equal(col.at(i).get('at'), i);
+      assert.equal(col.at(i).get('at'), i);
     }
   });
 
-  test("add; at should have preference over comparator", 1, function() {
+  QUnit.test("add; at should have preference over comparator", function(assert) {
+    assert.expect(1);
     var Col = Backbone.Collection.extend({
       comparator: function(a,b) {
         return a.id > b.id ? -1 : 1;
@@ -184,68 +196,73 @@
     var col = new Col([{id: 2}, {id: 3}]);
     col.add(new Backbone.Model({id: 1}), {at:   1});
 
-    equal(col.pluck('id').join(' '), '3 1 2');
+    assert.equal(col.pluck('id').join(' '), '3 1 2');
   });
 
-  test("add; at should add to the end if the index is out of bounds", 1, function() {
+  QUnit.test("add; at should add to the end if the index is out of bounds", function(assert) {
+    assert.expect(1);
     var col = new Backbone.Collection([{id: 2}, {id: 3}]);
     col.add(new Backbone.Model({id: 1}), {at:   5});
 
-    equal(col.pluck('id').join(' '), '2 3 1');
+    assert.equal(col.pluck('id').join(' '), '2 3 1');
   });
 
-  test("can't add model to collection twice", function() {
+  QUnit.test("can't add model to collection twice", function(assert) {
     var col = new Backbone.Collection([{id: 1}, {id: 2}, {id: 1}, {id: 2}, {id: 3}]);
-    equal(col.pluck('id').join(' '), '1 2 3');
+    assert.equal(col.pluck('id').join(' '), '1 2 3');
   });
 
-  test("can't add different model with same id to collection twice", 1, function() {
+  QUnit.test("can't add different model with same id to collection twice", function(assert) {
+    assert.expect(1);
     var col = new Backbone.Collection;
     col.unshift({id: 101});
     col.add({id: 101});
-    equal(col.length, 1);
+    assert.equal(col.length, 1);
   });
 
-  test("merge in duplicate models with {merge: true}", 3, function() {
+  QUnit.test("merge in duplicate models with {merge: true}", function(assert) {
+    assert.expect(3);
     var col = new Backbone.Collection;
     col.add([{id: 1, name: 'Moe'}, {id: 2, name: 'Curly'}, {id: 3, name: 'Larry'}]);
     col.add({id: 1, name: 'Moses'});
-    equal(col.first().get('name'), 'Moe');
+    assert.equal(col.first().get('name'), 'Moe');
     col.add({id: 1, name: 'Moses'}, {merge: true});
-    equal(col.first().get('name'), 'Moses');
+    assert.equal(col.first().get('name'), 'Moses');
     col.add({id: 1, name: 'Tim'}, {merge: true, silent: true});
-    equal(col.first().get('name'), 'Tim');
+    assert.equal(col.first().get('name'), 'Tim');
   });
 
-  test("add model to multiple collections", 10, function() {
+  QUnit.test("add model to multiple collections", function(assert) {
+    assert.expect(10);
     var counter = 0;
     var e = new Backbone.Model({id: 10, label : 'e'});
     e.on('add', function(model, collection) {
       counter++;
-      equal(e, model);
+      assert.equal(e, model);
       if (counter > 1) {
-        equal(collection, colF);
+        assert.equal(collection, colF);
       } else {
-        equal(collection, colE);
+        assert.equal(collection, colE);
       }
     });
     var colE = new Backbone.Collection([]);
     colE.on('add', function(model, collection) {
-      equal(e, model);
-      equal(colE, collection);
+      assert.equal(e, model);
+      assert.equal(colE, collection);
     });
     var colF = new Backbone.Collection([]);
     colF.on('add', function(model, collection) {
-      equal(e, model);
-      equal(colF, collection);
+      assert.equal(e, model);
+      assert.equal(colF, collection);
     });
     colE.add(e);
-    equal(e.collection, colE);
+    assert.equal(e.collection, colE);
     colF.add(e);
-    equal(e.collection, colE);
+    assert.equal(e.collection, colE);
   });
 
-  test("add model with parse", 1, function() {
+  QUnit.test("add model with parse", function(assert) {
+    assert.expect(1);
     var Model = Backbone.Model.extend({
       parse: function(obj) {
         obj.value += 1;
@@ -256,10 +273,10 @@
     var Col = Backbone.Collection.extend({model: Model});
     var col = new Col;
     col.add({value: 1}, {parse: true});
-    equal(col.at(0).get('value'), 2);
+    assert.equal(col.at(0).get('value'), 2);
   });
 
-  test("add with parse and merge", function() {
+  QUnit.test("add with parse and merge", function(assert) {
     var collection = new Backbone.Collection();
     collection.parse = function(attrs) {
       return _.map(attrs, function(model) {
@@ -269,10 +286,11 @@
     };
     collection.add({id: 1});
     collection.add({model: {id: 1, name: 'Alf'}}, {parse: true, merge: true});
-    equal(collection.first().get('name'), 'Alf');
+    assert.equal(collection.first().get('name'), 'Alf');
   });
 
-  test("add model to collection with sort()-style comparator", 3, function() {
+  QUnit.test("add model to collection with sort()-style comparator", function(assert) {
+    assert.expect(3);
     var col = new Backbone.Collection;
     col.comparator = function(a, b) {
       return a.get('name') < b.get('name') ? -1 : 1;
@@ -283,12 +301,13 @@
     col.add(tom);
     col.add(rob);
     col.add(tim);
-    equal(col.indexOf(rob), 0);
-    equal(col.indexOf(tim), 1);
-    equal(col.indexOf(tom), 2);
+    assert.equal(col.indexOf(rob), 0);
+    assert.equal(col.indexOf(tim), 1);
+    assert.equal(col.indexOf(tom), 2);
   });
 
-  test("comparator that depends on `this`", 2, function() {
+  QUnit.test("comparator that depends on `this`", function(assert) {
+    assert.expect(2);
     var col = new Backbone.Collection;
     col.negative = function(num) {
       return -num;
@@ -297,40 +316,42 @@
       return this.negative(a.id);
     };
     col.add([{id: 1}, {id: 2}, {id: 3}]);
-    deepEqual(col.pluck('id'), [3, 2, 1]);
+    assert.deepEqual(col.pluck('id'), [3, 2, 1]);
     col.comparator = function(a, b) {
       return this.negative(b.id) - this.negative(a.id);
     };
     col.sort();
-    deepEqual(col.pluck('id'), [1, 2, 3]);
+    assert.deepEqual(col.pluck('id'), [1, 2, 3]);
   });
 
-  test("remove", 11, function() {
+  QUnit.test("remove", function(assert) {
+    assert.expect(11);
     var removed = null;
     var result = null;
     col.on('remove', function(model, col, options) {
       removed = model.get('label');
-      equal(options.index, 3);
-      equal(col.get(model), undefined, '#3693: model cannot be fetched from collection');
+      assert.equal(options.index, 3);
+      assert.equal(col.get(model), undefined, '#3693: model cannot be fetched from collection');
     });
     result = col.remove(d);
-    equal(removed, 'd');
-    strictEqual(result, d);
+    assert.equal(removed, 'd');
+    assert.strictEqual(result, d);
     //if we try to remove d again, it's not going to actually get removed
     result = col.remove(d);
-    strictEqual(result, undefined);
-    equal(col.length, 3);
-    equal(col.first(), a);
+    assert.strictEqual(result, undefined);
+    assert.equal(col.length, 3);
+    assert.equal(col.first(), a);
     col.off();
     result = col.remove([c, d]);
-    equal(result.length, 1, 'only returns removed models');
-    equal(result[0], c, 'only returns removed models');
+    assert.equal(result.length, 1, 'only returns removed models');
+    assert.equal(result[0], c, 'only returns removed models');
     result = col.remove([c, b]);
-    equal(result.length, 1, 'only returns removed models');
-    equal(result[0], b, 'only returns removed models');
+    assert.equal(result.length, 1, 'only returns removed models');
+    assert.equal(result[0], b, 'only returns removed models');
   });
 
-  test("add and remove return values", 13, function() {
+  QUnit.test("add and remove return values", function(assert) {
+    assert.expect(13);
     var Even = Backbone.Model.extend({
       validate: function(attrs) {
         if (attrs.id % 2 !== 0) return "odd";
@@ -340,56 +361,60 @@
     col.model = Even;
 
     var list = col.add([{id: 2}, {id: 4}], {validate: true});
-    equal(list.length, 2);
-    ok(list[0] instanceof Backbone.Model);
-    equal(list[1], col.last());
-    equal(list[1].get('id'), 4);
+    assert.equal(list.length, 2);
+    assert.ok(list[0] instanceof Backbone.Model);
+    assert.equal(list[1], col.last());
+    assert.equal(list[1].get('id'), 4);
 
     list = col.add([{id: 3}, {id: 6}], {validate: true});
-    equal(col.length, 3);
-    equal(list[0], false);
-    equal(list[1].get('id'), 6);
+    assert.equal(col.length, 3);
+    assert.equal(list[0], false);
+    assert.equal(list[1].get('id'), 6);
 
     var result = col.add({id: 6});
-    equal(result.cid, list[1].cid);
+    assert.equal(result.cid, list[1].cid);
 
     result = col.remove({id: 6});
-    equal(col.length, 2);
-    equal(result.id, 6);
+    assert.equal(col.length, 2);
+    assert.equal(result.id, 6);
 
     list = col.remove([{id: 2}, {id: 8}]);
-    equal(col.length, 1);
-    equal(list[0].get('id'), 2);
-    equal(list[1], null);
+    assert.equal(col.length, 1);
+    assert.equal(list[0].get('id'), 2);
+    assert.equal(list[1], null);
   });
 
-  test("shift and pop", 2, function() {
+  QUnit.test("shift and pop", function(assert) {
+    assert.expect(2);
     var col = new Backbone.Collection([{a: 'a'}, {b: 'b'}, {c: 'c'}]);
-    equal(col.shift().get('a'), 'a');
-    equal(col.pop().get('c'), 'c');
+    assert.equal(col.shift().get('a'), 'a');
+    assert.equal(col.pop().get('c'), 'c');
   });
 
-  test("slice", 2, function() {
+  QUnit.test("slice", function(assert) {
+    assert.expect(2);
     var col = new Backbone.Collection([{a: 'a'}, {b: 'b'}, {c: 'c'}]);
     var array = col.slice(1, 3);
-    equal(array.length, 2);
-    equal(array[0].get('b'), 'b');
+    assert.equal(array.length, 2);
+    assert.equal(array[0].get('b'), 'b');
   });
 
-  test("events are unbound on remove", 3, function() {
+  QUnit.test("events are unbound on remove", function(assert) {
+    assert.expect(3);
     var counter = 0;
     var dj = new Backbone.Model();
     var emcees = new Backbone.Collection([dj]);
     emcees.on('change', function(){ counter++; });
     dj.set({name : 'Kool'});
-    equal(counter, 1);
+    assert.equal(counter, 1);
     emcees.reset([]);
-    equal(dj.collection, undefined);
+    assert.equal(dj.collection, undefined);
     dj.set({name : 'Shadow'});
-    equal(counter, 1);
+    assert.equal(counter, 1);
   });
 
-  test("remove in multiple collections", 7, function() {
+  QUnit.test("remove in multiple collections", function(assert) {
+    assert.expect(7);
     var modelData = {
       id : 5,
       title : 'Othello'
@@ -402,101 +427,107 @@
     });
     var colE = new Backbone.Collection([e]);
     var colF = new Backbone.Collection([f]);
-    ok(e != f);
-    ok(colE.length === 1);
-    ok(colF.length === 1);
+    assert.ok(e != f);
+    assert.ok(colE.length === 1);
+    assert.ok(colF.length === 1);
     colE.remove(e);
-    equal(passed, false);
-    ok(colE.length === 0);
+    assert.equal(passed, false);
+    assert.ok(colE.length === 0);
     colF.remove(e);
-    ok(colF.length === 0);
-    equal(passed, true);
+    assert.ok(colF.length === 0);
+    assert.equal(passed, true);
   });
 
-  test("remove same model in multiple collection", 16, function() {
+  QUnit.test("remove same model in multiple collection", function(assert) {
+    assert.expect(16);
     var counter = 0;
     var e = new Backbone.Model({id: 5, title: 'Othello'});
     e.on('remove', function(model, collection) {
       counter++;
-      equal(e, model);
+      assert.equal(e, model);
       if (counter > 1) {
-        equal(collection, colE);
+        assert.equal(collection, colE);
       } else {
-        equal(collection, colF);
+        assert.equal(collection, colF);
       }
     });
     var colE = new Backbone.Collection([e]);
     colE.on('remove', function(model, collection) {
-      equal(e, model);
-      equal(colE, collection);
+      assert.equal(e, model);
+      assert.equal(colE, collection);
     });
     var colF = new Backbone.Collection([e]);
     colF.on('remove', function(model, collection) {
-      equal(e, model);
-      equal(colF, collection);
+      assert.equal(e, model);
+      assert.equal(colF, collection);
     });
-    equal(colE, e.collection);
+    assert.equal(colE, e.collection);
     colF.remove(e);
-    ok(colF.length === 0);
-    ok(colE.length === 1);
-    equal(counter, 1);
-    equal(colE, e.collection);
+    assert.ok(colF.length === 0);
+    assert.ok(colE.length === 1);
+    assert.equal(counter, 1);
+    assert.equal(colE, e.collection);
     colE.remove(e);
-    equal(null, e.collection);
-    ok(colE.length === 0);
-    equal(counter, 2);
+    assert.equal(null, e.collection);
+    assert.ok(colE.length === 0);
+    assert.equal(counter, 2);
   });
 
-  test("model destroy removes from all collections", 3, function() {
+  QUnit.test("model destroy removes from all collections", function(assert) {
+    assert.expect(3);
     var e = new Backbone.Model({id: 5, title: 'Othello'});
     e.sync = function(method, model, options) { options.success(); };
     var colE = new Backbone.Collection([e]);
     var colF = new Backbone.Collection([e]);
     e.destroy();
-    ok(colE.length === 0);
-    ok(colF.length === 0);
-    equal(undefined, e.collection);
+    assert.ok(colE.length === 0);
+    assert.ok(colF.length === 0);
+    assert.equal(undefined, e.collection);
   });
 
-  test("Colllection: non-persisted model destroy removes from all collections", 3, function() {
+  QUnit.test("Collection: non-persisted model destroy removes from all collections", function(assert) {
+    assert.expect(3);
     var e = new Backbone.Model({title: 'Othello'});
     e.sync = function(method, model, options) { throw "should not be called"; };
     var colE = new Backbone.Collection([e]);
     var colF = new Backbone.Collection([e]);
     e.destroy();
-    ok(colE.length === 0);
-    ok(colF.length === 0);
-    equal(undefined, e.collection);
+    assert.ok(colE.length === 0);
+    assert.ok(colF.length === 0);
+    assert.equal(undefined, e.collection);
   });
 
-  test("fetch", 4, function() {
+  QUnit.test("fetch", function(assert) {
+    assert.expect(4);
     var collection = new Backbone.Collection;
     collection.url = '/test';
     collection.fetch();
-    equal(this.syncArgs.method, 'read');
-    equal(this.syncArgs.model, collection);
-    equal(this.syncArgs.options.parse, true);
+    assert.equal(this.syncArgs.method, 'read');
+    assert.equal(this.syncArgs.model, collection);
+    assert.equal(this.syncArgs.options.parse, true);
 
     collection.fetch({parse: false});
-    equal(this.syncArgs.options.parse, false);
+    assert.equal(this.syncArgs.options.parse, false);
   });
 
-  test("fetch with an error response triggers an error event", 1, function () {
+  QUnit.test("fetch with an error response triggers an error event", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection();
     collection.on('error', function () {
-      ok(true);
+      assert.ok(true);
     });
     collection.sync = function (method, model, options) { options.error(); };
     collection.fetch();
   });
 
-  test("#3283 - fetch with an error response calls error with context", 1, function () {
+  QUnit.test("#3283 - fetch with an error response calls error with context", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection();
     var obj = {};
     var options = {
       context: obj,
       error: function() {
-        equal(this, obj);
+        assert.equal(this, obj);
       }
     };
     collection.sync = function (method, model, options) {
@@ -505,7 +536,8 @@
     collection.fetch(options);
   });
 
-  test("ensure fetch only parses once", 1, function() {
+  QUnit.test("ensure fetch only parses once", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection;
     var counter = 0;
     collection.parse = function(models) {
@@ -515,20 +547,22 @@
     collection.url = '/test';
     collection.fetch();
     this.syncArgs.options.success([]);
-    equal(counter, 1);
+    assert.equal(counter, 1);
   });
 
-  test("create", 4, function() {
+  QUnit.test("create", function(assert) {
+    assert.expect(4);
     var collection = new Backbone.Collection;
     collection.url = '/test';
     var model = collection.create({label: 'f'}, {wait: true});
-    equal(this.syncArgs.method, 'create');
-    equal(this.syncArgs.model, model);
-    equal(model.get('label'), 'f');
-    equal(model.collection, collection);
+    assert.equal(this.syncArgs.method, 'create');
+    assert.equal(this.syncArgs.model, model);
+    assert.equal(model.get('label'), 'f');
+    assert.equal(model.collection, collection);
   });
 
-  test("create with validate:true enforces validation", 3, function() {
+  QUnit.test("create with validate:true enforces validation", function(assert) {
+    assert.expect(3);
     var ValidatingModel = Backbone.Model.extend({
       validate: function(attrs) {
         return "fail";
@@ -539,13 +573,14 @@
     });
     var col = new ValidatingCollection();
     col.on('invalid', function (collection, error, options) {
-      equal(error, "fail");
-      equal(options.validationError, 'fail');
+      assert.equal(error, "fail");
+      assert.equal(options.validationError, 'fail');
     });
-    equal(col.create({"foo":"bar"}, {validate:true}), false);
+    assert.equal(col.create({"foo":"bar"}, {validate:true}), false);
   });
 
-  test("create will pass extra options to success callback", 1, function () {
+  QUnit.test("create will pass extra options to success callback", function(assert) {
+    assert.expect(1);
     var Model = Backbone.Model.extend({
       sync: function (method, model, options) {
         _.extend(options, {specialSync: true});
@@ -561,19 +596,19 @@
     var collection = new Collection;
 
     var success = function (model, response, options) {
-      ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, "Options were passed correctly to callback");
     };
 
     collection.create({}, {success: success});
     this.ajaxSettings.success();
-
   });
 
-  test("create with wait:true should not call collection.parse", 0, function() {
+  QUnit.test("create with wait:true should not call collection.parse", function(assert) {
+    assert.expect(0);
     var Collection = Backbone.Collection.extend({
       url: '/test',
       parse: function () {
-        ok(false);
+        assert.ok(false);
       }
     });
 
@@ -583,7 +618,7 @@
     this.ajaxSettings.success();
   });
 
-  test("a failing create returns model with errors", function() {
+  QUnit.test("a failing create returns model with errors", function(assert) {
     var ValidatingModel = Backbone.Model.extend({
       validate: function(attrs) {
         return "fail";
@@ -594,25 +629,28 @@
     });
     var col = new ValidatingCollection();
     var m = col.create({"foo":"bar"});
-    equal(m.validationError, 'fail');
-    equal(col.length, 1);
+    assert.equal(m.validationError, 'fail');
+    assert.equal(col.length, 1);
   });
 
-  test("initialize", 1, function() {
+  QUnit.test("initialize", function(assert) {
+    assert.expect(1);
     var Collection = Backbone.Collection.extend({
       initialize: function() {
         this.one = 1;
       }
     });
     var coll = new Collection;
-    equal(coll.one, 1);
+    assert.equal(coll.one, 1);
   });
 
-  test("toJSON", 1, function() {
-    equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
+  QUnit.test("toJSON", function(assert) {
+    assert.expect(1);
+    assert.equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });
 
-  test("where and findWhere", 8, function() {
+  QUnit.test("where and findWhere", function(assert) {
+    assert.expect(8);
     var model = new Backbone.Model({a: 1});
     var coll = new Backbone.Collection([
       model,
@@ -621,46 +659,48 @@
       {a: 2, b: 2},
       {a: 3}
     ]);
-    equal(coll.where({a: 1}).length, 3);
-    equal(coll.where({a: 2}).length, 1);
-    equal(coll.where({a: 3}).length, 1);
-    equal(coll.where({b: 1}).length, 0);
-    equal(coll.where({b: 2}).length, 2);
-    equal(coll.where({a: 1, b: 2}).length, 1);
-    equal(coll.findWhere({a: 1}), model);
-    equal(coll.findWhere({a: 4}), void 0);
+    assert.equal(coll.where({a: 1}).length, 3);
+    assert.equal(coll.where({a: 2}).length, 1);
+    assert.equal(coll.where({a: 3}).length, 1);
+    assert.equal(coll.where({b: 1}).length, 0);
+    assert.equal(coll.where({b: 2}).length, 2);
+    assert.equal(coll.where({a: 1, b: 2}).length, 1);
+    assert.equal(coll.findWhere({a: 1}), model);
+    assert.equal(coll.findWhere({a: 4}), void 0);
   });
 
-  test("Underscore methods", 19, function() {
-    equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
-    equal(col.some(function(model){ return model.id === 100; }), false);
-    equal(col.some(function(model){ return model.id === 0; }), true);
-    equal(col.indexOf(b), 1);
-    equal(col.size(), 4);
-    equal(col.rest().length, 3);
-    ok(!_.includes(col.rest(), a));
-    ok(_.includes(col.rest(), d));
-    ok(!col.isEmpty());
-    ok(!_.includes(col.without(d), d));
+  QUnit.test("Underscore methods", function(assert) {
+    assert.expect(19);
+    assert.equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
+    assert.equal(col.some(function(model){ return model.id === 100; }), false);
+    assert.equal(col.some(function(model){ return model.id === 0; }), true);
+    assert.equal(col.indexOf(b), 1);
+    assert.equal(col.size(), 4);
+    assert.equal(col.rest().length, 3);
+    assert.ok(!_.includes(col.rest(), a));
+    assert.ok(_.includes(col.rest(), d));
+    assert.ok(!col.isEmpty());
+    assert.ok(!_.includes(col.without(d), d));
 
     var wrapped = col.chain();
-    equal(wrapped.map('id').max().value(), 3);
-    equal(wrapped.map('id').min().value(), 0);
-    deepEqual(wrapped
-            .filter(function(o){ return o.id % 2 === 0; })
-            .map(function(o){ return o.id * 2; })
-            .value(),
-          [4, 0]);
-    deepEqual(col.difference([c, d]), [a, b]);
-    ok(col.includes(col.sample()));
+    assert.equal(wrapped.map('id').max().value(), 3);
+    assert.equal(wrapped.map('id').min().value(), 0);
+    assert.deepEqual(wrapped
+      .filter(function(o){ return o.id % 2 === 0; })
+      .map(function(o){ return o.id * 2; })
+      .value(),
+      [4, 0]);
+    assert.deepEqual(col.difference([c, d]), [a, b]);
+    assert.ok(col.includes(col.sample()));
     var first = col.first();
-    deepEqual(col.groupBy(function(model){ return model.id; })[first.id], [first]);
-    deepEqual(col.countBy(function(model){ return model.id; }), {0: 1, 1: 1, 2: 1, 3: 1});
-    deepEqual(col.sortBy(function(model){ return model.id; })[0], col.at(3));
-    ok(col.indexBy('id')[first.id] === first);
+    assert.deepEqual(col.groupBy(function(model){ return model.id; })[first.id], [first]);
+    assert.deepEqual(col.countBy(function(model){ return model.id; }), {0: 1, 1: 1, 2: 1, 3: 1});
+    assert.deepEqual(col.sortBy(function(model){ return model.id; })[0], col.at(3));
+    assert.ok(col.indexBy('id')[first.id] === first);
   });
 
-  test("Underscore methods with object-style and property-style iteratee", 26, function () {
+  QUnit.test("Underscore methods with object-style and property-style iteratee", function(assert) {
+    assert.expect(26);
     var model = new Backbone.Model({a: 4, b: 1, e: 3});
     var coll = new Backbone.Collection([
       {a: 1, b: 1},
@@ -668,79 +708,81 @@
       {a: 3, b: 1},
       model
     ]);
-    equal(coll.find({a: 0}), undefined);
-    deepEqual(coll.find({a: 4}), model);
-    equal(coll.find('d'), undefined);
-    deepEqual(coll.find('e'), model);
-    equal(coll.filter({a: 0}), false);
-    deepEqual(coll.filter({a: 4}), [model]);
-    equal(coll.some({a: 0}), false);
-    equal(coll.some({a: 1}), true);
-    equal(coll.reject({a: 0}).length, 4);
-    deepEqual(coll.reject({a: 4}), _.without(coll.models, model));
-    equal(coll.every({a: 0}), false);
-    equal(coll.every({b: 1}), true);
-    deepEqual(coll.partition({a: 0})[0], []);
-    deepEqual(coll.partition({a: 0})[1], coll.models);
-    deepEqual(coll.partition({a: 4})[0], [model]);
-    deepEqual(coll.partition({a: 4})[1], _.without(coll.models, model));
-    deepEqual(coll.map({a: 2}), [false, true, false, false]);
-    deepEqual(coll.map('a'), [1, 2, 3, 4]);
-    deepEqual(coll.sortBy('a')[3], model);
-    deepEqual(coll.sortBy('e')[0], model);
-    deepEqual(coll.countBy({a: 4}), {'false': 3, 'true': 1});
-    deepEqual(coll.countBy('d'), {'undefined': 4});
-    equal(coll.findIndex({b: 1}), 0);
-    equal(coll.findIndex({b: 9}), -1);
-    equal(coll.findLastIndex({b: 1}), 3);
-    equal(coll.findLastIndex({b: 9}), -1);
+    assert.equal(coll.find({a: 0}), undefined);
+    assert.deepEqual(coll.find({a: 4}), model);
+    assert.equal(coll.find('d'), undefined);
+    assert.deepEqual(coll.find('e'), model);
+    assert.equal(coll.filter({a: 0}), false);
+    assert.deepEqual(coll.filter({a: 4}), [model]);
+    assert.equal(coll.some({a: 0}), false);
+    assert.equal(coll.some({a: 1}), true);
+    assert.equal(coll.reject({a: 0}).length, 4);
+    assert.deepEqual(coll.reject({a: 4}), _.without(coll.models, model));
+    assert.equal(coll.every({a: 0}), false);
+    assert.equal(coll.every({b: 1}), true);
+    assert.deepEqual(coll.partition({a: 0})[0], []);
+    assert.deepEqual(coll.partition({a: 0})[1], coll.models);
+    assert.deepEqual(coll.partition({a: 4})[0], [model]);
+    assert.deepEqual(coll.partition({a: 4})[1], _.without(coll.models, model));
+    assert.deepEqual(coll.map({a: 2}), [false, true, false, false]);
+    assert.deepEqual(coll.map('a'), [1, 2, 3, 4]);
+    assert.deepEqual(coll.sortBy('a')[3], model);
+    assert.deepEqual(coll.sortBy('e')[0], model);
+    assert.deepEqual(coll.countBy({a: 4}), {'false': 3, 'true': 1});
+    assert.deepEqual(coll.countBy('d'), {'undefined': 4});
+    assert.equal(coll.findIndex({b: 1}), 0);
+    assert.equal(coll.findIndex({b: 9}), -1);
+    assert.equal(coll.findLastIndex({b: 1}), 3);
+    assert.equal(coll.findLastIndex({b: 9}), -1);
   });
 
-  test("reset", 16, function() {
+  QUnit.test("reset", function(assert) {
+    assert.expect(16);
     var resetCount = 0;
     var models = col.models;
     col.on('reset', function() { resetCount += 1; });
     col.reset([]);
-    equal(resetCount, 1);
-    equal(col.length, 0);
-    equal(col.last(), null);
+    assert.equal(resetCount, 1);
+    assert.equal(col.length, 0);
+    assert.equal(col.last(), null);
     col.reset(models);
-    equal(resetCount, 2);
-    equal(col.length, 4);
-    equal(col.last(), d);
+    assert.equal(resetCount, 2);
+    assert.equal(col.length, 4);
+    assert.equal(col.last(), d);
     col.reset(_.map(models, function(m){ return m.attributes; }));
-    equal(resetCount, 3);
-    equal(col.length, 4);
-    ok(col.last() !== d);
-    ok(_.isEqual(col.last().attributes, d.attributes));
+    assert.equal(resetCount, 3);
+    assert.equal(col.length, 4);
+    assert.ok(col.last() !== d);
+    assert.ok(_.isEqual(col.last().attributes, d.attributes));
     col.reset();
-    equal(col.length, 0);
-    equal(resetCount, 4);
+    assert.equal(col.length, 0);
+    assert.equal(resetCount, 4);
 
     var f = new Backbone.Model({id: 20, label : 'f'});
     col.reset([undefined, f]);
-    equal(col.length, 2);
-    equal(resetCount, 5);
+    assert.equal(col.length, 2);
+    assert.equal(resetCount, 5);
 
     col.reset(new Array(4));
-    equal(col.length, 4);
-    equal(resetCount, 6);
+    assert.equal(col.length, 4);
+    assert.equal(resetCount, 6);
   });
 
-  test ("reset with different values", function(){
+  QUnit.test ("reset with different values", function(assert) {
     var col = new Backbone.Collection({id: 1});
     col.reset({id: 1, a: 1});
-    equal(col.get(1).get('a'), 1);
+    assert.equal(col.get(1).get('a'), 1);
   });
 
-  test("same references in reset", function() {
+  QUnit.test("same references in reset", function(assert) {
     var model = new Backbone.Model({id: 1});
     var collection = new Backbone.Collection({id: 1});
     collection.reset(model);
-    equal(collection.get(1), model);
+    assert.equal(collection.get(1), model);
   });
 
-  test("reset passes caller options", 3, function() {
+  QUnit.test("reset passes caller options", function(assert) {
+    assert.expect(3);
     var Model = Backbone.Model.extend({
       initialize: function(attrs, options) {
         this.model_parameter = options.model_parameter;
@@ -748,44 +790,48 @@
     });
     var col = new (Backbone.Collection.extend({ model: Model }))();
     col.reset([{ astring: "green", anumber: 1 }, { astring: "blue", anumber: 2 }], { model_parameter: 'model parameter' });
-    equal(col.length, 2);
+    assert.equal(col.length, 2);
     col.each(function(model) {
-      equal(model.model_parameter, 'model parameter');
+      assert.equal(model.model_parameter, 'model parameter');
     });
   });
 
-  test("reset does not alter options by reference", 2, function() {
+  QUnit.test("reset does not alter options by reference", function(assert) {
+    assert.expect(2);
     var col = new Backbone.Collection([{id:1}]);
     var origOpts = {};
     col.on("reset", function(col, opts){
-      equal(origOpts.previousModels, undefined);
-      equal(opts.previousModels[0].id, 1);
+      assert.equal(origOpts.previousModels, undefined);
+      assert.equal(opts.previousModels[0].id, 1);
     });
     col.reset([], origOpts);
   });
 
-  test("trigger custom events on models", 1, function() {
+  QUnit.test("trigger custom events on models", function(assert) {
+    assert.expect(1);
     var fired = null;
     a.on("custom", function() { fired = true; });
     a.trigger("custom");
-    equal(fired, true);
+    assert.equal(fired, true);
   });
 
-  test("add does not alter arguments", 2, function(){
+  QUnit.test("add does not alter arguments", function(assert) {
+    assert.expect(2);
     var attrs = {};
     var models = [attrs];
     new Backbone.Collection().add(models);
-    equal(models.length, 1);
-    ok(attrs === models[0]);
+    assert.equal(models.length, 1);
+    assert.ok(attrs === models[0]);
   });
 
-  test("#714: access `model.collection` in a brand new model.", 2, function() {
+  QUnit.test("#714: access `model.collection` in a brand new model.", function(assert) {
+    assert.expect(2);
     var collection = new Backbone.Collection;
     collection.url = '/test';
     var Model = Backbone.Model.extend({
       set: function(attrs) {
-        equal(attrs.prop, 'value');
-        equal(this.collection, collection);
+        assert.equal(attrs.prop, 'value');
+        assert.equal(this.collection, collection);
         return this;
       }
     });
@@ -793,16 +839,18 @@
     collection.create({prop: 'value'});
   });
 
-  test("#574, remove its own reference to the .models array.", 2, function() {
+  QUnit.test("#574, remove its own reference to the .models array.", function(assert) {
+    assert.expect(2);
     var col = new Backbone.Collection([
       {id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}
     ]);
-    equal(col.length, 6);
+    assert.equal(col.length, 6);
     col.remove(col.models);
-    equal(col.length, 0);
+    assert.equal(col.length, 0);
   });
 
-  test("#861, adding models to a collection which do not pass validation, with validate:true", 2, function() {
+  QUnit.test("#861, adding models to a collection which do not pass validation, with validate:true", function(assert) {
+    assert.expect(2);
     var Model = Backbone.Model.extend({
       validate: function(attrs) {
         if (attrs.id == 3) return "id can't be 3";
@@ -814,61 +862,67 @@
     });
 
     var collection = new Collection;
-    collection.on("invalid", function() { ok(true); });
+    collection.on("invalid", function() { assert.ok(true); });
 
     collection.add([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}], {validate:true});
-    deepEqual(collection.pluck("id"), [1, 2, 4, 5, 6]);
+    assert.deepEqual(collection.pluck("id"), [1, 2, 4, 5, 6]);
   });
 
-  test("Invalid models are discarded with validate:true.", 5, function() {
+  QUnit.test("Invalid models are discarded with validate:true.", function(assert) {
+    assert.expect(5);
     var collection = new Backbone.Collection;
-    collection.on('test', function() { ok(true); });
+    collection.on('test', function() { assert.ok(true); });
     collection.model = Backbone.Model.extend({
       validate: function(attrs){ if (!attrs.valid) return 'invalid'; }
     });
     var model = new collection.model({id: 1, valid: true});
     collection.add([model, {id: 2}], {validate:true});
     model.trigger('test');
-    ok(collection.get(model.cid));
-    ok(collection.get(1));
-    ok(!collection.get(2));
-    equal(collection.length, 1);
+    assert.ok(collection.get(model.cid));
+    assert.ok(collection.get(1));
+    assert.ok(!collection.get(2));
+    assert.equal(collection.length, 1);
   });
 
-  test("multiple copies of the same model", 3, function() {
+  QUnit.test("multiple copies of the same model", function(assert) {
+    assert.expect(3);
     var col = new Backbone.Collection();
     var model = new Backbone.Model();
     col.add([model, model]);
-    equal(col.length, 1);
+    assert.equal(col.length, 1);
     col.add([{id: 1}, {id: 1}]);
-    equal(col.length, 2);
-    equal(col.last().id, 1);
+    assert.equal(col.length, 2);
+    assert.equal(col.last().id, 1);
   });
 
-  test("#964 - collection.get return inconsistent", 2, function() {
+  QUnit.test("#964 - collection.get return inconsistent", function(assert) {
+    assert.expect(2);
     var c = new Backbone.Collection();
-    ok(c.get(null) === undefined);
-    ok(c.get() === undefined);
+    assert.ok(c.get(null) === undefined);
+    assert.ok(c.get() === undefined);
   });
 
-  test("#1112 - passing options.model sets collection.model", 2, function() {
+  QUnit.test("#1112 - passing options.model sets collection.model", function(assert) {
+    assert.expect(2);
     var Model = Backbone.Model.extend({});
     var c = new Backbone.Collection([{id: 1}], {model: Model});
-    ok(c.model === Model);
-    ok(c.at(0) instanceof Model);
+    assert.ok(c.model === Model);
+    assert.ok(c.at(0) instanceof Model);
   });
 
-  test("null and undefined are invalid ids.", 2, function() {
+  QUnit.test("null and undefined are invalid ids.", function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model({id: 1});
     var collection = new Backbone.Collection([model]);
     model.set({id: null});
-    ok(!collection.get('null'));
+    assert.ok(!collection.get('null'));
     model.set({id: 1});
     model.set({id: undefined});
-    ok(!collection.get('undefined'));
+    assert.ok(!collection.get('undefined'));
   });
 
-  test("falsy comparator", 4, function(){
+  QUnit.test("falsy comparator", function(assert) {
+    assert.expect(4);
     var Col = Backbone.Collection.extend({
       comparator: function(model){ return model.id; }
     });
@@ -876,19 +930,20 @@
     var colFalse = new Col(null, {comparator: false});
     var colNull = new Col(null, {comparator: null});
     var colUndefined = new Col(null, {comparator: undefined});
-    ok(col.comparator);
-    ok(!colFalse.comparator);
-    ok(!colNull.comparator);
-    ok(colUndefined.comparator);
+    assert.ok(col.comparator);
+    assert.ok(!colFalse.comparator);
+    assert.ok(!colNull.comparator);
+    assert.ok(colUndefined.comparator);
   });
 
-  test("#1355 - `options` is passed to success callbacks", 2, function(){
+  QUnit.test("#1355 - `options` is passed to success callbacks", function(assert) {
+    assert.expect(2);
     var m = new Backbone.Model({x:1});
     var col = new Backbone.Collection();
     var opts = {
       opts: true,
       success: function(collection, resp, options) {
-        ok(options.opts);
+        assert.ok(options.opts);
       }
     };
     col.sync = m.sync = function( method, collection, options ){
@@ -898,31 +953,33 @@
     col.create(m, opts);
   });
 
-  test("#1412 - Trigger 'request' and 'sync' events.", 4, function() {
+  QUnit.test("#1412 - Trigger 'request' and 'sync' events.", function(assert) {
+    assert.expect(4);
     var collection = new Backbone.Collection;
     collection.url = '/test';
     Backbone.ajax = function(settings){ settings.success(); };
 
     collection.on('request', function(obj, xhr, options) {
-      ok(obj === collection, "collection has correct 'request' event after fetching");
+      assert.ok(obj === collection, "collection has correct 'request' event after fetching");
     });
     collection.on('sync', function(obj, response, options) {
-      ok(obj === collection, "collection has correct 'sync' event after fetching");
+      assert.ok(obj === collection, "collection has correct 'sync' event after fetching");
     });
     collection.fetch();
     collection.off();
 
     collection.on('request', function(obj, xhr, options) {
-      ok(obj === collection.get(1), "collection has correct 'request' event after one of its models save");
+      assert.ok(obj === collection.get(1), "collection has correct 'request' event after one of its models save");
     });
     collection.on('sync', function(obj, response, options) {
-      ok(obj === collection.get(1), "collection has correct 'sync' event after one of its models save");
+      assert.ok(obj === collection.get(1), "collection has correct 'sync' event after one of its models save");
     });
     collection.create({id: 1});
     collection.off();
   });
 
-  test("#3283 - fetch, create calls success with context", 2, function() {
+  QUnit.test("#3283 - fetch, create calls success with context", function(assert) {
+    assert.expect(2);
     var collection = new Backbone.Collection;
     collection.url = '/test';
     Backbone.ajax = function(settings) {
@@ -932,7 +989,7 @@
     var options = {
       context: obj,
       success: function() {
-        equal(this, obj);
+        assert.equal(this, obj);
       }
     };
 
@@ -940,41 +997,46 @@
     collection.create({id: 1}, options);
   });
 
-  test("#1447 - create with wait adds model.", 1, function() {
+  QUnit.test("#1447 - create with wait adds model.", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection;
     var model = new Backbone.Model;
     model.sync = function(method, model, options){ options.success(); };
-    collection.on('add', function(){ ok(true); });
+    collection.on('add', function(){ assert.ok(true); });
     collection.create(model, {wait: true});
   });
 
-  test("#1448 - add sorts collection after merge.", 1, function() {
+  QUnit.test("#1448 - add sorts collection after merge.", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection([
       {id: 1, x: 1},
       {id: 2, x: 2}
     ]);
     collection.comparator = function(model){ return model.get('x'); };
     collection.add({id: 1, x: 3}, {merge: true});
-    deepEqual(collection.pluck('id'), [2, 1]);
+    assert.deepEqual(collection.pluck('id'), [2, 1]);
   });
 
-  test("#1655 - groupBy can be used with a string argument.", 3, function() {
+  QUnit.test("#1655 - groupBy can be used with a string argument.", function(assert) {
+    assert.expect(3);
     var collection = new Backbone.Collection([{x: 1}, {x: 2}]);
     var grouped = collection.groupBy('x');
-    strictEqual(_.keys(grouped).length, 2);
-    strictEqual(grouped[1][0].get('x'), 1);
-    strictEqual(grouped[2][0].get('x'), 2);
+    assert.strictEqual(_.keys(grouped).length, 2);
+    assert.strictEqual(grouped[1][0].get('x'), 1);
+    assert.strictEqual(grouped[2][0].get('x'), 2);
   });
 
-  test("#1655 - sortBy can be used with a string argument.", 1, function() {
+  QUnit.test("#1655 - sortBy can be used with a string argument.", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection([{x: 3}, {x: 1}, {x: 2}]);
     var values = _.map(collection.sortBy('x'), function(model) {
       return model.get('x');
     });
-    deepEqual(values, [1, 2, 3]);
+    assert.deepEqual(values, [1, 2, 3]);
   });
 
-  test("#1604 - Removal during iteration.", 0, function() {
+  QUnit.test("#1604 - Removal during iteration.", function(assert) {
+    assert.expect(0);
     var collection = new Backbone.Collection([{}, {}]);
     collection.on('add', function() {
       collection.at(0).destroy();
@@ -982,7 +1044,7 @@
     collection.add({}, {at: 0});
   });
 
-  test("#1638 - `sort` during `add` triggers correctly.", function() {
+  QUnit.test("#1638 - `sort` during `add` triggers correctly.", function(assert) {
     var collection = new Backbone.Collection;
     collection.comparator = function(model) { return model.get('x'); };
     var added = [];
@@ -992,16 +1054,17 @@
       added.push(model.id);
     });
     collection.add([{id: 1, x: 1}, {id: 2, x: 2}]);
-    deepEqual(added, [1, 2]);
+    assert.deepEqual(added, [1, 2]);
   });
 
-  test("fetch parses models by default", 1, function() {
+  QUnit.test("fetch parses models by default", function(assert) {
+    assert.expect(1);
     var model = {};
     var Collection = Backbone.Collection.extend({
       url: 'test',
       model: Backbone.Model.extend({
         parse: function(resp) {
-          strictEqual(resp, model);
+          assert.strictEqual(resp, model);
         }
       })
     });
@@ -1009,18 +1072,20 @@
     this.ajaxSettings.success([model]);
   });
 
-  test("`sort` shouldn't always fire on `add`", 1, function() {
+  QUnit.test("`sort` shouldn't always fire on `add`", function(assert) {
+    assert.expect(1);
     var c = new Backbone.Collection([{id: 1}, {id: 2}, {id: 3}], {
       comparator: 'id'
     });
-    c.sort = function(){ ok(true); };
+    c.sort = function(){ assert.ok(true); };
     c.add([]);
     c.add({id: 1});
     c.add([{id: 2}, {id: 3}]);
     c.add({id: 4});
   });
 
-  test("#1407 parse option on constructor parses collection and models", 2, function() {
+  QUnit.test("#1407 parse option on constructor parses collection and models", function(assert) {
+    assert.expect(2);
     var model = {
       namespace : [{id: 1}, {id:2}]
     };
@@ -1037,11 +1102,12 @@
     });
     var c = new Collection(model, {parse:true});
 
-    equal(c.length, 2);
-    equal(c.at(0).get('name'), 'test');
+    assert.equal(c.length, 2);
+    assert.equal(c.at(0).get('name'), 'test');
   });
 
-  test("#1407 parse option on reset parses collection and models", 2, function() {
+  QUnit.test("#1407 parse option on reset parses collection and models", function(assert) {
+    assert.expect(2);
     var model = {
       namespace : [{id: 1}, {id:2}]
     };
@@ -1057,14 +1123,15 @@
       }
     });
     var c = new Collection();
-        c.reset(model, {parse:true});
+    c.reset(model, {parse:true});
 
-    equal(c.length, 2);
-    equal(c.at(0).get('name'), 'test');
+    assert.equal(c.length, 2);
+    assert.equal(c.at(0).get('name'), 'test');
   });
 
 
-  test("Reset includes previous models in triggered event.", 1, function() {
+  QUnit.test("Reset includes previous models in triggered event.", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     var collection = new Backbone.Collection([model])
     .on('reset', function(collection, options) {
@@ -1073,7 +1140,7 @@
     collection.reset([]);
   });
 
-  test("set", function() {
+  QUnit.test("set", function(assert) {
     var m1 = new Backbone.Model();
     var m2 = new Backbone.Model({id: 2});
     var m3 = new Backbone.Model();
@@ -1081,64 +1148,66 @@
 
     // Test add/change/remove events
     c.on('add', function(model) {
-      strictEqual(model, m3);
+      assert.strictEqual(model, m3);
     });
     c.on('change', function(model) {
-      strictEqual(model, m2);
+      assert.strictEqual(model, m2);
     });
     c.on('remove', function(model) {
-      strictEqual(model, m1);
+      assert.strictEqual(model, m1);
     });
 
     // remove: false doesn't remove any models
     c.set([], {remove: false});
-    strictEqual(c.length, 2);
+    assert.strictEqual(c.length, 2);
 
     // add: false doesn't add any models
     c.set([m1, m2, m3], {add: false});
-    strictEqual(c.length, 2);
+    assert.strictEqual(c.length, 2);
 
     // merge: false doesn't change any models
     c.set([m1, {id: 2, a: 1}], {merge: false});
-    strictEqual(m2.get('a'), void 0);
+    assert.strictEqual(m2.get('a'), void 0);
 
     // add: false, remove: false only merges existing models
     c.set([m1, {id: 2, a: 0}, m3, {id: 4}], {add: false, remove: false});
-    strictEqual(c.length, 2);
-    strictEqual(m2.get('a'), 0);
+    assert.strictEqual(c.length, 2);
+    assert.strictEqual(m2.get('a'), 0);
 
     // default options add/remove/merge as appropriate
     c.set([{id: 2, a: 1}, m3]);
-    strictEqual(c.length, 2);
-    strictEqual(m2.get('a'), 1);
+    assert.strictEqual(c.length, 2);
+    assert.strictEqual(m2.get('a'), 1);
 
     // Test removing models not passing an argument
     c.off('remove').on('remove', function(model) {
-      ok(model === m2 || model === m3);
+      assert.ok(model === m2 || model === m3);
     });
     c.set([]);
-    strictEqual(c.length, 0);
+    assert.strictEqual(c.length, 0);
 
     // Test null models on set doesn't clear collection
     c.off();
     c.set([{id: 1}]);
     c.set();
-    strictEqual(c.length, 1);
+    assert.strictEqual(c.length, 1);
   });
 
-  test("set with only cids", 3, function() {
+  QUnit.test("set with only cids", function(assert) {
+    assert.expect(3);
     var m1 = new Backbone.Model;
     var m2 = new Backbone.Model;
     var c = new Backbone.Collection;
     c.set([m1, m2]);
-    equal(c.length, 2);
+    assert.equal(c.length, 2);
     c.set([m1]);
-    equal(c.length, 1);
+    assert.equal(c.length, 1);
     c.set([m1, m1, m1, m2, m2], {remove: false});
-    equal(c.length, 2);
+    assert.equal(c.length, 2);
   });
 
-  test("set with only idAttribute", 3, function() {
+  QUnit.test("set with only idAttribute", function(assert) {
+    assert.expect(3);
     var m1 = { _id: 1 };
     var m2 = { _id: 2 };
     var col = Backbone.Collection.extend({
@@ -1148,14 +1217,14 @@
     });
     var c = new col;
     c.set([m1, m2]);
-    equal(c.length, 2);
+    assert.equal(c.length, 2);
     c.set([m1]);
-    equal(c.length, 1);
+    assert.equal(c.length, 1);
     c.set([m1, m1, m1, m2, m2], {remove: false});
-    equal(c.length, 2);
+    assert.equal(c.length, 2);
   });
 
-  test("set + merge with default values defined", function() {
+  QUnit.test("set + merge with default values defined", function(assert) {
     var Model = Backbone.Model.extend({
       defaults: {
         key: 'value'
@@ -1163,17 +1232,17 @@
     });
     var m = new Model({id: 1});
     var col = new Backbone.Collection([m], {model: Model});
-    equal(col.first().get('key'), 'value');
+    assert.equal(col.first().get('key'), 'value');
 
     col.set({id: 1, key: 'other'});
-    equal(col.first().get('key'), 'other');
+    assert.equal(col.first().get('key'), 'other');
 
     col.set({id: 1, other: 'value'});
-    equal(col.first().get('key'), 'other');
-    equal(col.length, 1);
+    assert.equal(col.first().get('key'), 'other');
+    assert.equal(col.length, 1);
   });
 
-  test('merge without mutation', function () {
+  QUnit.test('merge without mutation', function(assert) {
     var Model = Backbone.Model.extend({
       initialize: function (attrs, options) {
         if (attrs.child) {
@@ -1184,14 +1253,14 @@
     var Collection = Backbone.Collection.extend({model: Model});
     var data = [{id: 1, child: {id: 2}}];
     var collection = new Collection(data);
-    equal(collection.first().id, 1);
+    assert.equal(collection.first().id, 1);
     collection.set(data);
-    equal(collection.first().id, 1);
+    assert.equal(collection.first().id, 1);
     collection.set([{id: 2, child: {id: 2}}].concat(data));
-    deepEqual(collection.pluck('id'), [2, 1]);
+    assert.deepEqual(collection.pluck('id'), [2, 1]);
   });
 
-  test("`set` and model level `parse`", function() {
+  QUnit.test("`set` and model level `parse`", function(assert) {
     var Model = Backbone.Model.extend({});
     var Collection = Backbone.Collection.extend({
       model: Model,
@@ -1203,14 +1272,14 @@
       {model: {id: 1}},
       {model: {id: 2}}
     ]}, {parse: true});
-    equal(collection.first(), model);
+    assert.equal(collection.first(), model);
   });
 
-  test("`set` data is only parsed once", function() {
+  QUnit.test("`set` data is only parsed once", function(assert) {
     var collection = new Backbone.Collection();
     collection.model = Backbone.Model.extend({
       parse: function (data) {
-        equal(data.parsed, void 0);
+        assert.equal(data.parsed, void 0);
         data.parsed = true;
         return data;
       }
@@ -1218,61 +1287,64 @@
     collection.set({}, {parse: true});
   });
 
-  test('`set` matches input order in the absence of a comparator', function () {
+  QUnit.test('`set` matches input order in the absence of a comparator', function(assert) {
     var one = new Backbone.Model({id: 1});
     var two = new Backbone.Model({id: 2});
     var three = new Backbone.Model({id: 3});
     var collection = new Backbone.Collection([one, two, three]);
     collection.set([{id: 3}, {id: 2}, {id: 1}]);
-    deepEqual(collection.models, [three, two, one]);
+    assert.deepEqual(collection.models, [three, two, one]);
     collection.set([{id: 1}, {id: 2}]);
-    deepEqual(collection.models, [one, two]);
+    assert.deepEqual(collection.models, [one, two]);
     collection.set([two, three, one]);
-    deepEqual(collection.models, [two, three, one]);
+    assert.deepEqual(collection.models, [two, three, one]);
     collection.set([{id: 1}, {id: 2}], {remove: false});
-    deepEqual(collection.models, [two, three, one]);
+    assert.deepEqual(collection.models, [two, three, one]);
     collection.set([{id: 1}, {id: 2}, {id: 3}], {merge: false});
-    deepEqual(collection.models, [one, two, three]);
+    assert.deepEqual(collection.models, [one, two, three]);
     collection.set([three, two, one, {id: 4}], {add: false});
-    deepEqual(collection.models, [one, two, three]);
+    assert.deepEqual(collection.models, [one, two, three]);
   });
 
-  test("#1894 - Push should not trigger a sort", 0, function() {
+  QUnit.test("#1894 - Push should not trigger a sort", function(assert) {
+    assert.expect(0);
     var Collection = Backbone.Collection.extend({
       comparator: 'id',
-      sort: function() { ok(false); }
+      sort: function() { assert.ok(false); }
     });
     new Collection().push({id: 1});
   });
 
-  test("#2428 - push duplicate models, return the correct one", 1, function() {
+  QUnit.test("#2428 - push duplicate models, return the correct one", function(assert) {
+    assert.expect(1);
     var col = new Backbone.Collection;
     var model1 = col.push({id: 101});
-    var model2 = col.push({id: 101})
-    ok(model2.cid == model1.cid);
+    var model2 = col.push({id: 101});
+    assert.ok(model2.cid == model1.cid);
   });
 
-  test("`set` with non-normal id", function() {
+  QUnit.test("`set` with non-normal id", function(assert) {
     var Collection = Backbone.Collection.extend({
       model: Backbone.Model.extend({idAttribute: '_id'})
     });
     var collection = new Collection({_id: 1});
     collection.set([{_id: 1, a: 1}], {add: false});
-    equal(collection.first().get('a'), 1);
+    assert.equal(collection.first().get('a'), 1);
   });
 
-  test("#1894 - `sort` can optionally be turned off", 0, function() {
+QUnit.test("#1894 - `sort` can optionally be turned off", function(assert) {
+    assert.expect(0);
     var Collection = Backbone.Collection.extend({
       comparator: 'id',
-      sort: function() { ok(false); }
+      sort: function() { assert.ok(false); }
     });
     new Collection().add({id: 1}, {sort: false});
   });
 
-  test("#1915 - `parse` data in the right order in `set`", function() {
+  QUnit.test("#1915 - `parse` data in the right order in `set`", function(assert) {
     var collection = new (Backbone.Collection.extend({
       parse: function (data) {
-        strictEqual(data.status, 'ok');
+        assert.strictEqual(data.status, 'ok');
         return data.data;
       }
     }));
@@ -1280,11 +1352,13 @@
     collection.set(res, {parse: true});
   });
 
-  asyncTest("#1939 - `parse` is passed `options`", 1, function () {
+  QUnit.test("#1939 - `parse` is passed `options`", function(assert) {
+    var done = assert.async();
+    assert.expect(1);
     var collection = new (Backbone.Collection.extend({
       url: '/',
       parse: function (data, options) {
-        strictEqual(options.xhr.someHeader, 'headerValue');
+        assert.strictEqual(options.xhr.someHeader, 'headerValue');
         return data;
       }
     }));
@@ -1294,12 +1368,13 @@
       return {someHeader: 'headerValue'};
     };
     collection.fetch({
-      success: function () { start(); }
+      success: function () { done(); }
     });
     Backbone.ajax = ajax;
   });
 
-  test("fetch will pass extra options to success callback", 1, function () {
+  QUnit.test("fetch will pass extra options to success callback", function(assert) {
+    assert.expect(1);
     var SpecialSyncCollection = Backbone.Collection.extend({
       url: '/test',
       sync: function (method, collection, options) {
@@ -1311,14 +1386,15 @@
     var collection = new SpecialSyncCollection();
 
     var onSuccess = function (collection, resp, options) {
-      ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, "Options were passed correctly to callback");
     };
 
     collection.fetch({ success: onSuccess });
     this.ajaxSettings.success();
   });
 
-  test("`add` only `sort`s when necessary", 2, function () {
+  QUnit.test("`add` only `sort`s when necessary", function(assert) {
+    assert.expect(2);
     var collection = new (Backbone.Collection.extend({
       comparator: 'a'
     }))([{id: 1}, {id: 2}, {id: 3}]);
@@ -1331,7 +1407,8 @@
     collection.add(collection.models, {merge: true}); // don't sort
   });
 
-  test("`add` only `sort`s when necessary with comparator function", 3, function () {
+  QUnit.test("`add` only `sort`s when necessary with comparator function", function(assert) {
+    assert.expect(3);
     var collection = new (Backbone.Collection.extend({
       comparator: function(a, b) {
         return a.get('a') > b.get('a') ? 1 : (a.get('a') < b.get('a') ? -1 : 0);
@@ -1346,7 +1423,8 @@
     collection.add(collection.models, {merge: true}); // don't sort
   });
 
-  test("Attach options to collection.", 2, function() {
+  QUnit.test("Attach options to collection.", function(assert) {
+    assert.expect(2);
     var Model = Backbone.Model;
     var comparator = function(){};
 
@@ -1355,31 +1433,32 @@
       comparator: comparator
     });
 
-    ok(collection.model === Model);
-    ok(collection.comparator === comparator);
+    assert.ok(collection.model === Model);
+    assert.ok(collection.comparator === comparator);
   });
 
-  test("`add` overrides `set` flags", function () {
+  QUnit.test("`add` overrides `set` flags", function(assert) {
     var collection = new Backbone.Collection();
     collection.once('add', function (model, collection, options) {
       collection.add({id: 2}, options);
     });
     collection.set({id: 1});
-    equal(collection.length, 2);
+    assert.equal(collection.length, 2);
   });
 
-  test("#2606 - Collection#create, success arguments", 1, function() {
+  QUnit.test("#2606 - Collection#create, success arguments", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection;
     collection.url = 'test';
     collection.create({}, {
       success: function(model, resp, options) {
-        strictEqual(resp, 'response');
+        assert.strictEqual(resp, 'response');
       }
     });
     this.ajaxSettings.success('response');
   });
 
-  test("#2612 - nested `parse` works with `Collection#set`", function() {
+  QUnit.test("#2612 - nested `parse` works with `Collection#set`", function(assert) {
 
     var Job = Backbone.Model.extend({
       constructor: function() {
@@ -1448,20 +1527,21 @@
     };
 
     var job = new Job(data, {parse: true});
-    equal(job.get('name'), 'JobName');
-    equal(job.items.at(0).get('name'), 'Sub1');
-    equal(job.items.length, 2);
-    equal(job.items.get(1).subItems.get(1).get('subName'), 'One');
-    equal(job.items.get(2).subItems.get(3).get('subName'), 'Three');
+    assert.equal(job.get('name'), 'JobName');
+    assert.equal(job.items.at(0).get('name'), 'Sub1');
+    assert.equal(job.items.length, 2);
+    assert.equal(job.items.get(1).subItems.get(1).get('subName'), 'One');
+    assert.equal(job.items.get(2).subItems.get(3).get('subName'), 'Three');
     job.set(job.parse(newData, {parse: true}));
-    equal(job.get('name'), 'NewJobName');
-    equal(job.items.at(0).get('name'), 'NewSub1');
-    equal(job.items.length, 2);
-    equal(job.items.get(1).subItems.get(1).get('subName'), 'NewOne');
-    equal(job.items.get(2).subItems.get(3).get('subName'), 'NewThree');
+    assert.equal(job.get('name'), 'NewJobName');
+    assert.equal(job.items.at(0).get('name'), 'NewSub1');
+    assert.equal(job.items.length, 2);
+    assert.equal(job.items.get(1).subItems.get(1).get('subName'), 'NewOne');
+    assert.equal(job.items.get(2).subItems.get(3).get('subName'), 'NewThree');
   });
 
-  test('_addReference binds all collection events & adds to the lookup hashes', 9, function() {
+  QUnit.test('_addReference binds all collection events & adds to the lookup hashes', function(assert) {
+    assert.expect(9);
 
     var calls = {add: 0, remove: 0};
 
@@ -1470,18 +1550,18 @@
       _addReference: function(model) {
         Backbone.Collection.prototype._addReference.apply(this, arguments);
         calls.add++;
-        equal(model, this._byId[model.id]);
-        equal(model, this._byId[model.cid]);
-        equal(model._events.all.length, 1);
+        assert.equal(model, this._byId[model.id]);
+        assert.equal(model, this._byId[model.cid]);
+        assert.equal(model._events.all.length, 1);
       },
 
       _removeReference: function(model) {
         Backbone.Collection.prototype._removeReference.apply(this, arguments);
         calls.remove++;
-        equal(this._byId[model.id], void 0);
-        equal(this._byId[model.cid], void 0);
-        equal(model.collection, void 0);
-        equal(model._events, void 0);
+        assert.equal(this._byId[model.id], void 0);
+        assert.equal(this._byId[model.cid], void 0);
+        assert.equal(model.collection, void 0);
+        assert.equal(model._events, void 0);
       }
 
     });
@@ -1490,50 +1570,51 @@
     var model = collection.add({id: 1});
     collection.remove(model);
 
-    equal(calls.add, 1);
-    equal(calls.remove, 1);
-
+    assert.equal(calls.add, 1);
+    assert.equal(calls.remove, 1);
   });
 
-  test('Do not allow duplicate models to be `add`ed or `set`', function() {
+  QUnit.test('Do not allow duplicate models to be `add`ed or `set`', function(assert) {
     var c = new Backbone.Collection();
 
     c.add([{id: 1}, {id: 1}]);
-    equal(c.length, 1);
-    equal(c.models.length, 1);
+    assert.equal(c.length, 1);
+    assert.equal(c.models.length, 1);
 
     c.set([{id: 1}, {id: 1}]);
-    equal(c.length, 1);
-    equal(c.models.length, 1);
+    assert.equal(c.length, 1);
+    assert.equal(c.models.length, 1);
   });
 
-  test('#3020: #set with {add: false} should not throw.', 2, function() {
+  QUnit.test('#3020: #set with {add: false} should not throw.', function(assert) {
+    assert.expect(2);
     var collection = new Backbone.Collection;
     collection.set([{id: 1}], {add: false});
-    strictEqual(collection.length, 0);
-    strictEqual(collection.models.length, 0);
+    assert.strictEqual(collection.length, 0);
+    assert.strictEqual(collection.models.length, 0);
   });
 
-  test("create with wait, model instance, #3028", 1, function() {
+  QUnit.test("create with wait, model instance, #3028", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection();
     var model = new Backbone.Model({id: 1});
     model.sync = function(){
-      equal(this.collection, collection);
+      assert.equal(this.collection, collection);
     };
     collection.create(model, {wait: true});
   });
 
-  test("modelId", function() {
+  QUnit.test("modelId", function(assert) {
     var Stooge = Backbone.Model.extend();
     var StoogeCollection = Backbone.Collection.extend({model: Stooge});
 
     // Default to using `Collection::model::idAttribute`.
-    equal(StoogeCollection.prototype.modelId({id: 1}), 1);
+    assert.equal(StoogeCollection.prototype.modelId({id: 1}), 1);
     Stooge.prototype.idAttribute = '_id';
-    equal(StoogeCollection.prototype.modelId({_id: 1}), 1);
+    assert.equal(StoogeCollection.prototype.modelId({_id: 1}), 1);
   });
 
-  test('Polymorphic models work with "simple" constructors', function () {
+  QUnit.test('Polymorphic models work with "simple" constructors', function(assert) {
     var A = Backbone.Model.extend();
     var B = Backbone.Model.extend();
     var C = Backbone.Collection.extend({
@@ -1542,14 +1623,14 @@
       }
     });
     var collection = new C([{id: 1, type: 'a'}, {id: 2, type: 'b'}]);
-    equal(collection.length, 2);
-    ok(collection.at(0) instanceof A);
-    equal(collection.at(0).id, 1);
-    ok(collection.at(1) instanceof B);
-    equal(collection.at(1).id, 2);
+    assert.equal(collection.length, 2);
+    assert.ok(collection.at(0) instanceof A);
+    assert.equal(collection.at(0).id, 1);
+    assert.ok(collection.at(1) instanceof B);
+    assert.equal(collection.at(1).id, 2);
   });
 
-  test('Polymorphic models work with "advanced" constructors', function () {
+  QUnit.test('Polymorphic models work with "advanced" constructors', function(assert) {
     var A = Backbone.Model.extend({idAttribute: '_id'});
     var B = Backbone.Model.extend({idAttribute: '_id'});
     var C = Backbone.Collection.extend({
@@ -1562,11 +1643,11 @@
       })
     });
     var collection = new C([{_id: 1, type: 'a'}, {_id: 2, type: 'b'}]);
-    equal(collection.length, 2);
-    ok(collection.at(0) instanceof A);
-    equal(collection.at(0), collection.get(1));
-    ok(collection.at(1) instanceof B);
-    equal(collection.at(1), collection.get(2));
+    assert.equal(collection.length, 2);
+    assert.ok(collection.at(0) instanceof A);
+    assert.equal(collection.at(0), collection.get(1));
+    assert.ok(collection.at(1) instanceof B);
+    assert.equal(collection.at(1), collection.get(2));
 
     C = Backbone.Collection.extend({
       model: function (attrs) {
@@ -1578,115 +1659,129 @@
       }
     });
     collection = new C([{id: 1, type: 'a'}, {id: 1, type: 'b'}]);
-    equal(collection.length, 2);
-    ok(collection.at(0) instanceof A);
-    equal(collection.at(0), collection.get('a-1'));
-    ok(collection.at(1) instanceof B);
-    equal(collection.at(1), collection.get('b-1'));
+    assert.equal(collection.length, 2);
+    assert.ok(collection.at(0) instanceof A);
+    assert.equal(collection.at(0), collection.get('a-1'));
+    assert.ok(collection.at(1) instanceof B);
+    assert.equal(collection.at(1), collection.get('b-1'));
   });
 
-  test("#3039: adding at index fires with correct at", 3, function() {
+  QUnit.test("#3039: adding at index fires with correct at", function(assert) {
+    assert.expect(3);
     var col = new Backbone.Collection([{at: 0}, {at: 4}]);
     col.on('add', function(model, col, options) {
-      equal(model.get('at'), options.index);
+      assert.equal(model.get('at'), options.index);
     });
     col.add([{at: 1}, {at: 2}, {at: 3}], {at: 1});
   });
 
-  test("#3039: index is not sent when at is not specified", 2, function() {
+  QUnit.test("#3039: index is not sent when at is not specified", function(assert) {
+    assert.expect(2);
     var col = new Backbone.Collection([{at: 0}]);
     col.on('add', function(model, col, options) {
-      equal(undefined, options.index);
+      assert.equal(undefined, options.index);
     });
     col.add([{at: 1}, {at: 2}]);
   });
 
-  test('#3199 - Order changing should trigger a sort', 1, function() {
-      var one = new Backbone.Model({id: 1});
-      var two = new Backbone.Model({id: 2});
-      var three = new Backbone.Model({id: 3});
-      var collection = new Backbone.Collection([one, two, three]);
-      collection.on('sort', function() {
-        ok(true);
-      });
-      collection.set([{id: 3}, {id: 2}, {id: 1}]);
+  QUnit.test('#3199 - Order changing should trigger a sort', function(assert) {
+    assert.expect(1);
+    var one = new Backbone.Model({id: 1});
+    var two = new Backbone.Model({id: 2});
+    var three = new Backbone.Model({id: 3});
+    var collection = new Backbone.Collection([one, two, three]);
+    collection.on('sort', function() {
+      assert.ok(true);
+    });
+    collection.set([{id: 3}, {id: 2}, {id: 1}]);
   });
 
-  test('#3199 - Adding a model should trigger a sort', 1, function() {
+  QUnit.test('#3199 - Adding a model should trigger a sort', function(assert) {
+    assert.expect(1);
     var one = new Backbone.Model({id: 1});
     var two = new Backbone.Model({id: 2});
     var three = new Backbone.Model({id: 3});
     var collection = new Backbone.Collection([one, two, three]);
     collection.on('sort', function() {
-      ok(true);
+      assert.ok(true);
     });
     collection.set([{id: 1}, {id: 2}, {id: 3}, {id: 0}]);
-  })
+  });
 
-  test('#3199 - Order not changing should not trigger a sort', 0, function() {
+  QUnit.test('#3199 - Order not changing should not trigger a sort', function(assert) {
+    assert.expect(0);
     var one = new Backbone.Model({id: 1});
     var two = new Backbone.Model({id: 2});
     var three = new Backbone.Model({id: 3});
     var collection = new Backbone.Collection([one, two, three]);
     collection.on('sort', function() {
-      ok(false);
+      assert.ok(false);
     });
     collection.set([{id: 1}, {id: 2}, {id: 3}]);
   });
 
-  test("add supports negative indexes", 1, function() {
+  QUnit.test("add supports negative indexes", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection([{id: 1}]);
     collection.add([{id: 2}, {id: 3}], {at: -1});
     collection.add([{id: 2.5}], {at: -2});
     collection.add([{id: 0.5}], {at: -6});
-    equal(collection.pluck('id').join(','), "0.5,1,2,2.5,3");
+    assert.equal(collection.pluck('id').join(','), "0.5,1,2,2.5,3");
   });
 
-  test("#set accepts options.at as a string", 1, function() {
+  QUnit.test("#set accepts options.at as a string", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
     collection.add([{id: 3}], {at: '1'});
-    deepEqual(collection.pluck('id'), [1, 3, 2]);
+    assert.deepEqual(collection.pluck('id'), [1, 3, 2]);
   });
-  test("adding multiple models triggers `update` event once", 1, function() {
+
+  QUnit.test("adding multiple models triggers `update` event once", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection;
-    collection.on('update', function() { ok(true); });
+    collection.on('update', function() { assert.ok(true); });
     collection.add([{id: 1}, {id: 2}, {id: 3}]);
   });
 
-  test("removing models triggers `update` event once", 1, function() {
+  QUnit.test("removing models triggers `update` event once", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}, {id: 3}]);
-    collection.on('update', function() { ok(true); });
+    collection.on('update', function() { assert.ok(true); });
     collection.remove([{id: 1}, {id: 2}]);
   });
 
-  test("remove does not trigger `set` when nothing removed", 0, function() {
+  QUnit.test("remove does not trigger `set` when nothing removed", function(assert) {
+    assert.expect(0);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
-    collection.on('update', function() { ok(false); });
+    collection.on('update', function() { assert.ok(false); });
     collection.remove([{id: 3}]);
   });
 
-  test("set triggers `set` event once", 1, function() {
+  QUnit.test("set triggers `set` event once", function(assert) {
+    assert.expect(1);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
-    collection.on('update', function() { ok(true); });
+    collection.on('update', function() { assert.ok(true); });
     collection.set([{id: 1}, {id: 3}]);
   });
 
-  test("set does not trigger `update` event when nothing added nor removed", 0, function() {
+  QUnit.test("set does not trigger `update` event when nothing added nor removed", function(assert) {
+    assert.expect(0);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
-    collection.on('update', function() { ok(false); });
+    collection.on('update', function() { assert.ok(false); });
     collection.set([{id: 1}, {id: 2}]);
   });
 
-  test("#3610 - invoke collects arguments", 3, function() {
+  QUnit.test("#3610 - invoke collects arguments", function(assert) {
+    assert.expect(3);
     var Model = Backbone.Model.extend({
-        method: function(a, b, c) {
-            equal(a, 1);
-            equal(b, 2);
-            equal(c, 3);
-        }
+      method: function(a, b, c) {
+        assert.equal(a, 1);
+        assert.equal(b, 2);
+        assert.equal(c, 3);
+      }
     });
     var Collection = Backbone.Collection.extend({
-        model: Model
+      model: Model
     });
     var collection = new Collection([{id: 1}]);
     collection.invoke('method', 1, 2, 3);

--- a/test/events.js
+++ b/test/events.js
@@ -1,41 +1,43 @@
 (function() {
 
-  module("Backbone.Events");
+  QUnit.module("Backbone.Events");
 
-  test("on and trigger", 2, function() {
+  QUnit.test("on and trigger", function(assert) {
+    assert.expect(2);
     var obj = { counter: 0 };
     _.extend(obj,Backbone.Events);
     obj.on('event', function() { obj.counter += 1; });
     obj.trigger('event');
-    equal(obj.counter,1,'counter should be incremented.');
+    assert.equal(obj.counter, 1, 'counter should be incremented.');
     obj.trigger('event');
     obj.trigger('event');
     obj.trigger('event');
     obj.trigger('event');
-    equal(obj.counter, 5, 'counter should be incremented five times.');
+    assert.equal(obj.counter, 5, 'counter should be incremented five times.');
   });
 
-  test("binding and triggering multiple events", 4, function() {
+  QUnit.test("binding and triggering multiple events", function(assert) {
+    assert.expect(4);
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
 
     obj.on('a b c', function() { obj.counter += 1; });
 
     obj.trigger('a');
-    equal(obj.counter, 1);
+    assert.equal(obj.counter, 1);
 
     obj.trigger('a b');
-    equal(obj.counter, 3);
+    assert.equal(obj.counter, 3);
 
     obj.trigger('c');
-    equal(obj.counter, 4);
+    assert.equal(obj.counter, 4);
 
     obj.off('a c');
     obj.trigger('a b c');
-    equal(obj.counter, 5);
+    assert.equal(obj.counter, 5);
   });
 
-  test("binding and triggering with event maps", function() {
+  QUnit.test("binding and triggering with event maps", function(assert) {
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
 
@@ -50,23 +52,23 @@
     }, obj);
 
     obj.trigger('a');
-    equal(obj.counter, 1);
+    assert.equal(obj.counter, 1);
 
     obj.trigger('a b');
-    equal(obj.counter, 3);
+    assert.equal(obj.counter, 3);
 
     obj.trigger('c');
-    equal(obj.counter, 4);
+    assert.equal(obj.counter, 4);
 
     obj.off({
       a: increment,
       c: increment
     }, obj);
     obj.trigger('a b c');
-    equal(obj.counter, 5);
+    assert.equal(obj.counter, 5);
   });
 
-  test("binding and triggering multiple event names with event maps", function() {
+  QUnit.test("binding and triggering multiple event names with event maps", function(assert) {
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
 
@@ -79,29 +81,30 @@
     });
 
     obj.trigger('a');
-    equal(obj.counter, 1);
+    assert.equal(obj.counter, 1);
 
     obj.trigger('a b');
-    equal(obj.counter, 3);
+    assert.equal(obj.counter, 3);
 
     obj.trigger('c');
-    equal(obj.counter, 4);
+    assert.equal(obj.counter, 4);
 
     obj.off({
       'a c': increment
     });
     obj.trigger('a b c');
-    equal(obj.counter, 5);
+    assert.equal(obj.counter, 5);
   });
 
-  test("binding and trigger with event maps context", 2, function() {
+  QUnit.test("binding and trigger with event maps context", function(assert) {
+    assert.expect(2);
     var obj = { counter: 0 };
     var context = {};
     _.extend(obj, Backbone.Events);
 
     obj.on({
         a: function() {
-            strictEqual(this, context, 'defaults `context` to `callback` param');
+            assert.strictEqual(this, context, 'defaults `context` to `callback` param');
         }
     }, context).trigger('a');
 
@@ -112,20 +115,22 @@
     }, this, context).trigger('a');
   });
 
-  test("listenTo and stopListening", 1, function() {
+  QUnit.test("listenTo and stopListening", function(assert) {
+    assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    a.listenTo(b, 'all', function(){ ok(true); });
+    a.listenTo(b, 'all', function(){ assert.ok(true); });
     b.trigger('anything');
-    a.listenTo(b, 'all', function(){ ok(false); });
+    a.listenTo(b, 'all', function(){ assert.ok(false); });
     a.stopListening();
     b.trigger('anything');
   });
 
-  test("listenTo and stopListening with event maps", 4, function() {
+  QUnit.test("listenTo and stopListening with event maps", function(assert) {
+    assert.expect(4);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    var cb = function(){ ok(true); };
+    var cb = function(){ assert.ok(true); };
     a.listenTo(b, {event: cb});
     b.trigger('event');
     a.listenTo(b, {event2: cb});
@@ -136,10 +141,11 @@
     b.trigger('event event2');
   });
 
-  test("stopListening with omitted args", 2, function () {
+  QUnit.test("stopListening with omitted args", function(assert) {
+    assert.expect(2);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    var cb = function () { ok(true); };
+    var cb = function () { assert.ok(true); };
     a.listenTo(b, 'event', cb);
     b.on('event', cb);
     a.listenTo(b, 'event2', cb);
@@ -152,7 +158,8 @@
     b.trigger('event2');
   });
 
-  test("listenToOnce", 2, function() {
+  QUnit.test("listenToOnce", function(assert) {
+    assert.expect(2);
     // Same as the previous test, but we use once rather than having to explicitly unbind
     var obj = { counterA: 0, counterB: 0 };
     _.extend(obj, Backbone.Events);
@@ -161,172 +168,186 @@
     obj.listenToOnce(obj, 'event', incrA);
     obj.listenToOnce(obj, 'event', incrB);
     obj.trigger('event');
-    equal(obj.counterA, 1, 'counterA should have only been incremented once.');
-    equal(obj.counterB, 1, 'counterB should have only been incremented once.');
+    assert.equal(obj.counterA, 1, 'counterA should have only been incremented once.');
+    assert.equal(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
 
-  test("listenToOnce and stopListening", 1, function() {
+  QUnit.test("listenToOnce and stopListening", function(assert) {
+    assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    a.listenToOnce(b, 'all', function() { ok(true); });
+    a.listenToOnce(b, 'all', function() { assert.ok(true); });
     b.trigger('anything');
     b.trigger('anything');
-    a.listenToOnce(b, 'all', function() { ok(false); });
+    a.listenToOnce(b, 'all', function() { assert.ok(false); });
     a.stopListening();
     b.trigger('anything');
   });
 
-  test("listenTo, listenToOnce and stopListening", 1, function() {
+  QUnit.test("listenTo, listenToOnce and stopListening", function(assert) {
+    assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    a.listenToOnce(b, 'all', function() { ok(true); });
+    a.listenToOnce(b, 'all', function() { assert.ok(true); });
     b.trigger('anything');
     b.trigger('anything');
-    a.listenTo(b, 'all', function() { ok(false); });
+    a.listenTo(b, 'all', function() { assert.ok(false); });
     a.stopListening();
     b.trigger('anything');
   });
 
-  test("listenTo and stopListening with event maps", 1, function() {
+  QUnit.test("listenTo and stopListening with event maps", function(assert) {
+    assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    a.listenTo(b, {change: function(){ ok(true); }});
+    a.listenTo(b, {change: function(){ assert.ok(true); }});
     b.trigger('change');
-    a.listenTo(b, {change: function(){ ok(false); }});
+    a.listenTo(b, {change: function(){ assert.ok(false); }});
     a.stopListening();
     b.trigger('change');
   });
 
-  test("listenTo yourself", 1, function(){
+  QUnit.test("listenTo yourself", function(assert) {
+    assert.expect(1);
     var e = _.extend({}, Backbone.Events);
-    e.listenTo(e, "foo", function(){ ok(true); });
+    e.listenTo(e, "foo", function(){ assert.ok(true); });
     e.trigger("foo");
   });
 
-  test("listenTo yourself cleans yourself up with stopListening", 1, function(){
+  QUnit.test("listenTo yourself cleans yourself up with stopListening", function(assert) {
+    assert.expect(1);
     var e = _.extend({}, Backbone.Events);
-    e.listenTo(e, "foo", function(){ ok(true); });
+    e.listenTo(e, "foo", function(){ assert.ok(true); });
     e.trigger("foo");
     e.stopListening();
     e.trigger("foo");
   });
 
-  test("stopListening cleans up references", 12, function() {
+  QUnit.test("stopListening cleans up references", function(assert) {
+    assert.expect(12);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     var fn = function() {};
     b.on('event', fn);
     a.listenTo(b, 'event', fn).stopListening();
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events.event), 1);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._events.event), 1);
+    assert.equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events.event), 1);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._events.event), 1);
+    assert.equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event');
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events.event), 1);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._events.event), 1);
+    assert.equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn).stopListening(b, 'event', fn);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events.event), 1);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._events.event), 1);
+    assert.equal(_.size(b._listeners), 0);
   });
 
-  test("stopListening cleans up references from listenToOnce", 12, function() {
+  QUnit.test("stopListening cleans up references from listenToOnce", function(assert) {
+    assert.expect(12);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     var fn = function() {};
     b.on('event', fn);
     a.listenToOnce(b, 'event', fn).stopListening();
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events.event), 1);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._events.event), 1);
+    assert.equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events.event), 1);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._events.event), 1);
+    assert.equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event');
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events.event), 1);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._events.event), 1);
+    assert.equal(_.size(b._listeners), 0);
     a.listenToOnce(b, 'event', fn).stopListening(b, 'event', fn);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._events.event), 1);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._events.event), 1);
+    assert.equal(_.size(b._listeners), 0);
   });
 
-  test("listenTo and off cleaning up references", 8, function() {
+  QUnit.test("listenTo and off cleaning up references", function(assert) {
+    assert.expect(8);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     var fn = function() {};
     a.listenTo(b, 'event', fn);
     b.off();
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn);
     b.off('event');
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn);
     b.off(null, fn);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._listeners), 0);
     a.listenTo(b, 'event', fn);
     b.off(null, null, a);
-    equal(_.size(a._listeningTo), 0);
-    equal(_.size(b._listeners), 0);
+    assert.equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(b._listeners), 0);
   });
 
-  test("listenTo and stopListening cleaning up references", 2, function() {
+  QUnit.test("listenTo and stopListening cleaning up references", function(assert) {
+    assert.expect(2);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    a.listenTo(b, 'all', function(){ ok(true); });
+    a.listenTo(b, 'all', function(){ assert.ok(true); });
     b.trigger('anything');
-    a.listenTo(b, 'other', function(){ ok(false); });
+    a.listenTo(b, 'other', function(){ assert.ok(false); });
     a.stopListening(b, 'other');
     a.stopListening(b, 'all');
-    equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(a._listeningTo), 0);
   });
 
-  test("listenToOnce without context cleans up references after the event has fired", 2, function() {
+  QUnit.test("listenToOnce without context cleans up references after the event has fired", function(assert) {
+    assert.expect(2);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
-    a.listenToOnce(b, 'all', function(){ ok(true); });
+    a.listenToOnce(b, 'all', function(){ assert.ok(true); });
     b.trigger('anything');
-    equal(_.size(a._listeningTo), 0);
+    assert.equal(_.size(a._listeningTo), 0);
   });
 
-  test("listenToOnce with event maps cleans up references", 2, function() {
+  QUnit.test("listenToOnce with event maps cleans up references", function(assert) {
+    assert.expect(2);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     a.listenToOnce(b, {
-      one: function() { ok(true); },
-      two: function() { ok(false); }
+      one: function() { assert.ok(true); },
+      two: function() { assert.ok(false); }
     });
     b.trigger('one');
-    equal(_.size(a._listeningTo), 1);
+    assert.equal(_.size(a._listeningTo), 1);
   });
 
-  test("listenToOnce with event maps binds the correct `this`", 1, function() {
+  QUnit.test("listenToOnce with event maps binds the correct `this`", function(assert) {
+    assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
     a.listenToOnce(b, {
-      one: function() { ok(this === a); },
-      two: function() { ok(false); }
+      one: function() { assert.ok(this === a); },
+      two: function() { assert.ok(false); }
     });
     b.trigger('one');
   });
 
-  test("listenTo with empty callback doesn't throw an error", 1, function(){
+  QUnit.test("listenTo with empty callback doesn't throw an error", function(assert) {
+    assert.expect(1);
     var e = _.extend({}, Backbone.Events);
     e.listenTo(e, "foo", null);
     e.trigger("foo");
-    ok(true);
+    assert.ok(true);
   });
 
-  test("trigger all for each event", 3, function() {
+  QUnit.test("trigger all for each event", function(assert) {
+    assert.expect(3);
     var a, b, obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
     obj.on('all', function(event) {
@@ -335,12 +356,13 @@
       if (event == 'b') b = true;
     })
     .trigger('a b');
-    ok(a);
-    ok(b);
-    equal(obj.counter, 2);
+    assert.ok(a);
+    assert.ok(b);
+    assert.equal(obj.counter, 2);
   });
 
-  test("on, then unbind all functions", 1, function() {
+  QUnit.test("on, then unbind all functions", function(assert) {
+    assert.expect(1);
     var obj = { counter: 0 };
     _.extend(obj,Backbone.Events);
     var callback = function() { obj.counter += 1; };
@@ -348,10 +370,11 @@
     obj.trigger('event');
     obj.off('event');
     obj.trigger('event');
-    equal(obj.counter, 1, 'counter should have only been incremented once.');
+    assert.equal(obj.counter, 1, 'counter should have only been incremented once.');
   });
 
-  test("bind two callbacks, unbind only one", 2, function() {
+  QUnit.test("bind two callbacks, unbind only one", function(assert) {
+    assert.expect(2);
     var obj = { counterA: 0, counterB: 0 };
     _.extend(obj,Backbone.Events);
     var callback = function() { obj.counterA += 1; };
@@ -360,11 +383,12 @@
     obj.trigger('event');
     obj.off('event', callback);
     obj.trigger('event');
-    equal(obj.counterA, 1, 'counterA should have only been incremented once.');
-    equal(obj.counterB, 2, 'counterB should have been incremented twice.');
+    assert.equal(obj.counterA, 1, 'counterA should have only been incremented once.');
+    assert.equal(obj.counterB, 2, 'counterB should have been incremented twice.');
   });
 
-  test("unbind a callback in the midst of it firing", 1, function() {
+  QUnit.test("unbind a callback in the midst of it firing", function(assert) {
+    assert.expect(1);
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
     var callback = function() {
@@ -375,10 +399,11 @@
     obj.trigger('event');
     obj.trigger('event');
     obj.trigger('event');
-    equal(obj.counter, 1, 'the callback should have been unbound.');
+    assert.equal(obj.counter, 1, 'the callback should have been unbound.');
   });
 
-  test("two binds that unbind themeselves", 2, function() {
+  QUnit.test("two binds that unbind themeselves", function(assert) {
+    assert.expect(2);
     var obj = { counterA: 0, counterB: 0 };
     _.extend(obj,Backbone.Events);
     var incrA = function(){ obj.counterA += 1; obj.off('event', incrA); };
@@ -388,16 +413,17 @@
     obj.trigger('event');
     obj.trigger('event');
     obj.trigger('event');
-    equal(obj.counterA, 1, 'counterA should have only been incremented once.');
-    equal(obj.counterB, 1, 'counterB should have only been incremented once.');
+    assert.equal(obj.counterA, 1, 'counterA should have only been incremented once.');
+    assert.equal(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
 
-  test("bind a callback with a supplied context", 1, function () {
+  QUnit.test("bind a callback with a supplied context", function(assert) {
+    assert.expect(1);
     var TestClass = function () {
       return this;
     };
     TestClass.prototype.assertTrue = function () {
-      ok(true, '`this` was bound to the callback');
+      assert.ok(true, '`this` was bound to the callback');
     };
 
     var obj = _.extend({},Backbone.Events);
@@ -405,7 +431,8 @@
     obj.trigger('event');
   });
 
-  test("nested trigger with unbind", 1, function () {
+  QUnit.test("nested trigger with unbind", function(assert) {
+    assert.expect(1);
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
     var incr1 = function(){ obj.counter += 1; obj.off('event', incr1); obj.trigger('event'); };
@@ -413,23 +440,25 @@
     obj.on('event', incr1);
     obj.on('event', incr2);
     obj.trigger('event');
-    equal(obj.counter, 3, 'counter should have been incremented three times');
+    assert.equal(obj.counter, 3, 'counter should have been incremented three times');
   });
 
-  test("callback list is not altered during trigger", 2, function () {
+  QUnit.test("callback list is not altered during trigger", function(assert) {
+    assert.expect(2);
     var counter = 0, obj = _.extend({}, Backbone.Events);
     var incr = function(){ counter++; };
     var incrOn = function(){ obj.on('event all', incr); };
     var incrOff = function(){ obj.off('event all', incr); };
 
     obj.on('event all', incrOn).trigger('event');
-    equal(counter, 0, 'on does not alter callback list');
+    assert.equal(counter, 0, 'on does not alter callback list');
 
     obj.off().on('event', incrOff).on('event all', incr).trigger('event');
-    equal(counter, 2, 'off does not alter callback list');
+    assert.equal(counter, 2, 'off does not alter callback list');
   });
 
-  test("#1282 - 'all' callback list is retrieved after each event.", 1, function() {
+  QUnit.test("#1282 - 'all' callback list is retrieved after each event.", function(assert) {
+    assert.expect(1);
     var counter = 0;
     var obj = _.extend({}, Backbone.Events);
     var incr = function(){ counter++; };
@@ -437,47 +466,53 @@
       obj.on('y', incr).on('all', incr);
     })
     .trigger('x y');
-    strictEqual(counter, 2);
+    assert.strictEqual(counter, 2);
   });
 
-  test("if no callback is provided, `on` is a noop", 0, function() {
+  QUnit.test("if no callback is provided, `on` is a noop", function(assert) {
+    assert.expect(0);
     _.extend({}, Backbone.Events).on('test').trigger('test');
   });
 
-  test("if callback is truthy but not a function, `on` should throw an error just like jQuery", 1, function() {
+  QUnit.test("if callback is truthy but not a function, `on` should throw an error just like jQuery", function(assert) {
+    assert.expect(1);
     var view = _.extend({}, Backbone.Events).on('test', 'noop');
-    throws(function() {
+    assert.throws(function() {
       view.trigger('test');
     });
   });
 
-  test("remove all events for a specific context", 4, function() {
+  QUnit.test("remove all events for a specific context", function(assert) {
+    assert.expect(4);
     var obj = _.extend({}, Backbone.Events);
-    obj.on('x y all', function() { ok(true); });
-    obj.on('x y all', function() { ok(false); }, obj);
+    obj.on('x y all', function() { assert.ok(true); });
+    obj.on('x y all', function() { assert.ok(false); }, obj);
     obj.off(null, null, obj);
     obj.trigger('x y');
   });
 
-  test("remove all events for a specific callback", 4, function() {
+  QUnit.test("remove all events for a specific callback", function(assert) {
+    assert.expect(4);
     var obj = _.extend({}, Backbone.Events);
-    var success = function() { ok(true); };
-    var fail = function() { ok(false); };
+    var success = function() { assert.ok(true); };
+    var fail = function() { assert.ok(false); };
     obj.on('x y all', success);
     obj.on('x y all', fail);
     obj.off(null, fail);
     obj.trigger('x y');
   });
 
-  test("#1310 - off does not skip consecutive events", 0, function() {
+  QUnit.test("#1310 - off does not skip consecutive events", function(assert) {
+    assert.expect(0);
     var obj = _.extend({}, Backbone.Events);
-    obj.on('event', function() { ok(false); }, obj);
-    obj.on('event', function() { ok(false); }, obj);
+    obj.on('event', function() { assert.ok(false); }, obj);
+    obj.on('event', function() { assert.ok(false); }, obj);
     obj.off(null, null, obj);
     obj.trigger('event');
   });
 
-  test("once", 2, function() {
+  QUnit.test("once", function(assert) {
+    assert.expect(2);
     // Same as the previous test, but we use once rather than having to explicitly unbind
     var obj = { counterA: 0, counterB: 0 };
     _.extend(obj, Backbone.Events);
@@ -486,12 +521,13 @@
     obj.once('event', incrA);
     obj.once('event', incrB);
     obj.trigger('event');
-    equal(obj.counterA, 1, 'counterA should have only been incremented once.');
-    equal(obj.counterB, 1, 'counterB should have only been incremented once.');
+    assert.equal(obj.counterA, 1, 'counterA should have only been incremented once.');
+    assert.equal(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
 
-  test("once variant one", 3, function() {
-    var f = function(){ ok(true); };
+  QUnit.test("once variant one", function(assert) {
+    assert.expect(3);
+    var f = function(){ assert.ok(true); };
 
     var a = _.extend({}, Backbone.Events).once('event', f);
     var b = _.extend({}, Backbone.Events).on('event', f);
@@ -502,8 +538,9 @@
     b.trigger('event');
   });
 
-  test("once variant two", 3, function() {
-    var f = function(){ ok(true); };
+  QUnit.test("once variant two", function(assert) {
+    assert.expect(3);
+    var f = function(){ assert.ok(true); };
     var obj = _.extend({}, Backbone.Events);
 
     obj
@@ -513,8 +550,9 @@
       .trigger('event');
   });
 
-  test("once with off", 0, function() {
-    var f = function(){ ok(true); };
+  QUnit.test("once with off", function(assert) {
+    assert.expect(0);
+    var f = function(){ assert.ok(true); };
     var obj = _.extend({}, Backbone.Events);
 
     obj.once('event', f);
@@ -522,7 +560,7 @@
     obj.trigger('event');
   });
 
-  test("once with event maps", function() {
+  QUnit.test("once with event maps", function(assert) {
     var obj = { counter: 0 };
     _.extend(obj, Backbone.Events);
 
@@ -537,94 +575,103 @@
     }, obj);
 
     obj.trigger('a');
-    equal(obj.counter, 1);
+    assert.equal(obj.counter, 1);
 
     obj.trigger('a b');
-    equal(obj.counter, 2);
+    assert.equal(obj.counter, 2);
 
     obj.trigger('c');
-    equal(obj.counter, 3);
+    assert.equal(obj.counter, 3);
 
     obj.trigger('a b c');
-    equal(obj.counter, 3);
+    assert.equal(obj.counter, 3);
   });
 
-  test("once with off only by context", 0, function() {
+  QUnit.test("once with off only by context", function(assert) {
+    assert.expect(0);
     var context = {};
     var obj = _.extend({}, Backbone.Events);
-    obj.once('event', function(){ ok(false); }, context);
+    obj.once('event', function(){ assert.ok(false); }, context);
     obj.off(null, null, context);
     obj.trigger('event');
   });
 
-  test("Backbone object inherits Events", function() {
-    ok(Backbone.on === Backbone.Events.on);
+  QUnit.test("Backbone object inherits Events", function(assert) {
+    assert.ok(Backbone.on === Backbone.Events.on);
   });
 
-  asyncTest("once with asynchronous events", 1, function() {
-    var func = _.debounce(function() { ok(true); start(); }, 50);
+  QUnit.test("once with asynchronous events", function(assert) {
+    var done = assert.async();
+    assert.expect(1);
+    var func = _.debounce(function() { assert.ok(true); done(); }, 50);
     var obj = _.extend({}, Backbone.Events).once('async', func);
 
     obj.trigger('async');
     obj.trigger('async');
   });
 
-  test("once with multiple events.", 2, function() {
+  QUnit.test("once with multiple events.", function(assert) {
+    assert.expect(2);
     var obj = _.extend({}, Backbone.Events);
-    obj.once('x y', function() { ok(true); });
+    obj.once('x y', function() { assert.ok(true); });
     obj.trigger('x y');
   });
 
-  test("Off during iteration with once.", 2, function() {
+  QUnit.test("Off during iteration with once.", function(assert) {
+    assert.expect(2);
     var obj = _.extend({}, Backbone.Events);
     var f = function(){ this.off('event', f); };
     obj.on('event', f);
     obj.once('event', function(){});
-    obj.on('event', function(){ ok(true); });
+    obj.on('event', function(){ assert.ok(true); });
 
     obj.trigger('event');
     obj.trigger('event');
   });
 
-  test("`once` on `all` should work as expected", 1, function() {
+  QUnit.test("`once` on `all` should work as expected", function(assert) {
+    assert.expect(1);
     Backbone.once('all', function() {
-      ok(true);
+      assert.ok(true);
       Backbone.trigger('all');
     });
     Backbone.trigger('all');
   });
 
-  test("once without a callback is a noop", 0, function() {
+  QUnit.test("once without a callback is a noop", function(assert) {
+    assert.expect(0);
     _.extend({}, Backbone.Events).once('event').trigger('event');
   });
 
-  test("listenToOnce without a callback is a noop", 0, function() {
+  QUnit.test("listenToOnce without a callback is a noop", function(assert) {
+    assert.expect(0);
     var obj = _.extend({}, Backbone.Events);
     obj.listenToOnce(obj, 'event').trigger('event');
   });
 
-  test("event functions are chainable", function() {
+  QUnit.test("event functions are chainable", function(assert) {
     var obj = _.extend({}, Backbone.Events);
     var obj2 = _.extend({}, Backbone.Events);
     var fn = function() {};
-    equal(obj, obj.trigger('noeventssetyet'));
-    equal(obj, obj.off('noeventssetyet'));
-    equal(obj, obj.stopListening('noeventssetyet'));
-    equal(obj, obj.on('a', fn));
-    equal(obj, obj.once('c', fn));
-    equal(obj, obj.trigger('a'));
-    equal(obj, obj.listenTo(obj2, 'a', fn));
-    equal(obj, obj.listenToOnce(obj2, 'b', fn));
-    equal(obj, obj.off('a c'));
-    equal(obj, obj.stopListening(obj2, 'a'));
-    equal(obj, obj.stopListening());
+    assert.equal(obj, obj.trigger('noeventssetyet'));
+    assert.equal(obj, obj.off('noeventssetyet'));
+    assert.equal(obj, obj.stopListening('noeventssetyet'));
+    assert.equal(obj, obj.on('a', fn));
+    assert.equal(obj, obj.once('c', fn));
+    assert.equal(obj, obj.trigger('a'));
+    assert.equal(obj, obj.listenTo(obj2, 'a', fn));
+    assert.equal(obj, obj.listenToOnce(obj2, 'b', fn));
+    assert.equal(obj, obj.off('a c'));
+    assert.equal(obj, obj.stopListening(obj2, 'a'));
+    assert.equal(obj, obj.stopListening());
   });
 
-  test("#3448 - listenToOnce with space-separated events", 2, function() {
+  QUnit.test("#3448 - listenToOnce with space-separated events", function(assert) {
+    assert.expect(2);
     var one = _.extend({}, Backbone.Events);
     var two = _.extend({}, Backbone.Events);
     var count = 1;
-    one.listenToOnce(two, 'x y', function(n) { ok(n === count++); });
+    one.listenToOnce(two, 'x y', function(n) { assert.ok(n === count++); });
     two.trigger('x', 1);
     two.trigger('x', 1);
     two.trigger('y', 2);

--- a/test/model.js
+++ b/test/model.js
@@ -6,9 +6,9 @@
   });
   var doc, collection;
 
-  module("Backbone.Model", {
+  QUnit.module("Backbone.Model", {
 
-    setup: function() {
+    beforeEach: function(assert) {
       doc = new proxy({
         id     : '1-the-tempest',
         title  : "The Tempest",
@@ -21,29 +21,32 @@
 
   });
 
-  test("initialize", 3, function() {
+  QUnit.test("initialize", function(assert) {
+    assert.expect(3);
     var Model = Backbone.Model.extend({
       initialize: function() {
         this.one = 1;
-        equal(this.collection, collection);
+        assert.equal(this.collection, collection);
       }
     });
     var model = new Model({}, {collection: collection});
-    equal(model.one, 1);
-    equal(model.collection, collection);
+    assert.equal(model.one, 1);
+    assert.equal(model.collection, collection);
   });
 
-  test("initialize with attributes and options", 1, function() {
+  QUnit.test("initialize with attributes and options", function(assert) {
+    assert.expect(1);
     var Model = Backbone.Model.extend({
       initialize: function(attributes, options) {
         this.one = options.one;
       }
     });
     var model = new Model({}, {one: 1});
-    equal(model.one, 1);
+    assert.equal(model.one, 1);
   });
 
-  test("initialize with parsed attributes", 1, function() {
+  QUnit.test("initialize with parsed attributes", function(assert) {
+    assert.expect(1);
     var Model = Backbone.Model.extend({
       parse: function(attrs) {
         attrs.value += 1;
@@ -51,10 +54,11 @@
       }
     });
     var model = new Model({value: 1}, {parse: true});
-    equal(model.get('value'), 2);
+    assert.equal(model.get('value'), 2);
   });
 
-  test("initialize with defaults", 2, function() {
+  QUnit.test("initialize with defaults", function(assert) {
+    assert.expect(2);
     var Model = Backbone.Model.extend({
       defaults: {
         first_name: 'Unknown',
@@ -62,11 +66,12 @@
       }
     });
     var model = new Model({'first_name': 'John'});
-    equal(model.get('first_name'), 'John');
-    equal(model.get('last_name'), 'Unknown');
+    assert.equal(model.get('first_name'), 'John');
+    assert.equal(model.get('last_name'), 'Unknown');
   });
 
-  test("parse can return null", 1, function() {
+  QUnit.test("parse can return null", function(assert) {
+    assert.expect(1);
     var Model = Backbone.Model.extend({
       parse: function(attrs) {
         attrs.value += 1;
@@ -74,30 +79,33 @@
       }
     });
     var model = new Model({value: 1}, {parse: true});
-    equal(JSON.stringify(model.toJSON()), "{}");
+    assert.equal(JSON.stringify(model.toJSON()), "{}");
   });
 
-  test("url", 3, function() {
+  QUnit.test("url", function(assert) {
+    assert.expect(3);
     doc.urlRoot = null;
-    equal(doc.url(), '/collection/1-the-tempest');
+    assert.equal(doc.url(), '/collection/1-the-tempest');
     doc.collection.url = '/collection/';
-    equal(doc.url(), '/collection/1-the-tempest');
+    assert.equal(doc.url(), '/collection/1-the-tempest');
     doc.collection = null;
-    throws(function() { doc.url(); });
+    assert.throws(function() { doc.url(); });
     doc.collection = collection;
   });
 
-  test("url when using urlRoot, and uri encoding", 2, function() {
+  QUnit.test("url when using urlRoot, and uri encoding", function(assert) {
+    assert.expect(2);
     var Model = Backbone.Model.extend({
       urlRoot: '/collection'
     });
     var model = new Model();
-    equal(model.url(), '/collection');
+    assert.equal(model.url(), '/collection');
     model.set({id: '+1+'});
-    equal(model.url(), '/collection/%2B1%2B');
+    assert.equal(model.url(), '/collection/%2B1%2B');
   });
 
-  test("url when using urlRoot as a function to determine urlRoot at runtime", 2, function() {
+  QUnit.test("url when using urlRoot as a function to determine urlRoot at runtime", function(assert) {
+    assert.expect(2);
     var Model = Backbone.Model.extend({
       urlRoot: function() {
         return '/nested/' + this.get('parent_id') + '/collection';
@@ -105,79 +113,85 @@
     });
 
     var model = new Model({parent_id: 1});
-    equal(model.url(), '/nested/1/collection');
+    assert.equal(model.url(), '/nested/1/collection');
     model.set({id: 2});
-    equal(model.url(), '/nested/1/collection/2');
+    assert.equal(model.url(), '/nested/1/collection/2');
   });
 
-  test("underscore methods", 5, function() {
+  QUnit.test("underscore methods", function(assert) {
+    assert.expect(5);
     var model = new Backbone.Model({ 'foo': 'a', 'bar': 'b', 'baz': 'c' });
     var model2 = model.clone();
-    deepEqual(model.keys(), ['foo', 'bar', 'baz']);
-    deepEqual(model.values(), ['a', 'b', 'c']);
-    deepEqual(model.invert(), { 'a': 'foo', 'b': 'bar', 'c': 'baz' });
-    deepEqual(model.pick('foo', 'baz'), {'foo': 'a', 'baz': 'c'});
-    deepEqual(model.omit('foo', 'bar'), {'baz': 'c'});
+    assert.deepEqual(model.keys(), ['foo', 'bar', 'baz']);
+    assert.deepEqual(model.values(), ['a', 'b', 'c']);
+    assert.deepEqual(model.invert(), { 'a': 'foo', 'b': 'bar', 'c': 'baz' });
+    assert.deepEqual(model.pick('foo', 'baz'), {'foo': 'a', 'baz': 'c'});
+    assert.deepEqual(model.omit('foo', 'bar'), {'baz': 'c'});
   });
 
-  test("chain", function() {
+  QUnit.test("chain", function(assert) {
     var model = new Backbone.Model({ a: 0, b: 1, c: 2 });
-    deepEqual(model.chain().pick("a", "b", "c").values().compact().value(), [1, 2]);
+    assert.deepEqual(model.chain().pick("a", "b", "c").values().compact().value(), [1, 2]);
   });
 
-  test("clone", 10, function() {
+  QUnit.test("clone", function(assert) {
+    assert.expect(10);
     var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
     var b = a.clone();
-    equal(a.get('foo'), 1);
-    equal(a.get('bar'), 2);
-    equal(a.get('baz'), 3);
-    equal(b.get('foo'), a.get('foo'), "Foo should be the same on the clone.");
-    equal(b.get('bar'), a.get('bar'), "Bar should be the same on the clone.");
-    equal(b.get('baz'), a.get('baz'), "Baz should be the same on the clone.");
+    assert.equal(a.get('foo'), 1);
+    assert.equal(a.get('bar'), 2);
+    assert.equal(a.get('baz'), 3);
+    assert.equal(b.get('foo'), a.get('foo'), "Foo should be the same on the clone.");
+    assert.equal(b.get('bar'), a.get('bar'), "Bar should be the same on the clone.");
+    assert.equal(b.get('baz'), a.get('baz'), "Baz should be the same on the clone.");
     a.set({foo : 100});
-    equal(a.get('foo'), 100);
-    equal(b.get('foo'), 1, "Changing a parent attribute does not change the clone.");
+    assert.equal(a.get('foo'), 100);
+    assert.equal(b.get('foo'), 1, "Changing a parent attribute does not change the clone.");
 
     var foo = new Backbone.Model({p: 1});
     var bar = new Backbone.Model({p: 2});
     bar.set(foo.clone().attributes, {unset: true});
-    equal(foo.get('p'), 1);
-    equal(bar.get('p'), undefined);
+    assert.equal(foo.get('p'), 1);
+    assert.equal(bar.get('p'), undefined);
   });
 
-  test("isNew", 6, function() {
+  QUnit.test("isNew", function(assert) {
+    assert.expect(6);
     var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
-    ok(a.isNew(), "it should be new");
+    assert.ok(a.isNew(), "it should be new");
     a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3, 'id': -5 });
-    ok(!a.isNew(), "any defined ID is legal, negative or positive");
+    assert.ok(!a.isNew(), "any defined ID is legal, negative or positive");
     a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3, 'id': 0 });
-    ok(!a.isNew(), "any defined ID is legal, including zero");
-    ok( new Backbone.Model({          }).isNew(), "is true when there is no id");
-    ok(!new Backbone.Model({ 'id': 2  }).isNew(), "is false for a positive integer");
-    ok(!new Backbone.Model({ 'id': -5 }).isNew(), "is false for a negative integer");
+    assert.ok(!a.isNew(), "any defined ID is legal, including zero");
+    assert.ok( new Backbone.Model({          }).isNew(), "is true when there is no id");
+    assert.ok(!new Backbone.Model({ 'id': 2  }).isNew(), "is false for a positive integer");
+    assert.ok(!new Backbone.Model({ 'id': -5 }).isNew(), "is false for a negative integer");
   });
 
-  test("get", 2, function() {
-    equal(doc.get('title'), 'The Tempest');
-    equal(doc.get('author'), 'Bill Shakespeare');
+  QUnit.test("get", function(assert) {
+    assert.expect(2);
+    assert.equal(doc.get('title'), 'The Tempest');
+    assert.equal(doc.get('author'), 'Bill Shakespeare');
   });
 
-  test("escape", 5, function() {
-    equal(doc.escape('title'), 'The Tempest');
+  QUnit.test("escape", function(assert) {
+    assert.expect(5);
+    assert.equal(doc.escape('title'), 'The Tempest');
     doc.set({audience: 'Bill & Bob'});
-    equal(doc.escape('audience'), 'Bill &amp; Bob');
+    assert.equal(doc.escape('audience'), 'Bill &amp; Bob');
     doc.set({audience: 'Tim > Joan'});
-    equal(doc.escape('audience'), 'Tim &gt; Joan');
+    assert.equal(doc.escape('audience'), 'Tim &gt; Joan');
     doc.set({audience: 10101});
-    equal(doc.escape('audience'), '10101');
+    assert.equal(doc.escape('audience'), '10101');
     doc.unset('audience');
-    equal(doc.escape('audience'), '');
+    assert.equal(doc.escape('audience'), '');
   });
 
-  test("has", 10, function() {
+  QUnit.test("has", function(assert) {
+    assert.expect(10);
     var model = new Backbone.Model();
 
-    strictEqual(model.has('name'), false);
+    assert.strictEqual(model.has('name'), false);
 
     model.set({
       '0': 0,
@@ -190,70 +204,73 @@
       'undefined': undefined
     });
 
-    strictEqual(model.has('0'), true);
-    strictEqual(model.has('1'), true);
-    strictEqual(model.has('true'), true);
-    strictEqual(model.has('false'), true);
-    strictEqual(model.has('empty'), true);
-    strictEqual(model.has('name'), true);
+    assert.strictEqual(model.has('0'), true);
+    assert.strictEqual(model.has('1'), true);
+    assert.strictEqual(model.has('true'), true);
+    assert.strictEqual(model.has('false'), true);
+    assert.strictEqual(model.has('empty'), true);
+    assert.strictEqual(model.has('name'), true);
 
     model.unset('name');
 
-    strictEqual(model.has('name'), false);
-    strictEqual(model.has('null'), false);
-    strictEqual(model.has('undefined'), false);
+    assert.strictEqual(model.has('name'), false);
+    assert.strictEqual(model.has('null'), false);
+    assert.strictEqual(model.has('undefined'), false);
   });
 
-  test("matches", 4, function() {
+  QUnit.test("matches", function(assert) {
+    assert.expect(4);
     var model = new Backbone.Model();
 
-    strictEqual(model.matches({'name': 'Jonas', 'cool': true}), false);
+    assert.strictEqual(model.matches({'name': 'Jonas', 'cool': true}), false);
 
     model.set({name: 'Jonas', 'cool': true});
 
-    strictEqual(model.matches({'name': 'Jonas'}), true);
-    strictEqual(model.matches({'name': 'Jonas', 'cool': true}), true);
-    strictEqual(model.matches({'name': 'Jonas', 'cool': false}), false);
+    assert.strictEqual(model.matches({'name': 'Jonas'}), true);
+    assert.strictEqual(model.matches({'name': 'Jonas', 'cool': true}), true);
+    assert.strictEqual(model.matches({'name': 'Jonas', 'cool': false}), false);
   });
 
-  test("matches with predicate", function() {
+  QUnit.test("matches with predicate", function(assert) {
     var model = new Backbone.Model({a: 0});
 
-    strictEqual(model.matches(function(attr) {
+    assert.strictEqual(model.matches(function(attr) {
       return attr.a > 1 && attr.b != null;
     }), false);
 
     model.set({a: 3, b: true});
 
-    strictEqual(model.matches(function(attr) {
+    assert.strictEqual(model.matches(function(attr) {
       return attr.a > 1 && attr.b != null;
     }), true);
   })
 
-  test("set and unset", 8, function() {
+  QUnit.test("set and unset", function(assert) {
+    assert.expect(8);
     var a = new Backbone.Model({id: 'id', foo: 1, bar: 2, baz: 3});
     var changeCount = 0;
     a.on("change:foo", function() { changeCount += 1; });
     a.set({'foo': 2});
-    ok(a.get('foo') == 2, "Foo should have changed.");
-    ok(changeCount == 1, "Change count should have incremented.");
-    a.set({'foo': 2}); // set with value that is not new shouldn't fire change event
-    ok(a.get('foo') == 2, "Foo should NOT have changed, still 2");
-    ok(changeCount == 1, "Change count should NOT have incremented.");
+    assert.ok(a.get('foo') == 2, "Foo should have changed.");
+    assert.ok(changeCount == 1, "Change count should have incremented.");
+    // set with value that is not new shouldn't fire change event
+    a.set({'foo': 2});
+    assert.ok(a.get('foo') == 2, "Foo should NOT have changed, still 2");
+    assert.ok(changeCount == 1, "Change count should NOT have incremented.");
 
     a.validate = function(attrs) {
-      equal(attrs.foo, void 0, "validate:true passed while unsetting");
+      assert.equal(attrs.foo, void 0, "validate:true passed while unsetting");
     };
     a.unset('foo', {validate: true});
-    equal(a.get('foo'), void 0, "Foo should have changed");
+    assert.equal(a.get('foo'), void 0, "Foo should have changed");
     delete a.validate;
-    ok(changeCount == 2, "Change count should have incremented for unset.");
+    assert.ok(changeCount == 2, "Change count should have incremented for unset.");
 
     a.unset('id');
-    equal(a.id, undefined, "Unsetting the id should remove the id property.");
+    assert.equal(a.id, undefined, "Unsetting the id should remove the id property.");
   });
 
-  test("#2030 - set with failed validate, followed by another set triggers change", function () {
+  QUnit.test("#2030 - set with failed validate, followed by another set triggers change", function(assert) {
     var attr = 0, main = 0, error = 0;
     var Model = Backbone.Model.extend({
       validate: function (attr) {
@@ -268,24 +285,25 @@
       model.on('change', function () { main++; });
       model.set({x:2}, {validate:true});
       model.set({x:1}, {validate:true});
-      deepEqual([attr, main, error], [1, 1, 1]);
+      assert.deepEqual([attr, main, error], [1, 1, 1]);
   });
 
-  test("set triggers changes in the correct order", function() {
+  QUnit.test("set triggers changes in the correct order", function(assert) {
     var value = null;
     var model = new Backbone.Model;
     model.on('last', function(){ value = 'last'; });
     model.on('first', function(){ value = 'first'; });
     model.trigger('first');
     model.trigger('last');
-    equal(value, 'last');
+    assert.equal(value, 'last');
   });
 
-  test("set falsy values in the correct order", 2, function() {
+  QUnit.test("set falsy values in the correct order", function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model({result: 'result'});
     model.on('change', function() {
-      equal(model.changed.result, void 0);
-      equal(model.previous('result'), false);
+      assert.equal(model.changed.result, void 0);
+      assert.equal(model.previous('result'), false);
     });
     model.set({result: void 0}, {silent: true});
     model.set({result: null}, {silent: true});
@@ -293,7 +311,7 @@
     model.set({result: void 0});
   });
 
-  test("nested set triggers with the correct options", function() {
+  QUnit.test("nested set triggers with the correct options", function(assert) {
     var model = new Backbone.Model();
     var o1 = {};
     var o2 = {};
@@ -301,19 +319,20 @@
     model.on('change', function(__, options) {
       switch (model.get('a')) {
       case 1:
-        equal(options, o1);
+        assert.equal(options, o1);
         return model.set('a', 2, o2);
       case 2:
-        equal(options, o2);
+        assert.equal(options, o2);
         return model.set('a', 3, o3);
       case 3:
-        equal(options, o3);
+        assert.equal(options, o3);
       }
     });
     model.set('a', 1, o1);
   });
 
-  test("multiple unsets", 1, function() {
+  QUnit.test("multiple unsets", function(assert) {
+    assert.expect(1);
     var i = 0;
     var counter = function(){ i++; };
     var model = new Backbone.Model({a: 1});
@@ -321,65 +340,70 @@
     model.set({a: 2});
     model.unset('a');
     model.unset('a');
-    equal(i, 2, 'Unset does not fire an event for missing attributes.');
+    assert.equal(i, 2, 'Unset does not fire an event for missing attributes.');
   });
 
-  test("unset and changedAttributes", 1, function() {
+  QUnit.test("unset and changedAttributes", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model({a: 1});
     model.on('change', function() {
-      ok('a' in model.changedAttributes(), 'changedAttributes should contain unset properties');
+      assert.ok('a' in model.changedAttributes(), 'changedAttributes should contain unset properties');
     });
     model.unset('a');
   });
 
-  test("using a non-default id attribute.", 5, function() {
+  QUnit.test("using a non-default id attribute.", function(assert) {
+    assert.expect(5);
     var MongoModel = Backbone.Model.extend({idAttribute : '_id'});
     var model = new MongoModel({id: 'eye-dee', _id: 25, title: 'Model'});
-    equal(model.get('id'), 'eye-dee');
-    equal(model.id, 25);
-    equal(model.isNew(), false);
+    assert.equal(model.get('id'), 'eye-dee');
+    assert.equal(model.id, 25);
+    assert.equal(model.isNew(), false);
     model.unset('_id');
-    equal(model.id, undefined);
-    equal(model.isNew(), true);
+    assert.equal(model.id, undefined);
+    assert.equal(model.isNew(), true);
   });
 
-  test("setting an alternative cid prefix", 4, function() {
+  QUnit.test("setting an alternative cid prefix", function(assert) {
+    assert.expect(4);
     var Model = Backbone.Model.extend({
       cidPrefix: 'm'
     });
     var model = new Model();
 
-    equal(model.cid.charAt(0), 'm');
+    assert.equal(model.cid.charAt(0), 'm');
 
     model = new Backbone.Model();
-    equal(model.cid.charAt(0), 'c');
+    assert.equal(model.cid.charAt(0), 'c');
 
     var Collection = Backbone.Collection.extend({
       model: Model
     });
     var collection = new Collection([{id: 'c5'}, {id: 'c6'}, {id: 'c7'}]);
 
-    equal(collection.get('c6').cid.charAt(0), 'm');
+    assert.equal(collection.get('c6').cid.charAt(0), 'm');
     collection.set([{id: 'c6', value: 'test'}], {
       merge: true,
       add: true,
       remove: false
     });
-    ok(collection.get('c6').has('value'));
+    assert.ok(collection.get('c6').has('value'));
   });
 
-  test("set an empty string", 1, function() {
+  QUnit.test("set an empty string", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model({name : "Model"});
     model.set({name : ''});
-    equal(model.get('name'), '');
+    assert.equal(model.get('name'), '');
   });
 
-  test("setting an object", 1, function() {
+  QUnit.test("setting an object", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model({
       custom: { foo: 1 }
     });
     model.on('change', function() {
-      ok(1);
+      assert.ok(1);
     });
     model.set({
       custom: { foo: 1 } // no change should be fired
@@ -389,20 +413,22 @@
     });
   });
 
-  test("clear", 3, function() {
+  QUnit.test("clear", function(assert) {
+    assert.expect(3);
     var changed;
     var model = new Backbone.Model({id: 1, name : "Model"});
     model.on("change:name", function(){ changed = true; });
     model.on("change", function() {
       var changedAttrs = model.changedAttributes();
-      ok('name' in changedAttrs);
+      assert.ok('name' in changedAttrs);
     });
     model.clear();
-    equal(changed, true);
-    equal(model.get('name'), undefined);
+    assert.equal(changed, true);
+    assert.equal(model.get('name'), undefined);
   });
 
-  test("defaults", 4, function() {
+  QUnit.test("defaults", function(assert) {
+    assert.expect(4);
     var Defaulted = Backbone.Model.extend({
       defaults: {
         "one": 1,
@@ -410,8 +436,8 @@
       }
     });
     var model = new Defaulted({two: undefined});
-    equal(model.get('one'), 1);
-    equal(model.get('two'), 2);
+    assert.equal(model.get('one'), 1);
+    assert.equal(model.get('two'), 2);
     Defaulted = Backbone.Model.extend({
       defaults: function() {
         return {
@@ -421,66 +447,72 @@
       }
     });
     model = new Defaulted({two: undefined});
-    equal(model.get('one'), 3);
-    equal(model.get('two'), 4);
+    assert.equal(model.get('one'), 3);
+    assert.equal(model.get('two'), 4);
   });
 
-  test("change, hasChanged, changedAttributes, previous, previousAttributes", 9, function() {
+  QUnit.test("change, hasChanged, changedAttributes, previous, previousAttributes", function(assert) {
+    assert.expect(9);
     var model = new Backbone.Model({name: "Tim", age: 10});
-    deepEqual(model.changedAttributes(), false);
+    assert.deepEqual(model.changedAttributes(), false);
     model.on('change', function() {
-      ok(model.hasChanged('name'), 'name changed');
-      ok(!model.hasChanged('age'), 'age did not');
-      ok(_.isEqual(model.changedAttributes(), {name : 'Rob'}), 'changedAttributes returns the changed attrs');
-      equal(model.previous('name'), 'Tim');
-      ok(_.isEqual(model.previousAttributes(), {name : "Tim", age : 10}), 'previousAttributes is correct');
+      assert.ok(model.hasChanged('name'), 'name changed');
+      assert.ok(!model.hasChanged('age'), 'age did not');
+      assert.ok(_.isEqual(model.changedAttributes(), {name : 'Rob'}), 'changedAttributes returns the changed attrs');
+      assert.equal(model.previous('name'), 'Tim');
+      assert.ok(_.isEqual(model.previousAttributes(), {name : "Tim", age : 10}), 'previousAttributes is correct');
     });
-    equal(model.hasChanged(), false);
-    equal(model.hasChanged(undefined), false);
+    assert.equal(model.hasChanged(), false);
+    assert.equal(model.hasChanged(undefined), false);
     model.set({name : 'Rob'});
-    equal(model.get('name'), 'Rob');
+    assert.equal(model.get('name'), 'Rob');
   });
 
-  test("changedAttributes", 3, function() {
+  QUnit.test("changedAttributes", function(assert) {
+    assert.expect(3);
     var model = new Backbone.Model({a: 'a', b: 'b'});
-    deepEqual(model.changedAttributes(), false);
-    equal(model.changedAttributes({a: 'a'}), false);
-    equal(model.changedAttributes({a: 'b'}).a, 'b');
+    assert.deepEqual(model.changedAttributes(), false);
+    assert.equal(model.changedAttributes({a: 'a'}), false);
+    assert.equal(model.changedAttributes({a: 'b'}).a, 'b');
   });
 
-  test("change with options", 2, function() {
+  QUnit.test("change with options", function(assert) {
+    assert.expect(2);
     var value;
     var model = new Backbone.Model({name: 'Rob'});
     model.on('change', function(model, options) {
       value = options.prefix + model.get('name');
     });
     model.set({name: 'Bob'}, {prefix: 'Mr. '});
-    equal(value, 'Mr. Bob');
+    assert.equal(value, 'Mr. Bob');
     model.set({name: 'Sue'}, {prefix: 'Ms. '});
-    equal(value, 'Ms. Sue');
+    assert.equal(value, 'Ms. Sue');
   });
 
-  test("change after initialize", 1, function () {
+  QUnit.test("change after initialize", function(assert) {
+    assert.expect(1);
     var changed = 0;
     var attrs = {id: 1, label: 'c'};
     var obj = new Backbone.Model(attrs);
     obj.on('change', function() { changed += 1; });
     obj.set(attrs);
-    equal(changed, 0);
+    assert.equal(changed, 0);
   });
 
-  test("save within change event", 1, function () {
+  QUnit.test("save within change event", function(assert) {
+    assert.expect(1);
     var env = this;
     var model = new Backbone.Model({firstName : "Taylor", lastName: "Swift"});
     model.url = '/test';
     model.on('change', function () {
       model.save();
-      ok(_.isEqual(env.syncArgs.model, model));
+      assert.ok(_.isEqual(env.syncArgs.model, model));
     });
     model.set({lastName: 'Hicks'});
   });
 
-  test("validate after save", 2, function() {
+  QUnit.test("validate after save", function(assert) {
+    assert.expect(2);
     var lastError, model = new Backbone.Model();
     model.validate = function(attrs) {
       if (attrs.admin) return "Can't change admin status.";
@@ -493,20 +525,22 @@
     });
     model.save(null);
 
-    equal(lastError, "Can't change admin status.");
-    equal(model.validationError, "Can't change admin status.");
+    assert.equal(lastError, "Can't change admin status.");
+    assert.equal(model.validationError, "Can't change admin status.");
   });
 
-  test("save", 2, function() {
+  QUnit.test("save", function(assert) {
+    assert.expect(2);
     doc.save({title : "Henry V"});
-    equal(this.syncArgs.method, 'update');
-    ok(_.isEqual(this.syncArgs.model, doc));
+    assert.equal(this.syncArgs.method, 'update');
+    assert.ok(_.isEqual(this.syncArgs.model, doc));
   });
 
-  test("save, fetch, destroy triggers error event when an error occurs", 3, function () {
+  QUnit.test("save, fetch, destroy triggers error event when an error occurs", function(assert) {
+    assert.expect(3);
     var model = new Backbone.Model();
     model.on('error', function () {
-      ok(true);
+      assert.ok(true);
     });
     model.sync = function (method, model, options) {
       options.error();
@@ -516,13 +550,14 @@
     model.destroy();
   });
 
-  test("#3283 - save, fetch, destroy calls success with context", 3, function () {
+  QUnit.test("#3283 - save, fetch, destroy calls success with context", function(assert) {
+    assert.expect(3);
     var model = new Backbone.Model();
     var obj = {};
     var options = {
       context: obj,
       success: function() {
-        equal(this, obj);
+        assert.equal(this, obj);
       }
     };
     model.sync = function (method, model, options) {
@@ -533,13 +568,14 @@
     model.destroy(options);
   });
 
-  test("#3283 - save, fetch, destroy calls error with context", 3, function () {
+  QUnit.test("#3283 - save, fetch, destroy calls error with context", function(assert) {
+    assert.expect(3);
     var model = new Backbone.Model();
     var obj = {};
     var options = {
       context: obj,
       error: function() {
-        equal(this, obj);
+        assert.equal(this, obj);
       }
     };
     model.sync = function (method, model, options) {
@@ -550,53 +586,56 @@
     model.destroy(options);
   });
 
-  test("#3470 - save and fetch with parse false", 2, function() {
+  QUnit.test("#3470 - save and fetch with parse false", function(assert) {
+    assert.expect(2);
     var i = 0;
     var model = new Backbone.Model();
     model.parse = function() {
-      ok(false);
+      assert.ok(false);
     };
     model.sync = function(method, model, options) {
       options.success({i: ++i});
     };
     model.fetch({parse: false});
-    equal(model.get('i'), i);
+    assert.equal(model.get('i'), i);
     model.save(null, {parse: false});
-    equal(model.get('i'), i);
+    assert.equal(model.get('i'), i);
   });
 
-  test("save with PATCH", function() {
+  QUnit.test("save with PATCH", function(assert) {
     doc.clear().set({id: 1, a: 1, b: 2, c: 3, d: 4});
     doc.save();
-    equal(this.syncArgs.method, 'update');
-    equal(this.syncArgs.options.attrs, undefined);
+    assert.equal(this.syncArgs.method, 'update');
+    assert.equal(this.syncArgs.options.attrs, undefined);
 
     doc.save({b: 2, d: 4}, {patch: true});
-    equal(this.syncArgs.method, 'patch');
-    equal(_.size(this.syncArgs.options.attrs), 2);
-    equal(this.syncArgs.options.attrs.d, 4);
-    equal(this.syncArgs.options.attrs.a, undefined);
-    equal(this.ajaxSettings.data, "{\"b\":2,\"d\":4}");
+    assert.equal(this.syncArgs.method, 'patch');
+    assert.equal(_.size(this.syncArgs.options.attrs), 2);
+    assert.equal(this.syncArgs.options.attrs.d, 4);
+    assert.equal(this.syncArgs.options.attrs.a, undefined);
+    assert.equal(this.ajaxSettings.data, "{\"b\":2,\"d\":4}");
   });
 
-  test("save with PATCH and different attrs", function() {
+  QUnit.test("save with PATCH and different attrs", function(assert) {
     doc.clear().save({b: 2, d: 4}, {patch: true, attrs: {B: 1, D: 3}});
-    equal(this.syncArgs.options.attrs.D, 3);
-    equal(this.syncArgs.options.attrs.d, undefined);
-    equal(this.ajaxSettings.data, "{\"B\":1,\"D\":3}");
-    deepEqual(doc.attributes, {b: 2, d: 4});
+    assert.equal(this.syncArgs.options.attrs.D, 3);
+    assert.equal(this.syncArgs.options.attrs.d, undefined);
+    assert.equal(this.ajaxSettings.data, "{\"B\":1,\"D\":3}");
+    assert.deepEqual(doc.attributes, {b: 2, d: 4});
   });
 
-  test("save in positional style", 1, function() {
+  QUnit.test("save in positional style", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     model.sync = function(method, model, options) {
       options.success();
     };
     model.save('title', 'Twelfth Night');
-    equal(model.get('title'), 'Twelfth Night');
+    assert.equal(model.get('title'), 'Twelfth Night');
   });
 
-  test("save with non-object success response", 2, function () {
+  QUnit.test("save with non-object success response", function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model();
     model.sync = function(method, model, options) {
       options.success('', options);
@@ -604,21 +643,22 @@
     };
     model.save({testing:'empty'}, {
       success: function (model) {
-        deepEqual(model.attributes, {testing:'empty'});
+        assert.deepEqual(model.attributes, {testing:'empty'});
       }
     });
   });
 
-  test("save with wait and supplied id", function() {
+  QUnit.test("save with wait and supplied id", function(assert) {
     var Model = Backbone.Model.extend({
       urlRoot: '/collection'
     });
     var model = new Model();
     model.save({id: 42}, {wait: true});
-    equal(this.ajaxSettings.url, '/collection/42');
+    assert.equal(this.ajaxSettings.url, '/collection/42');
   });
 
-  test("save will pass extra options to success callback", 1, function () {
+  QUnit.test("save will pass extra options to success callback", function(assert) {
+    assert.expect(1);
     var SpecialSyncModel = Backbone.Model.extend({
       sync: function (method, model, options) {
         _.extend(options, { specialSync: true });
@@ -630,20 +670,22 @@
     var model = new SpecialSyncModel();
 
     var onSuccess = function (model, response, options) {
-      ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, "Options were passed correctly to callback");
     };
 
     model.save(null, { success: onSuccess });
     this.ajaxSettings.success();
   });
 
-  test("fetch", 2, function() {
+  QUnit.test("fetch", function(assert) {
+    assert.expect(2);
     doc.fetch();
-    equal(this.syncArgs.method, 'read');
-    ok(_.isEqual(this.syncArgs.model, doc));
+    assert.equal(this.syncArgs.method, 'read');
+    assert.ok(_.isEqual(this.syncArgs.model, doc));
   });
 
-  test("fetch will pass extra options to success callback", 1, function () {
+  QUnit.test("fetch will pass extra options to success callback", function(assert) {
+    assert.expect(1);
     var SpecialSyncModel = Backbone.Model.extend({
       sync: function (method, model, options) {
         _.extend(options, { specialSync: true });
@@ -655,23 +697,25 @@
     var model = new SpecialSyncModel();
 
     var onSuccess = function (model, response, options) {
-      ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, "Options were passed correctly to callback");
     };
 
     model.fetch({ success: onSuccess });
     this.ajaxSettings.success();
   });
 
-  test("destroy", 3, function() {
+  QUnit.test("destroy", function(assert) {
+    assert.expect(3);
     doc.destroy();
-    equal(this.syncArgs.method, 'delete');
-    ok(_.isEqual(this.syncArgs.model, doc));
+    assert.equal(this.syncArgs.method, 'delete');
+    assert.ok(_.isEqual(this.syncArgs.model, doc));
 
     var newModel = new Backbone.Model;
-    equal(newModel.destroy(), false);
+    assert.equal(newModel.destroy(), false);
   });
 
-  test("destroy will pass extra options to success callback", 1, function () {
+  QUnit.test("destroy will pass extra options to success callback", function(assert) {
+    assert.expect(1);
     var SpecialSyncModel = Backbone.Model.extend({
       sync: function (method, model, options) {
         _.extend(options, { specialSync: true });
@@ -683,21 +727,22 @@
     var model = new SpecialSyncModel({ id: 'id' });
 
     var onSuccess = function (model, response, options) {
-      ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, "Options were passed correctly to callback");
     };
 
     model.destroy({ success: onSuccess });
     this.ajaxSettings.success();
   });
 
-  test("non-persisted destroy", 1, function() {
+  QUnit.test("non-persisted destroy", function(assert) {
+    assert.expect(1);
     var a = new Backbone.Model({ 'foo': 1, 'bar': 2, 'baz': 3});
     a.sync = function() { throw "should not be called"; };
     a.destroy();
-    ok(true, "non-persisted model should not call sync");
+    assert.ok(true, "non-persisted model should not call sync");
   });
 
-  test("validate", function() {
+  QUnit.test("validate", function(assert) {
     var lastError;
     var model = new Backbone.Model();
     model.validate = function(attrs) {
@@ -707,18 +752,19 @@
       lastError = error;
     });
     var result = model.set({a: 100});
-    equal(result, model);
-    equal(model.get('a'), 100);
-    equal(lastError, undefined);
+    assert.equal(result, model);
+    assert.equal(model.get('a'), 100);
+    assert.equal(lastError, undefined);
     result = model.set({admin: true});
-    equal(model.get('admin'), true);
+    assert.equal(model.get('admin'), true);
     result = model.set({a: 200, admin: false}, {validate:true});
-    equal(lastError, "Can't change admin status.");
-    equal(result, false);
-    equal(model.get('a'), 100);
+    assert.equal(lastError, "Can't change admin status.");
+    assert.equal(result, false);
+    assert.equal(model.get('a'), 100);
   });
 
-  test("validate on unset and clear", 6, function() {
+  QUnit.test("validate on unset and clear", function(assert) {
+    assert.expect(6);
     var error;
     var model = new Backbone.Model({name: "One"});
     model.validate = function(attrs) {
@@ -728,19 +774,20 @@
       }
     };
     model.set({name: "Two"});
-    equal(model.get('name'), 'Two');
-    equal(error, undefined);
+    assert.equal(model.get('name'), 'Two');
+    assert.equal(error, undefined);
     model.unset('name', {validate: true});
-    equal(error, true);
-    equal(model.get('name'), 'Two');
+    assert.equal(error, true);
+    assert.equal(model.get('name'), 'Two');
     model.clear({validate:true});
-    equal(model.get('name'), 'Two');
+    assert.equal(model.get('name'), 'Two');
     delete model.validate;
     model.clear();
-    equal(model.get('name'), undefined);
+    assert.equal(model.get('name'), undefined);
   });
 
-  test("validate with error callback", 8, function() {
+  QUnit.test("validate with error callback", function(assert) {
+    assert.expect(8);
     var lastError, boundError;
     var model = new Backbone.Model();
     model.validate = function(attrs) {
@@ -750,29 +797,31 @@
       boundError = true;
     });
     var result = model.set({a: 100}, {validate:true});
-    equal(result, model);
-    equal(model.get('a'), 100);
-    equal(model.validationError, null);
-    equal(boundError, undefined);
+    assert.equal(result, model);
+    assert.equal(model.get('a'), 100);
+    assert.equal(model.validationError, null);
+    assert.equal(boundError, undefined);
     result = model.set({a: 200, admin: true}, {validate:true});
-    equal(result, false);
-    equal(model.get('a'), 100);
-    equal(model.validationError, "Can't change admin status.");
-    equal(boundError, true);
+    assert.equal(result, false);
+    assert.equal(model.get('a'), 100);
+    assert.equal(model.validationError, "Can't change admin status.");
+    assert.equal(boundError, true);
   });
 
-  test("defaults always extend attrs (#459)", 2, function() {
+  QUnit.test("defaults always extend attrs (#459)", function(assert) {
+    assert.expect(2);
     var Defaulted = Backbone.Model.extend({
       defaults: {one: 1},
       initialize : function(attrs, opts) {
-        equal(this.attributes.one, 1);
+        assert.equal(this.attributes.one, 1);
       }
     });
     var providedattrs = new Defaulted({});
     var emptyattrs = new Defaulted();
   });
 
-  test("Inherit class properties", 6, function() {
+  QUnit.test("Inherit class properties", function(assert) {
+    assert.expect(6);
     var Parent = Backbone.Model.extend({
       instancePropSame: function() {},
       instancePropDiff: function() {}
@@ -786,17 +835,18 @@
     var adult = new Parent;
     var kid   = new Child;
 
-    equal(Child.classProp, Parent.classProp);
-    notEqual(Child.classProp, undefined);
+    assert.equal(Child.classProp, Parent.classProp);
+    assert.notEqual(Child.classProp, undefined);
 
-    equal(kid.instancePropSame, adult.instancePropSame);
-    notEqual(kid.instancePropSame, undefined);
+    assert.equal(kid.instancePropSame, adult.instancePropSame);
+    assert.notEqual(kid.instancePropSame, undefined);
 
-    notEqual(Child.prototype.instancePropDiff, Parent.prototype.instancePropDiff);
-    notEqual(Child.prototype.instancePropDiff, undefined);
+    assert.notEqual(Child.prototype.instancePropDiff, Parent.prototype.instancePropDiff);
+    assert.notEqual(Child.prototype.instancePropDiff, undefined);
   });
 
-  test("Nested change events don't clobber previous attributes", 4, function() {
+  QUnit.test("Nested change events don't clobber previous attributes", function(assert) {
+    assert.expect(4);
     new Backbone.Model()
     .on('change:state', function(model, newState) {
       equal(model.previous('state'), undefined);
@@ -811,25 +861,27 @@
     .set({state: 'hello'});
   });
 
-  test("hasChanged/set should use same comparison", 2, function() {
+  QUnit.test("hasChanged/set should use same comparison", function(assert) {
+    assert.expect(2);
     var changed = 0, model = new Backbone.Model({a: null});
     model.on('change', function() {
-      ok(this.hasChanged('a'));
+      assert.ok(this.hasChanged('a'));
     })
     .on('change:a', function() {
       changed++;
     })
     .set({a: undefined});
-    equal(changed, 1);
+    assert.equal(changed, 1);
   });
 
-  test("#582, #425, change:attribute callbacks should fire after all changes have occurred", 9, function() {
+  QUnit.test("#582, #425, change:attribute callbacks should fire after all changes have occurred", function(assert) {
+    assert.expect(9);
     var model = new Backbone.Model;
 
     var assertion = function() {
-      equal(model.get('a'), 'a');
-      equal(model.get('b'), 'b');
-      equal(model.get('c'), 'c');
+      assert.equal(model.get('a'), 'a');
+      assert.equal(model.get('b'), 'b');
+      assert.equal(model.get('c'), 'c');
     };
 
     model.on('change:a', assertion);
@@ -839,146 +891,160 @@
     model.set({a: 'a', b: 'b', c: 'c'});
   });
 
-  test("#871, set with attributes property", 1, function() {
+  QUnit.test("#871, set with attributes property", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     model.set({attributes: true});
-    ok(model.has('attributes'));
+    assert.ok(model.has('attributes'));
   });
 
-  test("set value regardless of equality/change", 1, function() {
+  QUnit.test("set value regardless of equality/change", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model({x: []});
     var a = [];
     model.set({x: a});
-    ok(model.get('x') === a);
+    assert.ok(model.get('x') === a);
   });
 
-  test("set same value does not trigger change", 0, function() {
+  QUnit.test("set same value does not trigger change", function(assert) {
+    assert.expect(0);
     var model = new Backbone.Model({x: 1});
-    model.on('change change:x', function() { ok(false); });
+    model.on('change change:x', function() { assert.ok(false); });
     model.set({x: 1});
     model.set({x: 1});
   });
 
-  test("unset does not fire a change for undefined attributes", 0, function() {
+  QUnit.test("unset does not fire a change for undefined attributes", function(assert) {
+    assert.expect(0);
     var model = new Backbone.Model({x: undefined});
-    model.on('change:x', function(){ ok(false); });
+    model.on('change:x', function(){ assert.ok(false); });
     model.unset('x');
   });
 
-  test("set: undefined values", 1, function() {
+  QUnit.test("set: undefined values", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model({x: undefined});
-    ok('x' in model.attributes);
+    assert.ok('x' in model.attributes);
   });
 
-  test("hasChanged works outside of change events, and true within", 6, function() {
+  QUnit.test("hasChanged works outside of change events, and true within", function(assert) {
+    assert.expect(6);
     var model = new Backbone.Model({x: 1});
     model.on('change:x', function() {
-      ok(model.hasChanged('x'));
-      equal(model.get('x'), 1);
+      assert.ok(model.hasChanged('x'));
+      assert.equal(model.get('x'), 1);
     });
     model.set({x: 2}, {silent: true});
-    ok(model.hasChanged());
-    equal(model.hasChanged('x'), true);
+    assert.ok(model.hasChanged());
+    assert.equal(model.hasChanged('x'), true);
     model.set({x: 1});
-    ok(model.hasChanged());
-    equal(model.hasChanged('x'), true);
+    assert.ok(model.hasChanged());
+    assert.equal(model.hasChanged('x'), true);
   });
 
-  test("hasChanged gets cleared on the following set", 4, function() {
+  QUnit.test("hasChanged gets cleared on the following set", function(assert) {
+    assert.expect(4);
     var model = new Backbone.Model;
     model.set({x: 1});
-    ok(model.hasChanged());
+    assert.ok(model.hasChanged());
     model.set({x: 1});
-    ok(!model.hasChanged());
+    assert.ok(!model.hasChanged());
     model.set({x: 2});
-    ok(model.hasChanged());
+    assert.ok(model.hasChanged());
     model.set({});
-    ok(!model.hasChanged());
+    assert.ok(!model.hasChanged());
   });
 
-  test("save with `wait` succeeds without `validate`", 1, function() {
+  QUnit.test("save with `wait` succeeds without `validate`", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     model.url = '/test';
     model.save({x: 1}, {wait: true});
-    ok(this.syncArgs.model === model);
+    assert.ok(this.syncArgs.model === model);
   });
 
-  test("save without `wait` doesn't set invalid attributes", function () {
+  QUnit.test("save without `wait` doesn't set invalid attributes", function(assert) {
     var model = new Backbone.Model();
     model.validate = function () { return 1; }
     model.save({a: 1});
-    equal(model.get('a'), void 0);
+    assert.equal(model.get('a'), void 0);
   });
 
-  test("save doesn't validate twice", function () {
+  QUnit.test("save doesn't validate twice", function(assert) {
     var model = new Backbone.Model();
     var times = 0;
     model.sync = function () {};
     model.validate = function () { ++times; }
     model.save({});
-    equal(times, 1);
+    assert.equal(times, 1);
   });
 
-  test("`hasChanged` for falsey keys", 2, function() {
+  QUnit.test("`hasChanged` for falsey keys", function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model();
     model.set({x: true}, {silent: true});
-    ok(!model.hasChanged(0));
-    ok(!model.hasChanged(''));
+    assert.ok(!model.hasChanged(0));
+    assert.ok(!model.hasChanged(''));
   });
 
-  test("`previous` for falsey keys", 2, function() {
+  QUnit.test("`previous` for falsey keys", function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model({0: true, '': true});
     model.set({0: false, '': false}, {silent: true});
-    equal(model.previous(0), true);
-    equal(model.previous(''), true);
+    assert.equal(model.previous(0), true);
+    assert.equal(model.previous(''), true);
   });
 
-  test("`save` with `wait` sends correct attributes", 5, function() {
+  QUnit.test("`save` with `wait` sends correct attributes", function(assert) {
+    assert.expect(5);
     var changed = 0;
     var model = new Backbone.Model({x: 1, y: 2});
     model.url = '/test';
     model.on('change:x', function() { changed++; });
     model.save({x: 3}, {wait: true});
-    deepEqual(JSON.parse(this.ajaxSettings.data), {x: 3, y: 2});
-    equal(model.get('x'), 1);
-    equal(changed, 0);
+    assert.deepEqual(JSON.parse(this.ajaxSettings.data), {x: 3, y: 2});
+    assert.equal(model.get('x'), 1);
+    assert.equal(changed, 0);
     this.syncArgs.options.success({});
-    equal(model.get('x'), 3);
-    equal(changed, 1);
+    assert.equal(model.get('x'), 3);
+    assert.equal(changed, 1);
   });
 
-  test("a failed `save` with `wait` doesn't leave attributes behind", 1, function() {
+  QUnit.test("a failed `save` with `wait` doesn't leave attributes behind", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model;
     model.url = '/test';
     model.save({x: 1}, {wait: true});
-    equal(model.get('x'), void 0);
+    assert.equal(model.get('x'), void 0);
   });
 
-  test("#1030 - `save` with `wait` results in correct attributes if success is called during sync", 2, function() {
+  QUnit.test("#1030 - `save` with `wait` results in correct attributes if success is called during sync", function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model({x: 1, y: 2});
     model.sync = function(method, model, options) {
       options.success();
     };
-    model.on("change:x", function() { ok(true); });
+    model.on("change:x", function() { assert.ok(true); });
     model.save({x: 3}, {wait: true});
-    equal(model.get('x'), 3);
+    assert.equal(model.get('x'), 3);
   });
 
-  test("save with wait validates attributes", function() {
+  QUnit.test("save with wait validates attributes", function(assert) {
     var model = new Backbone.Model();
     model.url = '/test';
-    model.validate = function() { ok(true); };
+    model.validate = function() { assert.ok(true); };
     model.save({x: 1}, {wait: true});
   });
 
-  test("save turns on parse flag", function () {
+  QUnit.test("save turns on parse flag", function(assert) {
     var Model = Backbone.Model.extend({
-      sync: function(method, model, options) { ok(options.parse); }
+      sync: function(method, model, options) { assert.ok(options.parse); }
     });
     new Model().save();
   });
 
-  test("nested `set` during `'change:attr'`", 2, function() {
+  QUnit.test("nested `set` during `'change:attr'`", function(assert) {
+    assert.expect(2);
     var events = [];
     var model = new Backbone.Model();
     model.on('all', function(event) { events.push(event); });
@@ -989,75 +1055,79 @@
       model.set({y: true});
     });
     model.set({x: true});
-    deepEqual(events, ['change:y', 'change:x', 'change']);
+    assert.deepEqual(events, ['change:y', 'change:x', 'change']);
     events = [];
     model.set({z: true});
-    deepEqual(events, []);
+    assert.deepEqual(events, []);
   });
 
-  test("nested `change` only fires once", 1, function() {
+  QUnit.test("nested `change` only fires once", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     model.on('change', function() {
-      ok(true);
+      assert.ok(true);
       model.set({x: true});
     });
     model.set({x: true});
   });
 
-  test("nested `set` during `'change'`", 6, function() {
+  QUnit.test("nested `set` during `'change'`", function(assert) {
+    assert.expect(6);
     var count = 0;
     var model = new Backbone.Model();
     model.on('change', function() {
       switch(count++) {
         case 0:
-          deepEqual(this.changedAttributes(), {x: true});
-          equal(model.previous('x'), undefined);
+          assert.deepEqual(this.changedAttributes(), {x: true});
+          assert.equal(model.previous('x'), undefined);
           model.set({y: true});
           break;
         case 1:
-          deepEqual(this.changedAttributes(), {x: true, y: true});
-          equal(model.previous('x'), undefined);
+          assert.deepEqual(this.changedAttributes(), {x: true, y: true});
+          assert.equal(model.previous('x'), undefined);
           model.set({z: true});
           break;
         case 2:
-          deepEqual(this.changedAttributes(), {x: true, y: true, z: true});
-          equal(model.previous('y'), undefined);
+          assert.deepEqual(this.changedAttributes(), {x: true, y: true, z: true});
+          assert.equal(model.previous('y'), undefined);
           break;
         default:
-          ok(false);
+          assert.ok(false);
       }
     });
     model.set({x: true});
   });
 
-  test("nested `change` with silent", 3, function() {
+  QUnit.test("nested `change` with silent", function(assert) {
+    assert.expect(3);
     var count = 0;
     var model = new Backbone.Model();
-    model.on('change:y', function() { ok(false); });
+    model.on('change:y', function() { assert.ok(false); });
     model.on('change', function() {
       switch(count++) {
         case 0:
-          deepEqual(this.changedAttributes(), {x: true});
+          assert.deepEqual(this.changedAttributes(), {x: true});
           model.set({y: true}, {silent: true});
           model.set({z: true});
           break;
         case 1:
-          deepEqual(this.changedAttributes(), {x: true, y: true, z: true});
+          assert.deepEqual(this.changedAttributes(), {x: true, y: true, z: true});
           break;
         case 2:
-          deepEqual(this.changedAttributes(), {z: false});
+          assert.deepEqual(this.changedAttributes(), {z: false});
           break;
         default:
-          ok(false);
+          assert.ok(false);
       }
     });
     model.set({x: true});
     model.set({z: false});
   });
 
-  test("nested `change:attr` with silent", 0, function() {
+  QUnit.test("nested `change:attr` with silent", function(assert) {
+    assert.expect(0);
     var model = new Backbone.Model();
-    model.on('change:y', function(){ ok(false); });
+    model.on('change:y', function(){ assert.ok(false); });
     model.on('change', function() {
       model.set({y: true}, {silent: true});
       model.set({z: true});
@@ -1065,19 +1135,21 @@
     model.set({x: true});
   });
 
-  test("multiple nested changes with silent", 1, function() {
+  QUnit.test("multiple nested changes with silent", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     model.on('change:x', function() {
       model.set({y: 1}, {silent: true});
       model.set({y: 2});
     });
     model.on('change:y', function(model, val) {
-      equal(val, 2);
+      assert.equal(val, 2);
     });
     model.set({x: true});
   });
 
-  test("multiple nested changes with silent", 1, function() {
+  QUnit.test("multiple nested changes with silent", function(assert) {
+    assert.expect(1);
     var changes = [];
     var model = new Backbone.Model();
     model.on('change:b', function(model, val) { changes.push(val); });
@@ -1085,21 +1157,23 @@
       model.set({b: 1});
     });
     model.set({b: 0});
-    deepEqual(changes, [0, 1]);
+    assert.deepEqual(changes, [0, 1]);
   });
 
-  test("basic silent change semantics", 1, function() {
+  QUnit.test("basic silent change semantics", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model;
     model.set({x: 1});
-    model.on('change', function(){ ok(true); });
+    model.on('change', function(){ assert.ok(true); });
     model.set({x: 2}, {silent: true});
     model.set({x: 1});
   });
 
-  test("nested set multiple times", 1, function() {
+  QUnit.test("nested set multiple times", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     model.on('change:b', function() {
-      ok(true);
+      assert.ok(true);
     });
     model.on('change:a', function() {
       model.set({b: true});
@@ -1108,25 +1182,28 @@
     model.set({a: true});
   });
 
-  test("#1122 - clear does not alter options.", 1, function() {
+  QUnit.test("#1122 - clear does not alter options.", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     var options = {};
     model.clear(options);
-    ok(!options.unset);
+    assert.ok(!options.unset);
   });
 
-  test("#1122 - unset does not alter options.", 1, function() {
+  QUnit.test("#1122 - unset does not alter options.", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     var options = {};
     model.unset('x', options);
-    ok(!options.unset);
+    assert.ok(!options.unset);
   });
 
-  test("#1355 - `options` is passed to success callbacks", 3, function() {
+  QUnit.test("#1355 - `options` is passed to success callbacks", function(assert) {
+    assert.expect(3);
     var model = new Backbone.Model();
     var opts = {
       success: function( model, resp, options ) {
-        ok(options);
+        assert.ok(options);
       }
     };
     model.sync = function(method, model, options) {
@@ -1137,77 +1214,86 @@
     model.destroy(opts);
   });
 
-  test("#1412 - Trigger 'sync' event.", 3, function() {
+  QUnit.test("#1412 - Trigger 'sync' event.", function(assert) {
+    assert.expect(3);
     var model = new Backbone.Model({id: 1});
     model.sync = function (method, model, options) { options.success(); };
-    model.on('sync', function(){ ok(true); });
+    model.on('sync', function(){ assert.ok(true); });
     model.fetch();
     model.save();
     model.destroy();
   });
 
-  asyncTest("#1365 - Destroy: New models execute success callback.", 2, function() {
+  QUnit.test("#1365 - Destroy: New models execute success callback.", function(assert) {
+    var done = assert.async();
+    assert.expect(2);
     new Backbone.Model()
-    .on('sync', function() { ok(false); })
-    .on('destroy', function(){ ok(true); })
+    .on('sync', function() { assert.ok(false); })
+    .on('destroy', function(){ assert.ok(true); })
     .destroy({ success: function(){
-        ok(true);
-        start();
+        assert.ok(true);
+        done();
     }});
   });
 
-  test("#1433 - Save: An invalid model cannot be persisted.", 1, function() {
+  QUnit.test("#1433 - Save: An invalid model cannot be persisted.", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model;
     model.validate = function(){ return 'invalid'; };
-    model.sync = function(){ ok(false); };
-    strictEqual(model.save(), false);
+    model.sync = function(){ assert.ok(false); };
+    assert.strictEqual(model.save(), false);
   });
 
-  test("#1377 - Save without attrs triggers 'error'.", 1, function() {
+  QUnit.test("#1377 - Save without attrs triggers 'error'.", function(assert) {
+    assert.expect(1);
     var Model = Backbone.Model.extend({
       url: '/test/',
       sync: function(method, model, options){ options.success(); },
       validate: function(){ return 'invalid'; }
     });
     var model = new Model({id: 1});
-    model.on('invalid', function(){ ok(true); });
+    model.on('invalid', function(){ assert.ok(true); });
     model.save();
   });
 
-  test("#1545 - `undefined` can be passed to a model constructor without coersion", function() {
+  QUnit.test("#1545 - `undefined` can be passed to a model constructor without coersion", function(assert) {
     var Model = Backbone.Model.extend({
       defaults: { one: 1 },
       initialize : function(attrs, opts) {
-        equal(attrs, undefined);
+        assert.equal(attrs, undefined);
       }
     });
     var emptyattrs = new Model();
     var undefinedattrs = new Model(undefined);
   });
 
-  asyncTest("#1478 - Model `save` does not trigger change on unchanged attributes", 0, function() {
+  QUnit.test("#1478 - Model `save` does not trigger change on unchanged attributes", function(assert) {
+    var done = assert.async();
+    assert.expect(0);
     var Model = Backbone.Model.extend({
       sync: function(method, model, options) {
         setTimeout(function(){
           options.success();
-          start();
+          done();
         }, 0);
       }
     });
     new Model({x: true})
-    .on('change:x', function(){ ok(false); })
+    .on('change:x', function(){ assert.ok(false); })
     .save(null, {wait: true});
   });
 
-  test("#1664 - Changing from one value, silently to another, back to original triggers a change.", 1, function() {
+  QUnit.test("#1664 - Changing from one value, silently to another, back to original triggers a change.", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model({x:1});
-    model.on('change:x', function() { ok(true); });
+    model.on('change:x', function() { assert.ok(true); });
     model.set({x:2},{silent:true});
     model.set({x:3},{silent:true});
     model.set({x:1});
   });
 
-  test("#1664 - multiple silent changes nested inside a change event", 2, function() {
+  QUnit.test("#1664 - multiple silent changes nested inside a change event", function(assert) {
+    assert.expect(2);
     var changes = [];
     var model = new Backbone.Model();
     model.on('change', function() {
@@ -1217,19 +1303,20 @@
     });
     model.on('change:a change:b change:c', function(model, val) { changes.push(val); });
     model.set({a:'a', b:1, c:'item'});
-    deepEqual(changes, ['a',1,'item']);
-    deepEqual(model.attributes, {a: 'c', b: 2});
+    assert.deepEqual(changes, ['a',1,'item']);
+    assert.deepEqual(model.attributes, {a: 'c', b: 2});
   });
 
-  test("#1791 - `attributes` is available for `parse`", function() {
+  QUnit.test("#1791 - `attributes` is available for `parse`", function(assert) {
     var Model = Backbone.Model.extend({
       parse: function() { this.has('a'); } // shouldn't throw an error
     });
     var model = new Model(null, {parse: true});
-    expect(0);
+    assert.expect(0);
   });
 
-  test("silent changes in last `change` event back to original triggers change", 2, function() {
+  QUnit.test("silent changes in last `change` event back to original triggers change", function(assert) {
+    assert.expect(2);
     var changes = [];
     var model = new Backbone.Model();
     model.on('change:a change:b change:c', function(model, val) { changes.push(val); });
@@ -1237,62 +1324,65 @@
       model.set({a:'c'}, {silent:true});
     });
     model.set({a:'a'});
-    deepEqual(changes, ['a']);
+    assert.deepEqual(changes, ['a']);
     model.set({a:'a'});
-    deepEqual(changes, ['a', 'a']);
+    assert.deepEqual(changes, ['a', 'a']);
   });
 
-  test("#1943 change calculations should use _.isEqual", function() {
+  QUnit.test("#1943 change calculations should use _.isEqual", function(assert) {
     var model = new Backbone.Model({a: {key: 'value'}});
     model.set('a', {key:'value'}, {silent:true});
-    equal(model.changedAttributes(), false);
+    assert.equal(model.changedAttributes(), false);
   });
 
-  test("#1964 - final `change` event is always fired, regardless of interim changes", 1, function () {
+  QUnit.test("#1964 - final `change` event is always fired, regardless of interim changes", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     model.on('change:property', function() {
       model.set('property', 'bar');
     });
     model.on('change', function() {
-      ok(true);
+      assert.ok(true);
     });
     model.set('property', 'foo');
   });
 
-  test("isValid", function() {
+  QUnit.test("isValid", function(assert) {
     var model = new Backbone.Model({valid: true});
     model.validate = function(attrs) {
       if (!attrs.valid) return "invalid";
     };
-    equal(model.isValid(), true);
-    equal(model.set({valid: false}, {validate:true}), false);
-    equal(model.isValid(), true);
+    assert.equal(model.isValid(), true);
+    assert.equal(model.set({valid: false}, {validate:true}), false);
+    assert.equal(model.isValid(), true);
     model.set({valid:false});
-    equal(model.isValid(), false);
-    ok(!model.set('valid', false, {validate: true}));
+    assert.equal(model.isValid(), false);
+    assert.ok(!model.set('valid', false, {validate: true}));
   });
 
-  test("#1179 - isValid returns true in the absence of validate.", 1, function() {
+  QUnit.test("#1179 - isValid returns true in the absence of validate.", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     model.validate = null;
-    ok(model.isValid());
+    assert.ok(model.isValid());
   });
 
-  test("#1961 - Creating a model with {validate:true} will call validate and use the error callback", function () {
+  QUnit.test("#1961 - Creating a model with {validate:true} will call validate and use the error callback", function(assert) {
     var Model = Backbone.Model.extend({
       validate: function (attrs) {
         if (attrs.id === 1) return "This shouldn't happen";
       }
     });
     var model = new Model({id: 1}, {validate: true});
-    equal(model.validationError, "This shouldn't happen");
+    assert.equal(model.validationError, "This shouldn't happen");
   });
 
-  test("toJSON receives attrs during save(..., {wait: true})", 1, function() {
+  QUnit.test("toJSON receives attrs during save(..., {wait: true})", function(assert) {
+    assert.expect(1);
     var Model = Backbone.Model.extend({
       url: '/test',
       toJSON: function() {
-        strictEqual(this.attributes.x, 1);
+        assert.strictEqual(this.attributes.x, 1);
         return _.clone(this.attributes);
       }
     });
@@ -1300,11 +1390,12 @@
     model.save({x: 1}, {wait: true});
   });
 
-  test("#2034 - nested set with silent only triggers one change", 1, function() {
+  QUnit.test("#2034 - nested set with silent only triggers one change", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model();
     model.on('change', function() {
       model.set({b: true}, {silent: true});
-      ok(true);
+      assert.ok(true);
     });
     model.set({a: true});
   });

--- a/test/noconflict.js
+++ b/test/noconflict.js
@@ -1,12 +1,13 @@
 (function() {
 
-  module("Backbone.noConflict");
+  QUnit.module("Backbone.noConflict");
 
-  test('noConflict', 2, function() {
+  QUnit.test('noConflict', function(assert) {
+    assert.expect(2);
     var noconflictBackbone = Backbone.noConflict();
-    equal(window.Backbone, undefined, 'Returned window.Backbone');
+    assert.equal(window.Backbone, undefined, 'Returned window.Backbone');
     window.Backbone = noconflictBackbone;
-    equal(window.Backbone, noconflictBackbone, 'Backbone is still pointing to the original Backbone');
+    assert.equal(window.Backbone, noconflictBackbone, 'Backbone is still pointing to the original Backbone');
   });
 
 })();

--- a/test/router.js
+++ b/test/router.js
@@ -40,7 +40,7 @@
 
   });
 
-  module("Backbone.Router", {
+  QUnit.module("Backbone.Router", {
 
     setup: function() {
       location = new Location('http://example.com');
@@ -176,167 +176,189 @@
 
   });
 
-  test("initialize", 1, function() {
-    equal(router.testing, 101);
+  QUnit.test("initialize", function(assert) {
+    assert.expect(1);
+    assert.equal(router.testing, 101);
   });
 
-  test("routes (simple)", 4, function() {
+  QUnit.test("routes (simple)", function(assert) {
+    assert.expect(4);
     location.replace('http://example.com#search/news');
     Backbone.history.checkUrl();
-    equal(router.query, 'news');
-    equal(router.page, void 0);
-    equal(lastRoute, 'search');
-    equal(lastArgs[0], 'news');
+    assert.equal(router.query, 'news');
+    assert.equal(router.page, void 0);
+    assert.equal(lastRoute, 'search');
+    assert.equal(lastArgs[0], 'news');
   });
 
-  test("routes (simple, but unicode)", 4, function() {
+  QUnit.test("routes (simple, but unicode)", function(assert) {
+    assert.expect(4);
     location.replace('http://example.com#search/тест');
     Backbone.history.checkUrl();
-    equal(router.query, "тест");
-    equal(router.page, void 0);
-    equal(lastRoute, 'search');
-    equal(lastArgs[0], "тест");
+    assert.equal(router.query, "тест");
+    assert.equal(router.page, void 0);
+    assert.equal(lastRoute, 'search');
+    assert.equal(lastArgs[0], "тест");
   });
 
-  test("routes (two part)", 2, function() {
+  QUnit.test("routes (two part)", function(assert) {
+    assert.expect(2);
     location.replace('http://example.com#search/nyc/p10');
     Backbone.history.checkUrl();
-    equal(router.query, 'nyc');
-    equal(router.page, '10');
+    assert.equal(router.query, 'nyc');
+    assert.equal(router.page, '10');
   });
 
-  test("routes via navigate", 2, function() {
+  QUnit.test("routes via navigate", function(assert) {
+    assert.expect(2);
     Backbone.history.navigate('search/manhattan/p20', {trigger: true});
-    equal(router.query, 'manhattan');
-    equal(router.page, '20');
+    assert.equal(router.query, 'manhattan');
+    assert.equal(router.page, '20');
   });
 
-  test("routes via navigate with params", 1, function() {
+  QUnit.test("routes via navigate with params", function(assert) {
+    assert.expect(1);
     Backbone.history.navigate('query/test?a=b', {trigger: true});
-    equal(router.queryArgs, 'a=b');
+    assert.equal(router.queryArgs, 'a=b');
   });
 
-  test("routes via navigate for backwards-compatibility", 2, function() {
+  QUnit.test("routes via navigate for backwards-compatibility", function(assert) {
+    assert.expect(2);
     Backbone.history.navigate('search/manhattan/p20', true);
-    equal(router.query, 'manhattan');
-    equal(router.page, '20');
+    assert.equal(router.query, 'manhattan');
+    assert.equal(router.page, '20');
   });
 
-  test("reports matched route via nagivate", 1, function() {
-    ok(Backbone.history.navigate('search/manhattan/p20', true));
+  QUnit.test("reports matched route via nagivate", function(assert) {
+    assert.expect(1);
+    assert.ok(Backbone.history.navigate('search/manhattan/p20', true));
   });
 
-  test("route precedence via navigate", 6, function(){
+  QUnit.test("route precedence via navigate", function(assert){
+    assert.expect(6);
     // check both 0.9.x and backwards-compatibility options
     _.each([ { trigger: true }, true ], function( options ){
       Backbone.history.navigate('contacts', options);
-      equal(router.contact, 'index');
+      assert.equal(router.contact, 'index');
       Backbone.history.navigate('contacts/new', options);
-      equal(router.contact, 'new');
+      assert.equal(router.contact, 'new');
       Backbone.history.navigate('contacts/foo', options);
-      equal(router.contact, 'load');
+      assert.equal(router.contact, 'load');
     });
   });
 
-  test("loadUrl is not called for identical routes.", 0, function() {
-    Backbone.history.loadUrl = function(){ ok(false); };
+  QUnit.test("loadUrl is not called for identical routes.", function(assert) {
+    assert.expect(0);
+    Backbone.history.loadUrl = function(){ assert.ok(false); };
     location.replace('http://example.com#route');
     Backbone.history.navigate('route');
     Backbone.history.navigate('/route');
     Backbone.history.navigate('/route');
   });
 
-  test("use implicit callback if none provided", 1, function() {
+  QUnit.test("use implicit callback if none provided", function(assert) {
+    assert.expect(1);
     router.count = 0;
     router.navigate('implicit', {trigger: true});
-    equal(router.count, 1);
+    assert.equal(router.count, 1);
   });
 
-  test("routes via navigate with {replace: true}", 1, function() {
+  QUnit.test("routes via navigate with {replace: true}", function(assert) {
+    assert.expect(1);
     location.replace('http://example.com#start_here');
     Backbone.history.checkUrl();
     location.replace = function(href) {
-      strictEqual(href, new Location('http://example.com#end_here').href);
+      assert.strictEqual(href, new Location('http://example.com#end_here').href);
     };
     Backbone.history.navigate('end_here', {replace: true});
   });
 
-  test("routes (splats)", 1, function() {
+  QUnit.test("routes (splats)", function(assert) {
+    assert.expect(1);
     location.replace('http://example.com#splat/long-list/of/splatted_99args/end');
     Backbone.history.checkUrl();
-    equal(router.args, 'long-list/of/splatted_99args');
+    assert.equal(router.args, 'long-list/of/splatted_99args');
   });
 
-  test("routes (github)", 3, function() {
+  QUnit.test("routes (github)", function(assert) {
+    assert.expect(3);
     location.replace('http://example.com#backbone/compare/1.0...braddunbar:with/slash');
     Backbone.history.checkUrl();
-    equal(router.repo, 'backbone');
-    equal(router.from, '1.0');
-    equal(router.to, 'braddunbar:with/slash');
+    assert.equal(router.repo, 'backbone');
+    assert.equal(router.from, '1.0');
+    assert.equal(router.to, 'braddunbar:with/slash');
   });
 
-  test("routes (optional)", 2, function() {
+  QUnit.test("routes (optional)", function(assert) {
+    assert.expect(2);
     location.replace('http://example.com#optional');
     Backbone.history.checkUrl();
-    ok(!router.arg);
+    assert.ok(!router.arg);
     location.replace('http://example.com#optional/thing');
     Backbone.history.checkUrl();
-    equal(router.arg, 'thing');
+    assert.equal(router.arg, 'thing');
   });
 
-  test("routes (complex)", 3, function() {
+  QUnit.test("routes (complex)", function(assert) {
+    assert.expect(3);
     location.replace('http://example.com#one/two/three/complex-part/four/five/six/seven');
     Backbone.history.checkUrl();
-    equal(router.first, 'one/two/three');
-    equal(router.part, 'part');
-    equal(router.rest, 'four/five/six/seven');
+    assert.equal(router.first, 'one/two/three');
+    assert.equal(router.part, 'part');
+    assert.equal(router.rest, 'four/five/six/seven');
   });
 
-  test("routes (query)", 5, function() {
+  QUnit.test("routes (query)", function(assert) {
+    assert.expect(5);
     location.replace('http://example.com#query/mandel?a=b&c=d');
     Backbone.history.checkUrl();
-    equal(router.entity, 'mandel');
-    equal(router.queryArgs, 'a=b&c=d');
-    equal(lastRoute, 'query');
-    equal(lastArgs[0], 'mandel');
-    equal(lastArgs[1], 'a=b&c=d');
+    assert.equal(router.entity, 'mandel');
+    assert.equal(router.queryArgs, 'a=b&c=d');
+    assert.equal(lastRoute, 'query');
+    assert.equal(lastArgs[0], 'mandel');
+    assert.equal(lastArgs[1], 'a=b&c=d');
   });
 
-  test("routes (anything)", 1, function() {
+  QUnit.test("routes (anything)", function(assert) {
+    assert.expect(1);
     location.replace('http://example.com#doesnt-match-a-route');
     Backbone.history.checkUrl();
-    equal(router.anything, 'doesnt-match-a-route');
+    assert.equal(router.anything, 'doesnt-match-a-route');
   });
 
-  test("routes (function)", 3, function() {
+  QUnit.test("routes (function)", function(assert) {
+    assert.expect(3);
     router.on('route', function(name) {
-      ok(name === '');
+      assert.ok(name === '');
     });
-    equal(ExternalObject.value, 'unset');
+    assert.equal(ExternalObject.value, 'unset');
     location.replace('http://example.com#function/set');
     Backbone.history.checkUrl();
-    equal(ExternalObject.value, 'set');
+    assert.equal(ExternalObject.value, 'set');
   });
 
-  test("Decode named parameters, not splats.", 2, function() {
+  QUnit.test("Decode named parameters, not splats.", function(assert) {
+    assert.expect(2);
     location.replace('http://example.com#decode/a%2Fb/c%2Fd/e');
     Backbone.history.checkUrl();
-    strictEqual(router.named, 'a/b');
-    strictEqual(router.path, 'c/d/e');
+    assert.strictEqual(router.named, 'a/b');
+    assert.strictEqual(router.path, 'c/d/e');
   });
 
-  test("fires event when router doesn't have callback on it", 1, function() {
-    router.on("route:noCallback", function(){ ok(true); });
+  QUnit.test("fires event when router doesn't have callback on it", function(assert) {
+    assert.expect(1);
+    router.on("route:noCallback", function(){ assert.ok(true); });
     location.replace('http://example.com#noCallback');
     Backbone.history.checkUrl();
   });
 
-  test("No events are triggered if #execute returns false.", 1, function() {
+  QUnit.test("No events are triggered if #execute returns false.", function(assert) {
+    assert.expect(1);
     var Router = Backbone.Router.extend({
 
       routes: {
         foo: function() {
-          ok(true);
+          assert.ok(true);
         }
       },
 
@@ -350,92 +372,100 @@
     var router = new Router;
 
     router.on('route route:foo', function() {
-      ok(false);
+      assert.ok(false);
     });
 
     Backbone.history.on('route', function() {
-      ok(false);
+      assert.ok(false);
     });
 
     location.replace('http://example.com#foo');
     Backbone.history.checkUrl();
   });
 
-  test("#933, #908 - leading slash", 2, function() {
+  QUnit.test("#933, #908 - leading slash", function(assert) {
+    assert.expect(2);
     location.replace('http://example.com/root/foo');
 
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     Backbone.history.start({root: '/root', hashChange: false, silent: true});
-    strictEqual(Backbone.history.getFragment(), 'foo');
+    assert.strictEqual(Backbone.history.getFragment(), 'foo');
 
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     Backbone.history.start({root: '/root/', hashChange: false, silent: true});
-    strictEqual(Backbone.history.getFragment(), 'foo');
+    assert.strictEqual(Backbone.history.getFragment(), 'foo');
   });
 
-  test("#967 - Route callback gets passed encoded values.", 3, function() {
+  QUnit.test("#967 - Route callback gets passed encoded values.", function(assert) {
+    assert.expect(3);
     var route = 'has%2Fslash/complex-has%23hash/has%20space';
     Backbone.history.navigate(route, {trigger: true});
-    strictEqual(router.first, 'has/slash');
-    strictEqual(router.part, 'has#hash');
-    strictEqual(router.rest, 'has space');
+    assert.strictEqual(router.first, 'has/slash');
+    assert.strictEqual(router.part, 'has#hash');
+    assert.strictEqual(router.rest, 'has space');
   });
 
-  test("correctly handles URLs with % (#868)", 3, function() {
+  QUnit.test("correctly handles URLs with % (#868)", function(assert) {
+    assert.expect(3);
     location.replace('http://example.com#search/fat%3A1.5%25');
     Backbone.history.checkUrl();
     location.replace('http://example.com#search/fat');
     Backbone.history.checkUrl();
-    equal(router.query, 'fat');
-    equal(router.page, void 0);
-    equal(lastRoute, 'search');
+    assert.equal(router.query, 'fat');
+    assert.equal(router.page, void 0);
+    assert.equal(lastRoute, 'search');
   });
 
-  test("#2666 - Hashes with UTF8 in them.", 2, function() {
+  QUnit.test("#2666 - Hashes with UTF8 in them.", function(assert) {
+    assert.expect(2);
     Backbone.history.navigate('charñ', {trigger: true});
-    equal(router.charType, 'UTF');
+    assert.equal(router.charType, 'UTF');
     Backbone.history.navigate('char%C3%B1', {trigger: true});
-    equal(router.charType, 'UTF');
+    assert.equal(router.charType, 'UTF');
   });
 
-  test("#1185 - Use pathname when hashChange is not wanted.", 1, function() {
+  QUnit.test("#1185 - Use pathname when hashChange is not wanted.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/path/name#hash');
     Backbone.history = _.extend(new Backbone.History, {location: location});
     Backbone.history.start({hashChange: false});
     var fragment = Backbone.history.getFragment();
-    strictEqual(fragment, location.pathname.replace(/^\//, ''));
+    assert.strictEqual(fragment, location.pathname.replace(/^\//, ''));
   });
 
-  test("#1206 - Strip leading slash before location.assign.", 1, function() {
+  QUnit.test("#1206 - Strip leading slash before location.assign.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root/');
     Backbone.history = _.extend(new Backbone.History, {location: location});
     Backbone.history.start({hashChange: false, root: '/root/'});
     location.assign = function(pathname) {
-      strictEqual(pathname, '/root/fragment');
+      assert.strictEqual(pathname, '/root/fragment');
     };
     Backbone.history.navigate('/fragment');
   });
 
-  test("#1387 - Root fragment without trailing slash.", 1, function() {
+  QUnit.test("#1387 - Root fragment without trailing slash.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root');
     Backbone.history = _.extend(new Backbone.History, {location: location});
     Backbone.history.start({hashChange: false, root: '/root/', silent: true});
-    strictEqual(Backbone.history.getFragment(), '');
+    assert.strictEqual(Backbone.history.getFragment(), '');
   });
 
-  test("#1366 - History does not prepend root to fragment.", 2, function() {
+  QUnit.test("#1366 - History does not prepend root to fragment.", function(assert) {
+    assert.expect(2);
     Backbone.history.stop();
     location.replace('http://example.com/root/');
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(state, title, url) {
-          strictEqual(url, '/root/x');
+          assert.strictEqual(url, '/root/x');
         }
       }
     });
@@ -445,17 +475,18 @@
       hashChange: false
     });
     Backbone.history.navigate('x');
-    strictEqual(Backbone.history.fragment, 'x');
+    assert.strictEqual(Backbone.history.fragment, 'x');
   });
 
-  test("Normalize root.", 1, function() {
+  QUnit.test("Normalize root.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root');
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(state, title, url) {
-          strictEqual(url, '/root/fragment');
+          assert.strictEqual(url, '/root/fragment');
         }
       }
     });
@@ -467,7 +498,8 @@
     Backbone.history.navigate('fragment');
   });
 
-  test("Normalize root.", 1, function() {
+  QUnit.test("Normalize root.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root#fragment');
     Backbone.history = _.extend(new Backbone.History, {
@@ -475,7 +507,7 @@
       history: {
         pushState: function(state, title, url) {},
         replaceState: function(state, title, url) {
-          strictEqual(url, '/root/fragment');
+          assert.strictEqual(url, '/root/fragment');
         }
       }
     });
@@ -485,18 +517,20 @@
     });
   });
 
-  test("Normalize root.", 1, function() {
+  QUnit.test("Normalize root.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root');
     Backbone.history = _.extend(new Backbone.History, {location: location});
-    Backbone.history.loadUrl = function() { ok(true); };
+    Backbone.history.loadUrl = function() { assert.ok(true); };
     Backbone.history.start({
       pushState: true,
       root: '/root'
     });
   });
 
-  test("Normalize root - leading slash.", 1, function() {
+  QUnit.test("Normalize root - leading slash.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root');
     Backbone.history = _.extend(new Backbone.History, {
@@ -507,10 +541,11 @@
       }
     });
     Backbone.history.start({root: 'root'});
-    strictEqual(Backbone.history.root, '/root/');
+    assert.strictEqual(Backbone.history.root, '/root/');
   });
 
-  test("Transition from hashChange to pushState.", 1, function() {
+  QUnit.test("Transition from hashChange to pushState.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root#x/y');
     Backbone.history = _.extend(new Backbone.History, {
@@ -518,7 +553,7 @@
       history: {
         pushState: function(){},
         replaceState: function(state, title, url){
-          strictEqual(url, '/root/x/y');
+          assert.strictEqual(url, '/root/x/y');
         }
       }
     });
@@ -528,7 +563,8 @@
     });
   });
 
-  test("#1619: Router: Normalize empty root", 1, function() {
+  QUnit.test("#1619: Router: Normalize empty root", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/');
     Backbone.history = _.extend(new Backbone.History, {
@@ -539,17 +575,18 @@
       }
     });
     Backbone.history.start({root: ''});
-    strictEqual(Backbone.history.root, '/');
+    assert.strictEqual(Backbone.history.root, '/');
   });
 
-  test("#1619: Router: nagivate with empty root", 1, function() {
+  QUnit.test("#1619: Router: nagivate with empty root", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/');
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(state, title, url) {
-          strictEqual(url, '/fragment');
+          assert.strictEqual(url, '/fragment');
         }
       }
     });
@@ -561,11 +598,12 @@
     Backbone.history.navigate('fragment');
   });
 
-  test("Transition from pushState to hashChange.", 1, function() {
+  QUnit.test("Transition from pushState to hashChange.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root/x/y?a=b');
     location.replace = function(url) {
-      strictEqual(url, '/root#x/y?a=b');
+      assert.strictEqual(url, '/root#x/y?a=b');
     };
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
@@ -580,7 +618,8 @@
     });
   });
 
-  test("#1695 - hashChange to pushState with search.", 1, function() {
+  QUnit.test("#1695 - hashChange to pushState with search.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root#x/y?a=b');
     Backbone.history = _.extend(new Backbone.History, {
@@ -588,7 +627,7 @@
       history: {
         pushState: function(){},
         replaceState: function(state, title, url){
-          strictEqual(url, '/root/x/y?a=b');
+          assert.strictEqual(url, '/root/x/y?a=b');
         }
       }
     });
@@ -598,46 +637,51 @@
     });
   });
 
-  test("#1746 - Router allows empty route.", 1, function() {
+  QUnit.test("#1746 - Router allows empty route.", function(assert) {
+    assert.expect(1);
     var Router = Backbone.Router.extend({
       routes: {'': 'empty'},
       empty: function(){},
       route: function(route){
-        strictEqual(route, '');
+        assert.strictEqual(route, '');
       }
     });
     new Router;
   });
 
-  test("#1794 - Trailing space in fragments.", 1, function() {
+  QUnit.test("#1794 - Trailing space in fragments.", function(assert) {
+    assert.expect(1);
     var history = new Backbone.History;
-    strictEqual(history.getFragment('fragment   '), 'fragment');
+    assert.strictEqual(history.getFragment('fragment   '), 'fragment');
   });
 
-  test("#1820 - Leading slash and trailing space.", 1, function() {
+  QUnit.test("#1820 - Leading slash and trailing space.", 1, function(assert) {
     var history = new Backbone.History;
-    strictEqual(history.getFragment('/fragment '), 'fragment');
+    assert.strictEqual(history.getFragment('/fragment '), 'fragment');
   });
 
-  test("#1980 - Optional parameters.", 2, function() {
+  QUnit.test("#1980 - Optional parameters.", function(assert) {
+    assert.expect(2);
     location.replace('http://example.com#named/optional/y');
     Backbone.history.checkUrl();
-    strictEqual(router.z, undefined);
+    assert.strictEqual(router.z, undefined);
     location.replace('http://example.com#named/optional/y123');
     Backbone.history.checkUrl();
-    strictEqual(router.z, '123');
+    assert.strictEqual(router.z, '123');
   });
 
-  test("#2062 - Trigger 'route' event on router instance.", 2, function() {
+  QUnit.test("#2062 - Trigger 'route' event on router instance.", function(assert) {
+    assert.expect(2);
     router.on('route', function(name, args) {
-      strictEqual(name, 'routeEvent');
-      deepEqual(args, ['x', null]);
+      assert.strictEqual(name, 'routeEvent');
+      assert.deepEqual(args, ['x', null]);
     });
     location.replace('http://example.com#route-event/x');
     Backbone.history.checkUrl();
   });
 
-  test("#2255 - Extend routes by making routes a function.", 1, function() {
+  QUnit.test("#2255 - Extend routes by making routes a function.", function(assert) {
+    assert.expect(1);
     var RouterBase = Backbone.Router.extend({
       routes: function() {
         return {
@@ -657,17 +701,18 @@
     });
 
     var router = new RouterExtended();
-    deepEqual({home: "root", index: "index.html", show: "show", search: "search"}, router.routes);
+    assert.deepEqual({home: "root", index: "index.html", show: "show", search: "search"}, router.routes);
   });
 
-  test("#2538 - hashChange to pushState only if both requested.", 0, function() {
+  QUnit.test("#2538 - hashChange to pushState only if both requested.", function(assert) {
+    assert.expect(0);
     Backbone.history.stop();
     location.replace('http://example.com/root?a=b#x/y');
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(){},
-        replaceState: function(){ ok(false); }
+        replaceState: function(){ assert.ok(false); }
       }
     });
     Backbone.history.start({
@@ -677,7 +722,8 @@
     });
   });
 
-  test('No hash fallback.', 0, function() {
+  QUnit.test('No hash fallback.', function(assert) {
+    assert.expect(0);
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
@@ -689,7 +735,7 @@
 
     var Router = Backbone.Router.extend({
       routes: {
-        hash: function() { ok(false); }
+        hash: function() { assert.ok(false); }
       }
     });
     var router = new Router;
@@ -703,13 +749,14 @@
     Backbone.history.checkUrl();
   });
 
-  test('#2656 - No trailing slash on root.', 1, function() {
+  QUnit.test('#2656 - No trailing slash on root.', function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(state, title, url){
-          strictEqual(url, '/root');
+          assert.strictEqual(url, '/root');
         }
       }
     });
@@ -718,13 +765,14 @@
     Backbone.history.navigate('');
   });
 
-  test('#2656 - No trailing slash on root.', 1, function() {
+  QUnit.test('#2656 - No trailing slash on root.', function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(state, title, url) {
-          strictEqual(url, '/');
+          assert.strictEqual(url, '/');
         }
       }
     });
@@ -733,13 +781,14 @@
     Backbone.history.navigate('');
   });
 
-  test('#2656 - No trailing slash on root.', 1, function() {
+  QUnit.test('#2656 - No trailing slash on root.', function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(state, title, url){
-          strictEqual(url, '/root?x=1');
+          assert.strictEqual(url, '/root?x=1');
         }
       }
     });
@@ -748,20 +797,21 @@
     Backbone.history.navigate('?x=1');
   });
 
-  test('#2765 - Fragment matching sans query/hash.', 2, function() {
+  QUnit.test('#2765 - Fragment matching sans query/hash.', function(assert) {
+    assert.expect(2);
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
         pushState: function(state, title, url) {
-          strictEqual(url, '/path?query#hash');
+          assert.strictEqual(url, '/path?query#hash');
         }
       }
     });
 
     var Router = Backbone.Router.extend({
       routes: {
-        path: function() { ok(true); }
+        path: function() { assert.ok(true); }
       }
     });
     var router = new Router;
@@ -771,11 +821,12 @@
     Backbone.history.navigate('path?query#hash', true);
   });
 
-  test('Do not decode the search params.', function() {
+  QUnit.test('Do not decode the search params.', function(assert) {
+    assert.expect(1);
     var Router = Backbone.Router.extend({
       routes: {
         path: function(params){
-          strictEqual(params, 'x=y%3Fz');
+          assert.strictEqual(params, 'x=y%3Fz');
         }
       }
     });
@@ -783,14 +834,15 @@
     Backbone.history.navigate('path?x=y%3Fz', true);
   });
 
-  test('Navigate to a hash url.', function() {
+  QUnit.test('Navigate to a hash url.', function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     Backbone.history.start({pushState: true});
     var Router = Backbone.Router.extend({
       routes: {
         path: function(params) {
-          strictEqual(params, 'x=y');
+          assert.strictEqual(params, 'x=y');
         }
       }
     });
@@ -799,14 +851,15 @@
     Backbone.history.checkUrl();
   });
 
-  test('#navigate to a hash url.', function() {
+  QUnit.test('#navigate to a hash url.', function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     Backbone.history.start({pushState: true});
     var Router = Backbone.Router.extend({
       routes: {
         path: function(params) {
-          strictEqual(params, 'x=y');
+          assert.strictEqual(params, 'x=y');
         }
       }
     });
@@ -814,14 +867,15 @@
     Backbone.history.navigate('path?x=y#hash', true);
   });
 
-  test('unicode pathname', 1, function() {
+  QUnit.test('unicode pathname', function(assert) {
+    assert.expect(1);
     location.replace('http://example.com/myyjä');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
       routes: {
         myyjä: function() {
-          ok(true);
+          assert.ok(true);
         }
       }
     });
@@ -829,7 +883,8 @@
     Backbone.history.start({pushState: true});
   });
 
-  test('unicode pathname with % in a parameter', 1, function() {
+  QUnit.test('unicode pathname with % in a parameter', function(assert) {
+    assert.expect(1);
     location.replace('http://example.com/myyjä/foo%20%25%3F%2f%40%25%20bar');
     location.pathname = '/myyj%C3%A4/foo%20%25%3F%2f%40%25%20bar';
     Backbone.history.stop();
@@ -837,7 +892,7 @@
     var Router = Backbone.Router.extend({
       routes: {
         'myyjä/:query': function(query) {
-          strictEqual(query, 'foo %?/@% bar');
+          assert.strictEqual(query, 'foo %?/@% bar');
         }
       }
     });
@@ -845,14 +900,15 @@
     Backbone.history.start({pushState: true});
   });
 
-  test('newline in route', 1, function() {
+  QUnit.test('newline in route', function(assert) {
+    assert.expect(1);
     location.replace('http://example.com/stuff%0Anonsense?param=foo%0Abar');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
       routes: {
         'stuff\nnonsense': function() {
-          ok(true);
+          assert.ok(true);
         }
       }
     });
@@ -860,7 +916,8 @@
     Backbone.history.start({pushState: true});
   });
 
-  test('Router#execute receives callback, args, name.', 3, function() {
+  QUnit.test('Router#execute receives callback, args, name.', function(assert) {
+    assert.expect(3);
     location.replace('http://example.com#foo/123/bar?x=y');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
@@ -868,20 +925,21 @@
       routes: {'foo/:id/bar': 'foo'},
       foo: function(){},
       execute: function(callback, args, name) {
-        strictEqual(callback, this.foo);
-        deepEqual(args, ['123', 'x=y']);
-        strictEqual(name, 'foo');
+        assert.strictEqual(callback, this.foo);
+        assert.deepEqual(args, ['123', 'x=y']);
+        assert.strictEqual(name, 'foo');
       }
     });
     var router = new Router;
     Backbone.history.start();
   });
 
-  test("pushState to hashChange with only search params.", 1, function() {
+  QUnit.test("pushState to hashChange with only search params.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com?a=b');
     location.replace = function(url) {
-      strictEqual(url, '/#?a=b');
+      assert.strictEqual(url, '/#?a=b');
     };
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
@@ -890,37 +948,40 @@
     Backbone.history.start({pushState: true});
   });
 
-  test("#3123 - History#navigate decodes before comparison.", 1, function() {
+  QUnit.test("#3123 - History#navigate decodes before comparison.", function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/shop/search?keyword=short%20dress');
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
       history: {
-        pushState: function(){ ok(false); },
-        replaceState: function(){ ok(false); }
+        pushState: function(){ assert.ok(false); },
+        replaceState: function(){ assert.ok(false); }
       }
     });
     Backbone.history.start({pushState: true});
     Backbone.history.navigate('shop/search?keyword=short%20dress', true);
-    strictEqual(Backbone.history.fragment, 'shop/search?keyword=short dress');
+    assert.strictEqual(Backbone.history.fragment, 'shop/search?keyword=short dress');
   });
 
-  test('#3175 - Urls in the params', 1, function() {
+  QUnit.test('#3175 - Urls in the params', function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com#login?a=value&backUrl=https%3A%2F%2Fwww.msn.com%2Fidp%2Fidpdemo%3Fspid%3Dspdemo%26target%3Db');
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var router = new Backbone.Router;
     router.route('login', function(params) {
-      strictEqual(params, 'a=value&backUrl=https%3A%2F%2Fwww.msn.com%2Fidp%2Fidpdemo%3Fspid%3Dspdemo%26target%3Db');
+      assert.strictEqual(params, 'a=value&backUrl=https%3A%2F%2Fwww.msn.com%2Fidp%2Fidpdemo%3Fspid%3Dspdemo%26target%3Db');
     });
     Backbone.history.start();
   });
 
-  test('#3358 - pushState to hashChange transition with search params', 1, function() {
+  QUnit.test('#3358 - pushState to hashChange transition with search params', function(assert) {
+    assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root?foo=bar');
     location.replace = function(url) {
-      strictEqual(url, '/root#?foo=bar');
+      assert.strictEqual(url, '/root#?foo=bar');
     };
     Backbone.history = _.extend(new Backbone.History, {
       location: location,
@@ -932,14 +993,15 @@
     Backbone.history.start({root: '/root', pushState: true});
   });
 
-  test("Paths that don't match the root should not match no root", 0, function() {
+  QUnit.test("Paths that don't match the root should not match no root", function(assert) {
+    assert.expect(0);
     location.replace('http://example.com/foo');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
       routes: {
         foo: function(){
-          ok(false, 'should not match unless root matches');
+          assert.ok(false, 'should not match unless root matches');
         }
       }
     });
@@ -947,14 +1009,15 @@
     Backbone.history.start({root: 'root', pushState: true});
   });
 
-  test("Paths that don't match the root should not match roots of the same length", 0, function() {
+  QUnit.test("Paths that don't match the root should not match roots of the same length", function(assert) {
+    assert.expect(0);
     location.replace('http://example.com/xxxx/foo');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
       routes: {
         foo: function(){
-          ok(false, 'should not match unless root matches');
+          assert.ok(false, 'should not match unless root matches');
         }
       }
     });
@@ -962,34 +1025,37 @@
     Backbone.history.start({root: 'root', pushState: true});
   });
 
-  test("roots with regex characters", 1, function() {
+  QUnit.test("roots with regex characters", function(assert) {
+    assert.expect(1);
     location.replace('http://example.com/x+y.z/foo');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
-      routes: {foo: function(){ ok(true); }}
+      routes: {foo: function(){ assert.ok(true); }}
     });
     var router = new Router;
     Backbone.history.start({root: 'x+y.z', pushState: true});
   });
 
-  test("roots with unicode characters", 1, function() {
+  QUnit.test("roots with unicode characters", function(assert) {
+    assert.expect(1);
     location.replace('http://example.com/®ooτ/foo');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
-      routes: {foo: function(){ ok(true); }}
+      routes: {foo: function(){ assert.ok(true); }}
     });
     var router = new Router;
     Backbone.history.start({root: '®ooτ', pushState: true});
   });
 
-  test("roots without slash", 1, function() {
+  QUnit.test("roots without slash", function(assert) {
+    assert.expect(1);
     location.replace('http://example.com/®ooτ');
     Backbone.history.stop();
     Backbone.history = _.extend(new Backbone.History, {location: location});
     var Router = Backbone.Router.extend({
-      routes: {'': function(){ ok(true); }}
+      routes: {'': function(){ assert.ok(true); }}
     });
     var router = new Router;
     Backbone.history.start({root: '®ooτ', pushState: true});

--- a/test/sync.js
+++ b/test/sync.js
@@ -11,208 +11,226 @@
     length : 123
   };
 
-  module("Backbone.sync", {
+  QUnit.module("Backbone.sync", {
 
-    setup : function() {
+    beforeEach : function(assert) {
       library = new Library;
       library.create(attrs, {wait: false});
     },
 
-    teardown: function() {
+    afterEach: function(assert) {
       Backbone.emulateHTTP = false;
     }
 
   });
 
-  test("read", 4, function() {
+  QUnit.test("read", function(assert) {
+    assert.expect(4);
     library.fetch();
-    equal(this.ajaxSettings.url, '/library');
-    equal(this.ajaxSettings.type, 'GET');
-    equal(this.ajaxSettings.dataType, 'json');
-    ok(_.isEmpty(this.ajaxSettings.data));
+    assert.equal(this.ajaxSettings.url, '/library');
+    assert.equal(this.ajaxSettings.type, 'GET');
+    assert.equal(this.ajaxSettings.dataType, 'json');
+    assert.ok(_.isEmpty(this.ajaxSettings.data));
   });
 
-  test("passing data", 3, function() {
+  QUnit.test("passing data", function(assert) {
+    assert.expect(3);
     library.fetch({data: {a: 'a', one: 1}});
-    equal(this.ajaxSettings.url, '/library');
-    equal(this.ajaxSettings.data.a, 'a');
-    equal(this.ajaxSettings.data.one, 1);
+    assert.equal(this.ajaxSettings.url, '/library');
+    assert.equal(this.ajaxSettings.data.a, 'a');
+    assert.equal(this.ajaxSettings.data.one, 1);
   });
 
-  test("create", 6, function() {
-    equal(this.ajaxSettings.url, '/library');
-    equal(this.ajaxSettings.type, 'POST');
-    equal(this.ajaxSettings.dataType, 'json');
+  QUnit.test("create", function(assert) {
+    assert.expect(6);
+    assert.equal(this.ajaxSettings.url, '/library');
+    assert.equal(this.ajaxSettings.type, 'POST');
+    assert.equal(this.ajaxSettings.dataType, 'json');
     var data = JSON.parse(this.ajaxSettings.data);
-    equal(data.title, 'The Tempest');
-    equal(data.author, 'Bill Shakespeare');
-    equal(data.length, 123);
+    assert.equal(data.title, 'The Tempest');
+    assert.equal(data.author, 'Bill Shakespeare');
+    assert.equal(data.length, 123);
   });
 
-  test("update", 7, function() {
+  QUnit.test("update", function(assert) {
+    assert.expect(7);
     library.first().save({id: '1-the-tempest', author: 'William Shakespeare'});
-    equal(this.ajaxSettings.url, '/library/1-the-tempest');
-    equal(this.ajaxSettings.type, 'PUT');
-    equal(this.ajaxSettings.dataType, 'json');
+    assert.equal(this.ajaxSettings.url, '/library/1-the-tempest');
+    assert.equal(this.ajaxSettings.type, 'PUT');
+    assert.equal(this.ajaxSettings.dataType, 'json');
     var data = JSON.parse(this.ajaxSettings.data);
-    equal(data.id, '1-the-tempest');
-    equal(data.title, 'The Tempest');
-    equal(data.author, 'William Shakespeare');
-    equal(data.length, 123);
+    assert.equal(data.id, '1-the-tempest');
+    assert.equal(data.title, 'The Tempest');
+    assert.equal(data.author, 'William Shakespeare');
+    assert.equal(data.length, 123);
   });
 
-  test("update with emulateHTTP and emulateJSON", 7, function() {
+  QUnit.test("update with emulateHTTP and emulateJSON", function(assert) {
+    assert.expect(7);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'}, {
       emulateHTTP: true,
       emulateJSON: true
     });
-    equal(this.ajaxSettings.url, '/library/2-the-tempest');
-    equal(this.ajaxSettings.type, 'POST');
-    equal(this.ajaxSettings.dataType, 'json');
-    equal(this.ajaxSettings.data._method, 'PUT');
+    assert.equal(this.ajaxSettings.url, '/library/2-the-tempest');
+    assert.equal(this.ajaxSettings.type, 'POST');
+    assert.equal(this.ajaxSettings.dataType, 'json');
+    assert.equal(this.ajaxSettings.data._method, 'PUT');
     var data = JSON.parse(this.ajaxSettings.data.model);
-    equal(data.id, '2-the-tempest');
-    equal(data.author, 'Tim Shakespeare');
-    equal(data.length, 123);
+    assert.equal(data.id, '2-the-tempest');
+    assert.equal(data.author, 'Tim Shakespeare');
+    assert.equal(data.length, 123);
   });
 
-  test("update with just emulateHTTP", 6, function() {
+  QUnit.test("update with just emulateHTTP", function(assert) {
+    assert.expect(6);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'}, {
       emulateHTTP: true
     });
-    equal(this.ajaxSettings.url, '/library/2-the-tempest');
-    equal(this.ajaxSettings.type, 'POST');
-    equal(this.ajaxSettings.contentType, 'application/json');
+    assert.equal(this.ajaxSettings.url, '/library/2-the-tempest');
+    assert.equal(this.ajaxSettings.type, 'POST');
+    assert.equal(this.ajaxSettings.contentType, 'application/json');
     var data = JSON.parse(this.ajaxSettings.data);
-    equal(data.id, '2-the-tempest');
-    equal(data.author, 'Tim Shakespeare');
-    equal(data.length, 123);
+    assert.equal(data.id, '2-the-tempest');
+    assert.equal(data.author, 'Tim Shakespeare');
+    assert.equal(data.length, 123);
   });
 
-  test("update with just emulateJSON", 6, function() {
+  QUnit.test("update with just emulateJSON", function(assert) {
+    assert.expect(6);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'}, {
       emulateJSON: true
     });
-    equal(this.ajaxSettings.url, '/library/2-the-tempest');
-    equal(this.ajaxSettings.type, 'PUT');
-    equal(this.ajaxSettings.contentType, 'application/x-www-form-urlencoded');
+    assert.equal(this.ajaxSettings.url, '/library/2-the-tempest');
+    assert.equal(this.ajaxSettings.type, 'PUT');
+    assert.equal(this.ajaxSettings.contentType, 'application/x-www-form-urlencoded');
     var data = JSON.parse(this.ajaxSettings.data.model);
-    equal(data.id, '2-the-tempest');
-    equal(data.author, 'Tim Shakespeare');
-    equal(data.length, 123);
+    assert.equal(data.id, '2-the-tempest');
+    assert.equal(data.author, 'Tim Shakespeare');
+    assert.equal(data.length, 123);
   });
 
-  test("read model", 3, function() {
+  QUnit.test("read model", function(assert) {
+    assert.expect(3);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().fetch();
-    equal(this.ajaxSettings.url, '/library/2-the-tempest');
-    equal(this.ajaxSettings.type, 'GET');
-    ok(_.isEmpty(this.ajaxSettings.data));
+    assert.equal(this.ajaxSettings.url, '/library/2-the-tempest');
+    assert.equal(this.ajaxSettings.type, 'GET');
+    assert.ok(_.isEmpty(this.ajaxSettings.data));
   });
 
-  test("destroy", 3, function() {
+  QUnit.test("destroy", function(assert) {
+    assert.expect(3);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().destroy({wait: true});
-    equal(this.ajaxSettings.url, '/library/2-the-tempest');
-    equal(this.ajaxSettings.type, 'DELETE');
-    equal(this.ajaxSettings.data, null);
+    assert.equal(this.ajaxSettings.url, '/library/2-the-tempest');
+    assert.equal(this.ajaxSettings.type, 'DELETE');
+    assert.equal(this.ajaxSettings.data, null);
   });
 
-  test("destroy with emulateHTTP", 3, function() {
+  QUnit.test("destroy with emulateHTTP", function(assert) {
+    assert.expect(3);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().destroy({
       emulateHTTP: true,
       emulateJSON: true
     });
-    equal(this.ajaxSettings.url, '/library/2-the-tempest');
-    equal(this.ajaxSettings.type, 'POST');
-    equal(JSON.stringify(this.ajaxSettings.data), '{"_method":"DELETE"}');
+    assert.equal(this.ajaxSettings.url, '/library/2-the-tempest');
+    assert.equal(this.ajaxSettings.type, 'POST');
+    assert.equal(JSON.stringify(this.ajaxSettings.data), '{"_method":"DELETE"}');
   });
 
-  test("urlError", 2, function() {
+  QUnit.test("urlError", function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model();
-    throws(function() {
+    assert.throws(function() {
       model.fetch();
     });
     model.fetch({url: '/one/two'});
-    equal(this.ajaxSettings.url, '/one/two');
+    assert.equal(this.ajaxSettings.url, '/one/two');
   });
 
-  test("#1052 - `options` is optional.", 0, function() {
+  QUnit.test("#1052 - `options` is optional.", function(assert) {
+    assert.expect(0);
     var model = new Backbone.Model();
     model.url = '/test';
     Backbone.sync('create', model);
   });
 
-  test("Backbone.ajax", 1, function() {
+  QUnit.test("Backbone.ajax", function(assert) {
+    assert.expect(1);
     Backbone.ajax = function(settings){
-      strictEqual(settings.url, '/test');
+      assert.strictEqual(settings.url, '/test');
     };
     var model = new Backbone.Model();
     model.url = '/test';
     Backbone.sync('create', model);
   });
 
-  test("Call provided error callback on error.", 1, function() {
+  QUnit.test("Call provided error callback on error.", function(assert) {
+    assert.expect(1);
     var model = new Backbone.Model;
     model.url = '/test';
     Backbone.sync('read', model, {
-      error: function() { ok(true); }
+      error: function() { assert.ok(true); }
     });
     this.ajaxSettings.error();
   });
 
-  test('Use Backbone.emulateHTTP as default.', 2, function() {
+  QUnit.test('Use Backbone.emulateHTTP as default.', function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model;
     model.url = '/test';
 
     Backbone.emulateHTTP = true;
     model.sync('create', model);
-    strictEqual(this.ajaxSettings.emulateHTTP, true);
+    assert.strictEqual(this.ajaxSettings.emulateHTTP, true);
 
     Backbone.emulateHTTP = false;
     model.sync('create', model);
-    strictEqual(this.ajaxSettings.emulateHTTP, false);
+    assert.strictEqual(this.ajaxSettings.emulateHTTP, false);
   });
 
-  test('Use Backbone.emulateJSON as default.', 2, function() {
+  QUnit.test('Use Backbone.emulateJSON as default.', function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model;
     model.url = '/test';
 
     Backbone.emulateJSON = true;
     model.sync('create', model);
-    strictEqual(this.ajaxSettings.emulateJSON, true);
+    assert.strictEqual(this.ajaxSettings.emulateJSON, true);
 
     Backbone.emulateJSON = false;
     model.sync('create', model);
-    strictEqual(this.ajaxSettings.emulateJSON, false);
+    assert.strictEqual(this.ajaxSettings.emulateJSON, false);
   });
 
-  test("#1756 - Call user provided beforeSend function.", 4, function() {
+  QUnit.test("#1756 - Call user provided beforeSend function.", function(assert) {
+    assert.expect(4);
     Backbone.emulateHTTP = true;
     var model = new Backbone.Model;
     model.url = '/test';
     var xhr = {
       setRequestHeader: function(header, value) {
-        strictEqual(header, 'X-HTTP-Method-Override');
-        strictEqual(value, 'DELETE');
+        assert.strictEqual(header, 'X-HTTP-Method-Override');
+        assert.strictEqual(value, 'DELETE');
       }
     };
     model.sync('delete', model, {
       beforeSend: function(_xhr) {
-        ok(_xhr === xhr);
+        assert.ok(_xhr === xhr);
         return false;
       }
     });
-    strictEqual(this.ajaxSettings.beforeSend(xhr), false);
+    assert.strictEqual(this.ajaxSettings.beforeSend(xhr), false);
   });
 
-  test('#2928 - Pass along `textStatus` and `errorThrown`.', 2, function() {
+  QUnit.test('#2928 - Pass along `textStatus` and `errorThrown`.', function(assert) {
+    assert.expect(2);
     var model = new Backbone.Model;
     model.url = '/test';
     model.on('error', function(model, xhr, options) {
-      strictEqual(options.textStatus, 'textStatus');
-      strictEqual(options.errorThrown, 'errorThrown');
+      assert.strictEqual(options.textStatus, 'textStatus');
+      assert.strictEqual(options.errorThrown, 'errorThrown');
     });
     model.fetch();
     this.ajaxSettings.error({}, 'textStatus', 'errorThrown');

--- a/test/view.js
+++ b/test/view.js
@@ -2,9 +2,9 @@
 
   var view;
 
-  module("Backbone.View", {
+  QUnit.module("Backbone.View", {
 
-    setup: function() {
+    beforeEach: function(assert) {
       $('#qunit-fixture').append(
         '<div id="testElement"><h1>Test</h1></div>'
       );
@@ -18,46 +18,52 @@
 
   });
 
-  test("constructor", 3, function() {
-    equal(view.el.id, 'test-view');
-    equal(view.el.className, 'test-view');
-    equal(view.el.other, void 0);
+  QUnit.test("constructor", function(assert) {
+    assert.expect(3);
+    assert.equal(view.el.id, 'test-view');
+    assert.equal(view.el.className, 'test-view');
+    assert.equal(view.el.other, void 0);
   });
 
-  test("$", 2, function() {
+  QUnit.test("$", function(assert) {
+    assert.expect(2);
     var view = new Backbone.View;
     view.setElement('<p><a><b>test</b></a></p>');
     var result = view.$('a b');
 
-    strictEqual(result[0].innerHTML, 'test');
-    ok(result.length === +result.length);
+    assert.strictEqual(result[0].innerHTML, 'test');
+    assert.ok(result.length === +result.length);
   });
 
-  test("$el", 3, function() {
+  QUnit.test("$el", function(assert) {
+    assert.expect(3);
     var view = new Backbone.View;
     view.setElement('<p><a><b>test</b></a></p>');
-    strictEqual(view.el.nodeType, 1);
+    assert.strictEqual(view.el.nodeType, 1);
 
-    ok(view.$el instanceof Backbone.$);
-    strictEqual(view.$el[0], view.el);
+    assert.ok(view.$el instanceof Backbone.$);
+    assert.strictEqual(view.$el[0], view.el);
   });
 
-  test("initialize", 1, function() {
+  QUnit.test("initialize", function(assert) {
+    assert.expect(1);
     var View = Backbone.View.extend({
       initialize: function() {
         this.one = 1;
       }
     });
 
-    strictEqual(new View().one, 1);
+    assert.strictEqual(new View().one, 1);
   });
 
-  test("render", 1, function() {
+  QUnit.test("render", function(assert) {
+    assert.expect(1);
     var view = new Backbone.View;
-    equal(view.render(), view, '#render returns the view instance');
+    assert.equal(view.render(), view, '#render returns the view instance');
   });
 
-  test("delegateEvents", 6, function() {
+  QUnit.test("delegateEvents", function(assert) {
+    assert.expect(6);
     var counter1 = 0, counter2 = 0;
 
     var view = new Backbone.View({el: '#testElement'});
@@ -68,33 +74,35 @@
 
     view.delegateEvents(events);
     view.$('h1').trigger('click');
-    equal(counter1, 1);
-    equal(counter2, 1);
+    assert.equal(counter1, 1);
+    assert.equal(counter2, 1);
 
     view.$('h1').trigger('click');
-    equal(counter1, 2);
-    equal(counter2, 2);
+    assert.equal(counter1, 2);
+    assert.equal(counter2, 2);
 
     view.delegateEvents(events);
     view.$('h1').trigger('click');
-    equal(counter1, 3);
-    equal(counter2, 3);
+    assert.equal(counter1, 3);
+    assert.equal(counter2, 3);
   });
 
-  test("delegate", 3, function() {
+  QUnit.test("delegate", function(assert) {
+    assert.expect(3);
     var view = new Backbone.View({el: '#testElement'});
     view.delegate('click', 'h1', function() {
-      ok(true);
+      assert.ok(true);
     });
     view.delegate('click', function() {
-      ok(true);
+      assert.ok(true);
     });
     view.$('h1').trigger('click');
 
-    equal(view.delegate(), view, '#delegate returns the view instance');
+    assert.equal(view.delegate(), view, '#delegate returns the view instance');
   });
 
-  test("delegateEvents allows functions for callbacks", 3, function() {
+  QUnit.test("delegateEvents allows functions for callbacks", function(assert) {
+    assert.expect(3);
     var view = new Backbone.View({el: '<p></p>'});
     view.counter = 0;
 
@@ -106,24 +114,26 @@
 
     view.delegateEvents(events);
     view.$el.trigger('click');
-    equal(view.counter, 1);
+    assert.equal(view.counter, 1);
 
     view.$el.trigger('click');
-    equal(view.counter, 2);
+    assert.equal(view.counter, 2);
 
     view.delegateEvents(events);
     view.$el.trigger('click');
-    equal(view.counter, 3);
+    assert.equal(view.counter, 3);
   });
 
 
-  test("delegateEvents ignore undefined methods", 0, function() {
+  QUnit.test("delegateEvents ignore undefined methods", function(assert) {
+    assert.expect(0);
     var view = new Backbone.View({el: '<p></p>'});
     view.delegateEvents({'click': 'undefinedMethod'});
     view.$el.trigger('click');
   });
 
-  test("undelegateEvents", 7, function() {
+  QUnit.test("undelegateEvents", function(assert) {
+    assert.expect(7);
     var counter1 = 0, counter2 = 0;
 
     var view = new Backbone.View({el: '#testElement'});
@@ -134,107 +144,116 @@
 
     view.delegateEvents(events);
     view.$('h1').trigger('click');
-    equal(counter1, 1);
-    equal(counter2, 1);
+    assert.equal(counter1, 1);
+    assert.equal(counter2, 1);
 
     view.undelegateEvents();
     view.$('h1').trigger('click');
-    equal(counter1, 1);
-    equal(counter2, 2);
+    assert.equal(counter1, 1);
+    assert.equal(counter2, 2);
 
     view.delegateEvents(events);
     view.$('h1').trigger('click');
-    equal(counter1, 2);
-    equal(counter2, 3);
+    assert.equal(counter1, 2);
+    assert.equal(counter2, 3);
 
-    equal(view.undelegateEvents(), view, '#undelegateEvents returns the view instance');
+    assert.equal(view.undelegateEvents(), view, '#undelegateEvents returns the view instance');
   });
 
-  test("undelegate", 1, function() {
+  QUnit.test("undelegate", function(assert) {
+    assert.expect(1);
     view = new Backbone.View({el: '#testElement'});
-    view.delegate('click', function() { ok(false); });
-    view.delegate('click', 'h1', function() { ok(false); });
+    view.delegate('click', function() { assert.ok(false); });
+    view.delegate('click', 'h1', function() { assert.ok(false); });
 
     view.undelegate('click');
 
     view.$('h1').trigger('click');
     view.$el.trigger('click');
 
-    equal(view.undelegate(), view, '#undelegate returns the view instance');
+    assert.equal(view.undelegate(), view, '#undelegate returns the view instance');
   });
 
-  test("undelegate with passed handler", 1, function() {
+  QUnit.test("undelegate with passed handler", function(assert) {
+    assert.expect(1);
     view = new Backbone.View({el: '#testElement'});
-    var listener = function() { ok(false); };
+    var listener = function() { assert.ok(false); };
     view.delegate('click', listener);
-    view.delegate('click', function() { ok(true); });
+    view.delegate('click', function() { assert.ok(true); });
     view.undelegate('click', listener);
     view.$el.trigger('click');
   });
 
-  test("undelegate with selector", 2, function() {
+  QUnit.test("undelegate with selector", function(assert) {
+    assert.expect(2);
     view = new Backbone.View({el: '#testElement'});
-    view.delegate('click', function() { ok(true); });
-    view.delegate('click', 'h1', function() { ok(false); });
+    view.delegate('click', function() { assert.ok(true); });
+    view.delegate('click', 'h1', function() { assert.ok(false); });
     view.undelegate('click', 'h1');
     view.$('h1').trigger('click');
     view.$el.trigger('click');
   });
 
-  test("undelegate with handler and selector", 2, function() {
+  QUnit.test("undelegate with handler and selector", function(assert) {
+    assert.expect(2);
     view = new Backbone.View({el: '#testElement'});
-    view.delegate('click', function() { ok(true); });
-    var handler = function(){ ok(false); };
+    view.delegate('click', function() { assert.ok(true); });
+    var handler = function(){ assert.ok(false); };
     view.delegate('click', 'h1', handler);
     view.undelegate('click', 'h1', handler);
     view.$('h1').trigger('click');
     view.$el.trigger('click');
   });
 
-  test("tagName can be provided as a string", 1, function() {
+  QUnit.test("tagName can be provided as a string", function(assert) {
+    assert.expect(1);
     var View = Backbone.View.extend({
       tagName: 'span'
     });
 
-    equal(new View().el.tagName, 'SPAN');
+    assert.equal(new View().el.tagName, 'SPAN');
   });
 
-  test("tagName can be provided as a function", 1, function() {
+  QUnit.test("tagName can be provided as a function", function(assert) {
+    assert.expect(1);
     var View = Backbone.View.extend({
       tagName: function() {
         return 'p';
       }
     });
 
-    ok(new View().$el.is('p'));
+    assert.ok(new View().$el.is('p'));
   });
 
-  test("_ensureElement with DOM node el", 1, function() {
+  QUnit.test("_ensureElement with DOM node el", function(assert) {
+    assert.expect(1);
     var View = Backbone.View.extend({
       el: document.body
     });
 
-    equal(new View().el, document.body);
+    assert.equal(new View().el, document.body);
   });
 
-  test("_ensureElement with string el", 3, function() {
+  QUnit.test("_ensureElement with string el", function(assert) {
+    assert.expect(3);
     var View = Backbone.View.extend({
       el: "body"
     });
-    strictEqual(new View().el, document.body);
+    assert.strictEqual(new View().el, document.body);
 
     View = Backbone.View.extend({
       el: "#testElement > h1"
     });
-    strictEqual(new View().el, $("#testElement > h1").get(0));
+    assert.strictEqual(new View().el, $("#testElement > h1").get(0));
 
     View = Backbone.View.extend({
       el: "#nonexistent"
     });
-    ok(!new View().el);
+    assert.ok(!new View().el);
   });
 
-  test("with className and id functions", 2, function() {
+  QUnit.test("with className and id functions", function(assert) {
+    assert.expect(2);
     var View = Backbone.View.extend({
       className: function() {
         return 'className';
@@ -244,11 +263,12 @@
       }
     });
 
-    strictEqual(new View().el.className, 'className');
-    strictEqual(new View().el.id, 'id');
+    assert.strictEqual(new View().el.className, 'className');
+    assert.strictEqual(new View().el.id, 'id');
   });
 
-  test("with attributes", 2, function() {
+  QUnit.test("with attributes", function(assert) {
+    assert.expect(2);
     var View = Backbone.View.extend({
       attributes: {
         id: 'id',
@@ -256,21 +276,23 @@
       }
     });
 
-    strictEqual(new View().el.className, 'class');
-    strictEqual(new View().el.id, 'id');
+    assert.strictEqual(new View().el.className, 'class');
+    assert.strictEqual(new View().el.id, 'id');
   });
 
-  test("with attributes as a function", 1, function() {
+  QUnit.test("with attributes as a function", function(assert) {
+    assert.expect(1);
     var View = Backbone.View.extend({
       attributes: function() {
         return {'class': 'dynamic'};
       }
     });
 
-    strictEqual(new View().el.className, 'dynamic');
+    assert.strictEqual(new View().el.className, 'dynamic');
   });
 
-  test("should default to className/id properties", 4, function() {
+  QUnit.test("should default to className/id properties", function(assert) {
+    assert.expect(4);
     var View = Backbone.View.extend({
       className: 'backboneClass',
       id: 'backboneId',
@@ -281,13 +303,14 @@
     });
 
     var view = new View;
-    strictEqual(view.el.className, 'backboneClass');
-    strictEqual(view.el.id, 'backboneId');
-    strictEqual(view.$el.attr('class'), 'backboneClass');
-    strictEqual(view.$el.attr('id'), 'backboneId');
+    assert.strictEqual(view.el.className, 'backboneClass');
+    assert.strictEqual(view.el.id, 'backboneId');
+    assert.strictEqual(view.$el.attr('class'), 'backboneClass');
+    assert.strictEqual(view.$el.attr('id'), 'backboneId');
   });
 
-  test("multiple views per element", 3, function() {
+  QUnit.test("multiple views per element", function(assert) {
+    assert.expect(3);
     var count = 0;
     var $el = $('<p></p>');
 
@@ -302,22 +325,23 @@
 
     var view1 = new View;
     $el.trigger("click");
-    equal(1, count);
+    assert.equal(1, count);
 
     var view2 = new View;
     $el.trigger("click");
-    equal(3, count);
+    assert.equal(3, count);
 
     view1.delegateEvents();
     $el.trigger("click");
-    equal(5, count);
+    assert.equal(5, count);
   });
 
-  test("custom events", 2, function() {
+  QUnit.test("custom events", function(assert) {
+    assert.expect(2);
     var View = Backbone.View.extend({
       el: $('body'),
       events: {
-        "fake$event": function() { ok(true); }
+        "fake$event": function() { assert.ok(true); }
       }
     });
 
@@ -328,24 +352,26 @@
     $('body').trigger('fake$event');
   });
 
-  test("#1048 - setElement uses provided object.", 2, function() {
+  QUnit.test("#1048 - setElement uses provided object.", function(assert) {
+    assert.expect(2);
     var $el = $('body');
 
     var view = new Backbone.View({el: $el});
-    ok(view.$el === $el);
+    assert.ok(view.$el === $el);
 
     view.setElement($el = $($el));
-    ok(view.$el === $el);
+    assert.ok(view.$el === $el);
   });
 
-  test("#986 - Undelegate before changing element.", 1, function() {
+  QUnit.test("#986 - Undelegate before changing element.", function(assert) {
+    assert.expect(1);
     var button1 = $('<button></button>');
     var button2 = $('<button></button>');
 
     var View = Backbone.View.extend({
       events: {
         click: function(e) {
-          ok(view.el === e.target);
+          assert.ok(view.el === e.target);
         }
       }
     });
@@ -357,23 +383,25 @@
     button2.trigger('click');
   });
 
-  test("#1172 - Clone attributes object", 2, function() {
+  QUnit.test("#1172 - Clone attributes object", function(assert) {
+    assert.expect(2);
     var View = Backbone.View.extend({
       attributes: {foo: 'bar'}
     });
 
     var view1 = new View({id: 'foo'});
-    strictEqual(view1.el.id, 'foo');
+    assert.strictEqual(view1.el.id, 'foo');
 
     var view2 = new View();
-    ok(!view2.el.id);
+    assert.ok(!view2.el.id);
   });
 
-  test("views stopListening", 0, function() {
+  QUnit.test("views stopListening", function(assert) {
+    assert.expect(0);
     var View = Backbone.View.extend({
       initialize: function() {
-        this.listenTo(this.model, 'all x', function(){ ok(false); });
-        this.listenTo(this.collection, 'all x', function(){ ok(false); });
+        this.listenTo(this.model, 'all x', function(){ assert.ok(false); });
+        this.listenTo(this.collection, 'all x', function(){ assert.ok(false); });
       }
     });
 
@@ -387,7 +415,8 @@
     view.collection.trigger('x');
   });
 
-  test("Provide function for el.", 2, function() {
+  QUnit.test("Provide function for el.", function(assert) {
+    assert.expect(2);
     var View = Backbone.View.extend({
       el: function() {
         return "<p><a></a></p>";
@@ -395,11 +424,12 @@
     });
 
     var view = new View;
-    ok(view.$el.is('p'));
-    ok(view.$el.has('a'));
+    assert.ok(view.$el.is('p'));
+    assert.ok(view.$el.has('a'));
   });
 
-  test("events passed in options", 1, function() {
+  QUnit.test("events passed in options", function(assert) {
+    assert.expect(1);
     var counter = 0;
 
     var View = Backbone.View.extend({
@@ -416,32 +446,34 @@
     });
 
     view.$('h1').trigger('click').trigger('click');
-    equal(counter, 2);
+    assert.equal(counter, 2);
   });
 
-  test("remove", 2, function() {
+  QUnit.test("remove", function(assert) {
+    assert.expect(2);
     var view = new Backbone.View;
     document.body.appendChild(view.el);
 
-    view.delegate('click', function() { ok(false); });
-    view.listenTo(view, 'all x', function() { ok(false); });
+    view.delegate('click', function() { assert.ok(false); });
+    view.listenTo(view, 'all x', function() { assert.ok(false); });
 
-    equal(view.remove(), view, '#remove returns the view instance');
+    assert.equal(view.remove(), view, '#remove returns the view instance');
     view.$el.trigger('click');
     view.trigger('x');
 
     // In IE8 and below, parentNode still exists but is not document.body.
-    notEqual(view.el.parentNode, document.body);
+    assert.notEqual(view.el.parentNode, document.body);
   });
 
-  test("setElement", 3, function() {
+  QUnit.test("setElement", function(assert) {
+    assert.expect(3);
     var view = new Backbone.View({
       events: {
-        click: function() { ok(false); }
+        click: function() { assert.ok(false); }
       }
     });
     view.events = {
-      click: function() { ok(true); }
+      click: function() { assert.ok(true); }
     };
     var oldEl = view.el;
     var $oldEl = view.$el;
@@ -451,8 +483,8 @@
     $oldEl.click();
     view.$el.click();
 
-    notEqual(oldEl, view.el);
-    notEqual($oldEl, view.$el);
+    assert.notEqual(oldEl, view.el);
+    assert.notEqual($oldEl, view.$el);
   });
 
 })();


### PR DESCRIPTION
Fixes #3813.

I had to manually migrate `test/router.js` because my migrator apparently can't handle non-ASCII characters. Please do pay special attention to that one.

I don't know CoffeeScript that well, but it looks like the assertions in that library are simply falling back to the Node environment (and therefore its assert module). Thus I assume no modification needs to happen to that file (due to it not actually being QUnit tests). Please let me know if this is incorrect.