### PR TITLE
Document using [] for Collections with zero models

### DIFF
--- a/index.html
+++ b/index.html
@@ -1822,7 +1822,7 @@ alert(library.get('dvd-1').id + ' ' + library.get('vhs-1').id);
       <b>initialize</b> function, it will be invoked when the collection is
       created. There are a couple of options that, if provided, are attached to
       the collection directly: <tt>model</tt> and <tt>comparator</tt>.<br />
-      Pass <tt>null</tt> for <tt>models</tt> to create an empty Collection with <tt>options</tt>.
+      Pass <tt>[]</tt> for <tt>models</tt> to create an empty Collection with <tt>options</tt>.
     </p>
 
 <pre>

--- a/test/collection.js
+++ b/test/collection.js
@@ -1437,6 +1437,22 @@ QUnit.test("#1894 - `sort` can optionally be turned off", function(assert) {
     assert.ok(collection.comparator === comparator);
   });
 
+  QUnit.test("Pass falsey for `models` for empty Col with `options`", function(assert) {
+    assert.expect(9);
+    var opts = {a: 1, b: 2};
+    _.forEach([undefined, null, false], function(falsey) {
+      var Collection = Backbone.Collection.extend({
+        initialize: function(models, options) {
+          assert.strictEqual(models, falsey);
+          assert.strictEqual(options, opts);
+        }
+      });
+
+      var col = new Collection(falsey, opts);
+      assert.strictEqual(col.length, 0);
+    });
+  });
+
   QUnit.test("`add` overrides `set` flags", function(assert) {
     var collection = new Backbone.Collection();
     collection.once('add', function (model, collection, options) {


### PR DESCRIPTION
*Updated:*

The documented example shows passing `[]` to instantiate an empty collection
while still supplying an options object. This change makes the preceding
documentation consistent with that example.

I also noticed that we don't have any tests covering the previously recommended
approach of passing `null` (or any falsey value) for models. I've added a test
to ensure we continue to support that usage.