### PR TITLE
Ensure `attr` is a string when passed to `this.map`.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1011,7 +1011,7 @@
 
     // Pluck an attribute from each model in the collection.
     pluck: function(attr) {
-      return this.map(attr);
+      return this.map(attr + '');
     },
 
     // Fetch the default set of models for this collection, resetting the


### PR DESCRIPTION
This PR ensures `attr` is a string when passed to `this.map`. I've had folks rely on the undocumented behavior of letting iteratees slip through if `attr` is not coerced.