### PR TITLE
Deopt Underscore methods that change on arguments

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -87,6 +87,9 @@
         return _[method](this[attribute], cb(iteratee, this), context);
       };
       case 4: return function(iteratee, defaultVal, context) {
+        if(arguments.length < 2) {
+          return _[method](this[attribute], cb(iteratee, this));
+        }
         return _[method](this[attribute], cb(iteratee, this), defaultVal, context);
       };
       default: return function() {

--- a/backbone.js
+++ b/backbone.js
@@ -87,9 +87,6 @@
         return _[method](this[attribute], cb(iteratee, this), context);
       };
       case 4: return function(iteratee, defaultVal, context) {
-        if(arguments.length < 2) {
-          return _[method](this[attribute], cb(iteratee, this));
-        }
         return _[method](this[attribute], cb(iteratee, this), defaultVal, context);
       };
       default: return function() {
@@ -1169,8 +1166,8 @@
   // Underscore methods that we want to implement on the Collection.
   // 90% of the core usefulness of Backbone Collections is actually implemented
   // right here:
-  var collectionMethods = { forEach: 3, each: 3, map: 3, collect: 3, reduce: 4,
-      foldl: 4, inject: 4, reduceRight: 4, foldr: 4, find: 3, detect: 3, filter: 3,
+  var collectionMethods = { forEach: 3, each: 3, map: 3, collect: 3, reduce: 0,
+      foldl: 0, inject: 0, reduceRight: 0, foldr: 0, find: 3, detect: 3, filter: 3,
       select: 3, reject: 3, every: 3, all: 3, some: 3, any: 3, include: 3, includes: 3,
       contains: 3, invoke: 0, max: 3, min: 3, toArray: 1, size: 1, first: 3,
       head: 3, take: 3, initial: 3, rest: 3, tail: 3, drop: 3, last: 3,

--- a/test/collection.js
+++ b/test/collection.js
@@ -670,10 +670,12 @@
   });
 
   QUnit.test("Underscore methods", function(assert) {
-    assert.expect(19);
+    assert.expect(21);
     assert.equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
     assert.equal(col.some(function(model){ return model.id === 100; }), false);
     assert.equal(col.some(function(model){ return model.id === 0; }), true);
+    assert.equal(col.reduce(function(a, b) {return a.id > b.id ? a : b}).id, 3);
+    assert.equal(col.reduceRight(function(a, b) {return a.id > b.id ? a : b}).id, 3);
     assert.equal(col.indexOf(b), 1);
     assert.equal(col.size(), 4);
     assert.equal(col.rest().length, 3);


### PR DESCRIPTION
All of our currently deoptimized Underscore methods (`pick`, `omit`, `invoke`, `without`, and `difference`) change behavior based on the number of arguments pass to the call. This both adds `reduce` (and friends).

Supersedes (and incorporates) #3810.