### PR TITLE
Separate attributes into hook

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1325,11 +1325,8 @@
     // an element from the `id`, `className` and `tagName` properties.
     _ensureElement: function() {
       if (!this.el) {
-        var attrs = _.extend({}, _.result(this, 'attributes'));
-        if (this.id) attrs.id = _.result(this, 'id');
-        if (this.className) attrs['class'] = _.result(this, 'className');
         this.setElement(this._createElement(_.result(this, 'tagName')));
-        this._setAttributes(attrs);
+        this._setAttributes(this._attributes());
       } else {
         this.setElement(_.result(this, 'el'));
       }
@@ -1339,6 +1336,13 @@
     // subclasses using an alternative DOM manipulation API.
     _setAttributes: function(attributes) {
       this.$el.attr(attributes);
+    },
+
+    _attributes: function() {
+      var attrs = _.extend({}, _.result(this, 'attributes'));
+      if (this.id) attrs.id = _.result(this, 'id');
+      if (this.className) attrs['class'] = _.result(this, 'className');
+      return attrs;
     }
 
   });


### PR DESCRIPTION
A small change to allow subclasses access to the attributes that should be on the view. This is particularly handy when there are dynamic attributes...

Something like:

```js
var View = Backbone.View.extend({
    id() { return this.model.get('id'); },
    attributes() {
        // some logic
    },

    render() {
        this.$el.html(this.template(this.model.attributes));

        var attrs = _.extend({}, _.result(this, 'attributes'));
        if (this.id) attrs.id = _.result(this, 'id');
        if (this.className) attrs['class'] = _.result(this, 'className');
        return attrs;

        this.$el.attr(attrs);
    }
});
```

Notice the attributes update code is just copied pasted from the Backbone source.