### PR TITLE
Update wording to "space-separated" to be consistent

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -146,7 +146,7 @@
         events = eventsApi(iteratee, events, names[i], name[names[i]], opts);
       }
     } else if (name && eventSplitter.test(name)) {
-      // Handle space separated event names by delegating them individually.
+      // Handle space-separated event names by delegating them individually.
       for (names = name.split(eventSplitter); i < names.length; i++) {
         events = iteratee(events, names[i], callback, opts);
       }


### PR DESCRIPTION
This is both grammatically correct, and consistent with the language in the rest of the comments. 