### PR TITLE
Change `_.invoke` to `_.map`.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1011,7 +1011,9 @@
 
     // Pluck an attribute from each model in the collection.
     pluck: function(attr) {
-      return _.invoke(this.models, 'get', attr);
+      return _.map(this.models, function(model) {
+        return model.get(attr);
+      });
     },
 
     // Fetch the default set of models for this collection, resetting the


### PR DESCRIPTION
This makes way for `_.invoke` to be renamed `_.mapInvoke` or other in lodash v4 (due out in Jan 2016).