### PR TITLE
Performance with stopListening

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -242,7 +242,6 @@
 
       listening.obj.off(name, callback, this);
     }
-    if (_.isEmpty(listeningTo)) this._listeningTo = void 0;
 
     return this;
   };

--- a/test/events.js
+++ b/test/events.js
@@ -158,6 +158,27 @@
     b.trigger('event2');
   });
 
+  QUnit.test("stopListening performance", function (assert) {
+    assert.expect(1);
+
+    window.console.info("Creating models and listening to changes");
+    var a = _.extend({}, Backbone.Events);
+    var models = _.times(100000, function() {
+      var model = new Backbone.Model();
+      a.listenTo(model, 'change', _.noop);
+      return model;
+    });
+
+    window.console.info("Starting to stop listening to model changes");
+    var start = new Date();
+    models.forEach(function(model) {
+      a.stopListening(model);
+    });
+    var end = new Date();
+    window.console.info("time: " + (end - start));
+    assert.ok((end - start) <= 1500, "should remove listeners in under 1.5 seconds");
+  });
+
   QUnit.test("listenToOnce", function(assert) {
     assert.expect(2);
     // Same as the previous test, but we use once rather than having to explicitly unbind

--- a/test/events.js
+++ b/test/events.js
@@ -158,27 +158,6 @@
     b.trigger('event2');
   });
 
-  QUnit.test("stopListening performance", function (assert) {
-    assert.expect(1);
-
-    window.console.info("Creating models and listening to changes");
-    var a = _.extend({}, Backbone.Events);
-    var models = _.times(100000, function() {
-      var model = new Backbone.Model();
-      a.listenTo(model, 'change', _.noop);
-      return model;
-    });
-
-    window.console.info("Starting to stop listening to model changes");
-    var start = new Date();
-    models.forEach(function(model) {
-      a.stopListening(model);
-    });
-    var end = new Date();
-    window.console.info("time: " + (end - start));
-    assert.ok((end - start) <= 1500, "should remove listeners in under 1.5 seconds");
-  });
-
   QUnit.test("listenToOnce", function(assert) {
     assert.expect(2);
     // Same as the previous test, but we use once rather than having to explicitly unbind


### PR DESCRIPTION
When listening to a lot of models, stopListening(model) is very expensive due to checking whether listeningTo is empty. I've added a test that demonstrates the problem. I might be missing it, but I see no benefit to just leaving _listeningTo = {}.

```javascript
if (_.isEmpty(listeningTo)) this._listeningTo = void 0; 
```
