### PR TITLE
Add a preinitialize method to allow for true instance properties and ES6 classes

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -394,6 +394,7 @@
   var Model = Backbone.Model = function(attributes, options) {
     var attrs = attributes || {};
     options || (options = {});
+    this.preinitialize.apply(this, arguments);
     this.cid = _.uniqueId(this.cidPrefix);
     this.attributes = {};
     if (options.collection) this.collection = options.collection;
@@ -421,6 +422,10 @@
     // The prefix is used to create the client id which is used to identify models locally.
     // You may want to override this if you're experiencing name clashes with model ids.
     cidPrefix: 'c',
+
+    // preinitialize is an empty function by default. You can override it with a function
+    // or object.  preinitialize will run before any instantiation logic is run in the Model.
+    preinitialize: function(){},
 
     // Initialize is an empty function by default. Override it with your own
     // initialization logic.
@@ -756,6 +761,7 @@
   // its models in sort order, as they're added and removed.
   var Collection = Backbone.Collection = function(models, options) {
     options || (options = {});
+    this.preinitialize.apply(this, arguments);
     if (options.model) this.model = options.model;
     if (options.comparator !== void 0) this.comparator = options.comparator;
     this._reset();
@@ -784,6 +790,11 @@
     // The default model for a collection is just a **Backbone.Model**.
     // This should be overridden in most cases.
     model: Model,
+
+
+    // preinitialize is an empty function by default. You can override it with a function
+    // or object.  preinitialize will run before any instantiation logic is run in the Collection.
+    preinitialize: function(){},
 
     // Initialize is an empty function by default. Override it with your own
     // initialization logic.
@@ -1221,6 +1232,7 @@
   // if an existing element is not provided...
   var View = Backbone.View = function(options) {
     this.cid = _.uniqueId('view');
+    this.preinitialize.apply(this, arguments);
     _.extend(this, _.pick(options, viewOptions));
     this._ensureElement();
     this.initialize.apply(this, arguments);
@@ -1243,6 +1255,10 @@
     $: function(selector) {
       return this.$el.find(selector);
     },
+
+    // preinitialize is an empty function by default. You can override it with a function
+    // or object.  preinitialize will run before any instantiation logic is run in the View
+    preinitialize: function(){},
 
     // Initialize is an empty function by default. Override it with your own
     // initialization logic.
@@ -1469,6 +1485,7 @@
   // matched. Creating a new one sets its `routes` hash, if not set statically.
   var Router = Backbone.Router = function(options) {
     options || (options = {});
+    this.preinitialize.apply(this, arguments);
     if (options.routes) this.routes = options.routes;
     this._bindRoutes();
     this.initialize.apply(this, arguments);
@@ -1483,6 +1500,10 @@
 
   // Set up all inheritable **Backbone.Router** properties and methods.
   _.extend(Router.prototype, Events, {
+
+    // preinitialize is an empty function by default. You can override it with a function
+    // or object.  preinitialize will run before any instantiation logic is run in the Router.
+    preinitialize: function(){},
 
     // Initialize is an empty function by default. Override it with your own
     // initialization logic.

--- a/test/collection.js
+++ b/test/collection.js
@@ -661,6 +661,31 @@
     assert.equal(coll.one, 1);
   });
 
+  QUnit.test('preinitialize', function(assert) {
+    assert.expect(1);
+    var Collection = Backbone.Collection.extend({
+      preinitialize: function() {
+        this.one = 1;
+      }
+    });
+    var coll = new Collection;
+    assert.equal(coll.one, 1);
+  });
+
+  QUnit.test('preinitialize occurs before the collection is set up', function(assert) {
+    assert.expect(2);
+    var Collection = Backbone.Collection.extend({
+      preinitialize: function() {
+        assert.notEqual(this.model, FooModel);
+      }
+    });
+    var FooModel = Backbone.Model.extend({id: 'foo'});
+    var coll = new Collection({}, {
+      model: FooModel
+    });
+    assert.equal(coll.model, FooModel);
+  });
+
   QUnit.test('toJSON', function(assert) {
     assert.expect(1);
     assert.equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');

--- a/test/model.js
+++ b/test/model.js
@@ -63,6 +63,36 @@
     assert.equal(model.get('value'), 2);
   });
 
+
+  QUnit.test('preinitialize', function(assert) {
+    assert.expect(2);
+    var Model = Backbone.Model.extend({
+
+      preinitialize: function() {
+        this.one = 1;
+      }
+    });
+    var model = new Model({}, {collection: collection});
+    assert.equal(model.one, 1);
+    assert.equal(model.collection, collection);
+  });
+
+  QUnit.test('preinitialize occurs before the model is set up', function(assert) {
+    assert.expect(6);
+    var Model = Backbone.Model.extend({
+
+      preinitialize: function() {
+        assert.equal(this.collection, undefined);
+        assert.equal(this.cid, undefined);
+        assert.equal(this.id, undefined);
+      }
+    });
+    var model = new Model({id: 'foo'}, {collection: collection});
+    assert.equal(model.collection, collection);
+    assert.equal(model.id, 'foo');
+    assert.notEqual(model.cid, undefined);
+  });
+
   QUnit.test('parse can return null', function(assert) {
     assert.expect(1);
     var Model = Backbone.Model.extend({

--- a/test/router.js
+++ b/test/router.js
@@ -95,6 +95,10 @@
       '*anything': 'anything'
     },
 
+    preinitialize: function(options) {
+      this.testpreinit = 'foo';
+    },
+
     initialize: function(options) {
       this.testing = options.testing;
       this.route('implicit', 'implicit');
@@ -179,6 +183,11 @@
   QUnit.test('initialize', function(assert) {
     assert.expect(1);
     assert.equal(router.testing, 101);
+  });
+
+  QUnit.test('preinitialize', function(assert) {
+    assert.expect(1);
+    assert.equal(router.testpreinit, 'foo');
   });
 
   QUnit.test('routes (simple)', function(assert) {

--- a/test/view.js
+++ b/test/view.js
@@ -61,6 +61,28 @@
     assert.strictEqual(new View().one, 1);
   });
 
+  QUnit.test('preinitialize', function(assert) {
+    assert.expect(1);
+    var View = Backbone.View.extend({
+      preinitialize: function() {
+        this.one = 1;
+      }
+    });
+
+    assert.strictEqual(new View().one, 1);
+  });
+
+  QUnit.test('preinitialize occurs before the view is set up', function(assert) {
+    assert.expect(2);
+    var View = Backbone.View.extend({
+      preinitialize: function() {
+        assert.equal(this.el, undefined);
+      }
+    });
+    var _view = new View({});
+    assert.notEqual(_view.el, undefined);
+  });
+
   QUnit.test('render', function(assert) {
     assert.expect(1);
     var myView = new Backbone.View;


### PR DESCRIPTION
This is my attempt to allow for better support for ES6 classes through a new method, localProps.

`localProps` allows you to define a function (or an object), that is evaluated in the constructor for Models/Collections/Views/Routers, with the result being mixed in to each local object.

As a happy side effect this allows a declarative format for instance properties on an object (instead of using `this.foo = 'bar'` statements in the constructor).

This allows us to write something like 

```
class DocumentRow extends Backbone.View {

    localProps() {
        return {
          tagName:  "li",
          className: "document-row",
          events: {
            "click .icon":          "open",
            "click .button.edit":   "openEditDialog",
            "click .button.delete": "destroy"
          }
        };
    }

    initialize() {
        this.listenTo(this.model, "change", this.render);
    }

    render() {
        //...
    }
}
```

instead of adding properties to the prototype separate from the class declaration or using non-standard features like decorators.

See #3560 for more background on why this is useful/necessary