### PR TITLE
make _validate respect silent option

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -718,13 +718,16 @@
     },
 
     // Run validation against the next complete set of model attributes,
-    // returning `true` if all is well. Otherwise, fire an `"invalid"` event.
+    // returning `true` if all is well. Otherwise, return false and
+    // fire an `"invalid"` event (if not silent).
     _validate: function(attrs, options) {
       if (!options.validate || !this.validate) return true;
       attrs = _.extend({}, this.attributes, attrs);
       var error = this.validationError = this.validate(attrs, options) || null;
       if (!error) return true;
-      this.trigger('invalid', this, error, _.extend(options, {validationError: error}));
+      if (!options.silent) {
+        this.trigger('invalid', this, error, _.extend(options, {validationError: error}));
+      }
       return false;
     }
 

--- a/test/model.js
+++ b/test/model.js
@@ -1367,6 +1367,31 @@
     assert.ok(model.isValid());
   });
 
+  QUnit.test('#3884 - _validate respects silent option so isValid can return false without triggering invalid.', function(assert) {
+    assert.expect(2);
+    var model = new Backbone.Model();
+    model.validate = function() { return 'some problem'; };
+    model.on('invalid', function() {
+      throw 'invalid';
+    });
+    assert.ok(!model.isValid({silent: true}));
+    assert.throws(model.isValid);
+  });
+
+  QUnit.test('#3884 - _validate respects silent option so set can be silent even with validation.', function(assert) {
+    assert.expect(1);
+    var model = new Backbone.Model();
+    model.validate = function() { return 'some problem'; };
+    model.on('invalid', function() {
+      throw 'invalid';
+    });
+    model.on('change:foo', function() {
+      throw 'change';
+    });
+    model.set('foo', 'bar', {silent: true, validate: true});
+    assert.ok(true);
+  });
+
   QUnit.test('#1961 - Creating a model with {validate:true} will call validate and use the error callback', function(assert) {
     var Model = Backbone.Model.extend({
       validate: function(attrs) {


### PR DESCRIPTION
This is useful both for `isValid` - where the validity of a model can easily be ascertained without sounding the invalid alarm - as well as for `set` where silence is respected even when validating.
