### PR TITLE
Avoid Object.prototype collisions with defaults

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -398,7 +398,8 @@
     this.attributes = {};
     if (options.collection) this.collection = options.collection;
     if (options.parse) attrs = this.parse(attrs, options) || {};
-    attrs = _.defaults({}, attrs, _.result(this, 'defaults'));
+    var defaults = _.result(this, 'defaults');
+    attrs = _.defaults(_.extend({}, defaults, attrs), defaults);
     this.set(attrs, options);
     this.changed = {};
     this.initialize.apply(this, arguments);
@@ -714,7 +715,7 @@
 
     // Check if the model is currently in a valid state.
     isValid: function(options) {
-      return this._validate({}, _.defaults({validate: true}, options));
+      return this._validate({}, _.extend({}, options, {validate: true}));
     },
 
     // Run validation against the next complete set of model attributes,
@@ -824,7 +825,7 @@
     set: function(models, options) {
       if (models == null) return;
 
-      options = _.defaults({}, options, setOptions);
+      options = _.extend({}, setOptions, options);
       if (options.parse && !this._isModel(models)) {
         models = this.parse(models, options) || [];
       }

--- a/test/model.js
+++ b/test/model.js
@@ -34,6 +34,12 @@
     assert.equal(model.collection, collection);
   });
 
+  QUnit.test('Object.prototype properties are overridden by attributes', function(assert) {
+    assert.expect(1);
+    var model = new Backbone.Model({hasOwnProperty: true});
+    assert.equal(model.get('hasOwnProperty'), true);
+  });
+
   QUnit.test('initialize with attributes and options', function(assert) {
     assert.expect(1);
     var Model = Backbone.Model.extend({
@@ -55,19 +61,6 @@
     });
     var model = new Model({value: 1}, {parse: true});
     assert.equal(model.get('value'), 2);
-  });
-
-  QUnit.test('initialize with defaults', function(assert) {
-    assert.expect(2);
-    var Model = Backbone.Model.extend({
-      defaults: {
-        firstName: 'Unknown',
-        lastName: 'Unknown'
-      }
-    });
-    var model = new Model({'firstName': 'John'});
-    assert.equal(model.get('firstName'), 'John');
-    assert.equal(model.get('lastName'), 'Unknown');
   });
 
   QUnit.test('parse can return null', function(assert) {
@@ -428,7 +421,7 @@
   });
 
   QUnit.test('defaults', function(assert) {
-    assert.expect(4);
+    assert.expect(9);
     var Defaulted = Backbone.Model.extend({
       defaults: {
         one: 1,
@@ -438,6 +431,9 @@
     var model = new Defaulted({two: undefined});
     assert.equal(model.get('one'), 1);
     assert.equal(model.get('two'), 2);
+    model = new Defaulted({two: 3});
+    assert.equal(model.get('one'), 1);
+    assert.equal(model.get('two'), 3);
     Defaulted = Backbone.Model.extend({
       defaults: function() {
         return {
@@ -449,6 +445,15 @@
     model = new Defaulted({two: undefined});
     assert.equal(model.get('one'), 3);
     assert.equal(model.get('two'), 4);
+    Defaulted = Backbone.Model.extend({
+      defaults: {hasOwnProperty: true}
+    });
+    model = new Defaulted();
+    assert.equal(model.get('hasOwnProperty'), true);
+    model = new Defaulted({hasOwnProperty: undefined});
+    assert.equal(model.get('hasOwnProperty'), true);
+    model = new Defaulted({hasOwnProperty: false});
+    assert.equal(model.get('hasOwnProperty'), false);
   });
 
   QUnit.test('change, hasChanged, changedAttributes, previous, previousAttributes', function(assert) {
@@ -989,8 +994,8 @@
 
   QUnit.test('`previous` for falsey keys', function(assert) {
     assert.expect(2);
-    var model = new Backbone.Model({0: true, '': true});
-    model.set({0: false, '': false}, {silent: true});
+    var model = new Backbone.Model({'0': true, '': true});
+    model.set({'0': false, '': false}, {silent: true});
     assert.equal(model.previous(0), true);
     assert.equal(model.previous(''), true);
   });


### PR DESCRIPTION
This is definitely an underscore concern, but it's easier to demo in Backbone code.

Fixes #3842.