### PR TITLE
Performance with stopListening (slow when stop listening to lots of events)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -242,7 +242,6 @@
 
       listening.obj.off(name, callback, this);
     }
-    if (_.isEmpty(listeningTo)) this._listeningTo = void 0;
 
     return this;
   };


### PR DESCRIPTION
_.isEmpty can be painfully slow when listening to numerous events and assigning _listenTo to undefined isn't necessary.

Sorry for a second pull request - I had some issues with my [previous one](https://github.com/jashkenas/backbone/pull/3862). As requested I've removed the performance tests.