### PR TITLE
Deopt Underscore methods that use `arguments`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -68,6 +68,9 @@
   // form param named `model`.
   Backbone.emulateJSON = false;
 
+  // A cached regex to detect if the Underscore function contains the `arguments`
+  // keyword.
+  var containsArguments = /\barguments\b/;
   // Proxy Backbone class methods to Underscore functions, wrapping the model's
   // `attributes` object or collection's `models` array behind the scenes.
   //
@@ -76,6 +79,10 @@
   //
   // `Function#apply` can be slow so we use the method's arg count, if we know it.
   var addMethod = function(length, method, attribute) {
+    // In case we don't catch it, deopt Underscore functions that contain
+    // the arguments keyword.
+    if (length > 0 && containsArguments.test(_[method])) length = 0;
+
     switch (length) {
       case 1: return function() {
         return _[method](this[attribute]);


### PR DESCRIPTION
To prevent issues like #3810, we can test each underscore method for the presence of `arguments`. If found, we explicitly deoptimize the wrapping method, so that the call arguments exactly match the wrapper's.