### PR TITLE
Large batch of ESLint cleanups

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,10 @@
     "node": true,
     "amd": true
   },
-
+  "globals": {
+    "attachEvent": true,
+    "detachEvent": true
+  },
   "rules": {
     "array-bracket-spacing": [2],
     "camelcase": 2,
@@ -57,6 +60,7 @@
     "no-spaced-func": 2,
     "no-throw-literal": 2,
     "no-trailing-spaces": 2,
+    "no-undef": 2,
     "no-undef-init": 2,
     "no-undefined": 2,
     "no-unneeded-ternary": 2,

--- a/.eslintrc
+++ b/.eslintrc
@@ -47,6 +47,7 @@
     "no-irregular-whitespace": 2,
     "no-label-var": 2,
     "no-lone-blocks": 2,
+    "no-lonely-if": 2,
     "no-multi-str": 2,
     "no-native-reassign": 2,
     "no-negated-in-lhs": 1,

--- a/.eslintrc
+++ b/.eslintrc
@@ -67,6 +67,7 @@
     "no-unreachable": 2,
     "no-with": 2,
     "object-curly-spacing": [2, "never"],
+    "quote-props": [1, "consistent-as-needed"],
     "quotes": [2, "single", "avoid-escape"],
     "radix": 2,
     "semi": 2,

--- a/backbone.js
+++ b/backbone.js
@@ -619,8 +619,8 @@
       // the model will be valid when the attributes, if any, are set.
       if (attrs && !wait) {
         if (!this.set(attrs, options)) return false;
-      } else {
-        if (!this._validate(attrs, options)) return false;
+      } else if (!this._validate(attrs, options)) {
+        return false;
       }
 
       // After a successful server-side save, the client is (optionally)

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -20,7 +20,6 @@
     "no-throw-literal": 0,
     "no-undefined": 0,
     "quote-props": 0,
-    "semi": 0,
     "space-before-function-paren": 0
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -10,7 +10,6 @@
   },
   "rules": {
     "no-throw-literal": 0,
-    "no-undefined": 0,
-    "quote-props": 0
+    "no-undefined": 0
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -9,7 +9,6 @@
     "$": true
   },
   "rules": {
-    "camelCase": 0,
     "no-throw-literal": 0,
     "no-undefined": 0,
     "quote-props": 0

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,7 +3,10 @@
     "browser": true
   },
   "globals": {
-    "QUnit": false
+    "QUnit": false,
+    "Backbone": true,
+    "_": true,
+    "$": true
   },
   "rules": {
     "array-bracket-spacing": 0,

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -9,17 +9,9 @@
     "$": true
   },
   "rules": {
-    "array-bracket-spacing": 0,
-    "brace-style": 0,
-    "camelcase": 0,
-    "comma-spacing": 0,
-    "no-extend-native": 0,
-    "no-new-wrappers": 0,
-    "no-spaced-func": 0,
-    "no-sparse-arrays": 0,
+    "camelCase": 0,
     "no-throw-literal": 0,
     "no-undefined": 0,
-    "quote-props": 0,
-    "space-before-function-paren": 0
+    "quote-props": 0
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -20,7 +20,6 @@
     "no-throw-literal": 0,
     "no-undefined": 0,
     "quote-props": 0,
-    "quotes": 0,
     "semi": 0,
     "space-before-function-paren": 0
   }

--- a/test/collection.js
+++ b/test/collection.js
@@ -2,7 +2,7 @@
 
   var a, b, c, d, e, col, otherCol;
 
-  QUnit.module("Backbone.Collection", {
+  QUnit.module('Backbone.Collection', {
 
     beforeEach: function(assert) {
       a         = new Backbone.Model({id: 3, label: 'a'});
@@ -16,7 +16,7 @@
 
   });
 
-  QUnit.test("new and sort", function(assert) {
+  QUnit.test('new and sort', function(assert) {
     assert.expect(6);
     var counter = 0;
     col.on('sort', function(){ counter++; });
@@ -34,7 +34,7 @@
     assert.equal(col.length, 4);
   });
 
-  QUnit.test("String comparator.", function(assert) {
+  QUnit.test('String comparator.', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection([
       {id: 3},
@@ -44,7 +44,7 @@
     assert.deepEqual(collection.pluck('id'), [1, 2, 3]);
   });
 
-  QUnit.test("new and parse", function(assert) {
+  QUnit.test('new and parse', function(assert) {
     assert.expect(3);
     var Collection = Backbone.Collection.extend({
       parse: function(data) {
@@ -60,7 +60,7 @@
     assert.strictEqual(collection.last().get('a'), 4);
   });
 
-  QUnit.test("clone preserves model and comparator", function(assert) {
+  QUnit.test('clone preserves model and comparator', function(assert) {
     assert.expect(3);
     var Model = Backbone.Model.extend();
     var comparator = function(model){ return model.id; };
@@ -75,7 +75,7 @@
     assert.strictEqual(collection.comparator, comparator);
   });
 
-  QUnit.test("get", function(assert) {
+  QUnit.test('get', function(assert) {
     assert.expect(6);
     assert.equal(col.get(0), d);
     assert.equal(col.get(d.clone()), d);
@@ -85,7 +85,7 @@
     assert.equal(col.get(col.first().cid), col.first());
   });
 
-  QUnit.test("get with non-default ids", function(assert) {
+  QUnit.test('get with non-default ids', function(assert) {
     assert.expect(5);
     var MongoModel = Backbone.Model.extend({idAttribute: '_id'});
     var model = new MongoModel({_id: 100});
@@ -106,7 +106,7 @@
     assert.equal(collection.get(1).id, 1);
   });
 
-  QUnit.test("update index when id changes", function(assert) {
+  QUnit.test('update index when id changes', function(assert) {
     assert.expect(4);
     var col = new Backbone.Collection();
     col.add([
@@ -121,18 +121,18 @@
     assert.equal(col.get(101).get('name'), 'dalmatians');
   });
 
-  QUnit.test("at", function(assert) {
+  QUnit.test('at', function(assert) {
     assert.expect(2);
     assert.equal(col.at(2), c);
     assert.equal(col.at(-2), c);
   });
 
-  QUnit.test("pluck", function(assert) {
+  QUnit.test('pluck', function(assert) {
     assert.expect(1);
     assert.equal(col.pluck('label').join(' '), 'a b c d');
   });
 
-  QUnit.test("add", function(assert) {
+  QUnit.test('add', function(assert) {
     assert.expect(14);
     var added, opts, secondAdded;
     added = opts = secondAdded = null;
@@ -176,7 +176,7 @@
     assert.equal(addCount, 7);
   });
 
-  QUnit.test("add multiple models", function(assert) {
+  QUnit.test('add multiple models', function(assert) {
     assert.expect(6);
     var col = new Backbone.Collection([{at: 0}, {at: 1}, {at: 9}]);
     col.add([{at: 2}, {at: 3}, {at: 4}, {at: 5}, {at: 6}, {at: 7}, {at: 8}], {at: 2});
@@ -185,7 +185,7 @@
     }
   });
 
-  QUnit.test("add; at should have preference over comparator", function(assert) {
+  QUnit.test('add; at should have preference over comparator', function(assert) {
     assert.expect(1);
     var Col = Backbone.Collection.extend({
       comparator: function(a, b) {
@@ -199,7 +199,7 @@
     assert.equal(col.pluck('id').join(' '), '3 1 2');
   });
 
-  QUnit.test("add; at should add to the end if the index is out of bounds", function(assert) {
+  QUnit.test('add; at should add to the end if the index is out of bounds', function(assert) {
     assert.expect(1);
     var col = new Backbone.Collection([{id: 2}, {id: 3}]);
     col.add(new Backbone.Model({id: 1}), {at: 5});
@@ -220,7 +220,7 @@
     assert.equal(col.length, 1);
   });
 
-  QUnit.test("merge in duplicate models with {merge: true}", function(assert) {
+  QUnit.test('merge in duplicate models with {merge: true}', function(assert) {
     assert.expect(3);
     var col = new Backbone.Collection;
     col.add([{id: 1, name: 'Moe'}, {id: 2, name: 'Curly'}, {id: 3, name: 'Larry'}]);
@@ -232,7 +232,7 @@
     assert.equal(col.first().get('name'), 'Tim');
   });
 
-  QUnit.test("add model to multiple collections", function(assert) {
+  QUnit.test('add model to multiple collections', function(assert) {
     assert.expect(10);
     var counter = 0;
     var e = new Backbone.Model({id: 10, label: 'e'});
@@ -261,7 +261,7 @@
     assert.equal(e.collection, colE);
   });
 
-  QUnit.test("add model with parse", function(assert) {
+  QUnit.test('add model with parse', function(assert) {
     assert.expect(1);
     var Model = Backbone.Model.extend({
       parse: function(obj) {
@@ -276,7 +276,7 @@
     assert.equal(col.at(0).get('value'), 2);
   });
 
-  QUnit.test("add with parse and merge", function(assert) {
+  QUnit.test('add with parse and merge', function(assert) {
     var collection = new Backbone.Collection();
     collection.parse = function(attrs) {
       return _.map(attrs, function(model) {
@@ -289,7 +289,7 @@
     assert.equal(collection.first().get('name'), 'Alf');
   });
 
-  QUnit.test("add model to collection with sort()-style comparator", function(assert) {
+  QUnit.test('add model to collection with sort()-style comparator', function(assert) {
     assert.expect(3);
     var col = new Backbone.Collection;
     col.comparator = function(a, b) {
@@ -306,7 +306,7 @@
     assert.equal(col.indexOf(tom), 2);
   });
 
-  QUnit.test("comparator that depends on `this`", function(assert) {
+  QUnit.test('comparator that depends on `this`', function(assert) {
     assert.expect(2);
     var col = new Backbone.Collection;
     col.negative = function(num) {
@@ -324,7 +324,7 @@
     assert.deepEqual(col.pluck('id'), [1, 2, 3]);
   });
 
-  QUnit.test("remove", function(assert) {
+  QUnit.test('remove', function(assert) {
     assert.expect(12);
     var removed = null;
     var result = null;
@@ -352,11 +352,11 @@
     assert.deepEqual(result, [], 'returns empty array when nothing removed');
   });
 
-  QUnit.test("add and remove return values", function(assert) {
+  QUnit.test('add and remove return values', function(assert) {
     assert.expect(13);
     var Even = Backbone.Model.extend({
       validate: function(attrs) {
-        if (attrs.id % 2 !== 0) return "odd";
+        if (attrs.id % 2 !== 0) return 'odd';
       }
     });
     var col = new Backbone.Collection;
@@ -386,14 +386,14 @@
     assert.equal(list[1], null);
   });
 
-  QUnit.test("shift and pop", function(assert) {
+  QUnit.test('shift and pop', function(assert) {
     assert.expect(2);
     var col = new Backbone.Collection([{a: 'a'}, {b: 'b'}, {c: 'c'}]);
     assert.equal(col.shift().get('a'), 'a');
     assert.equal(col.pop().get('c'), 'c');
   });
 
-  QUnit.test("slice", function(assert) {
+  QUnit.test('slice', function(assert) {
     assert.expect(2);
     var col = new Backbone.Collection([{a: 'a'}, {b: 'b'}, {c: 'c'}]);
     var array = col.slice(1, 3);
@@ -401,7 +401,7 @@
     assert.equal(array[0].get('b'), 'b');
   });
 
-  QUnit.test("events are unbound on remove", function(assert) {
+  QUnit.test('events are unbound on remove', function(assert) {
     assert.expect(3);
     var counter = 0;
     var dj = new Backbone.Model();
@@ -415,7 +415,7 @@
     assert.equal(counter, 1);
   });
 
-  QUnit.test("remove in multiple collections", function(assert) {
+  QUnit.test('remove in multiple collections', function(assert) {
     assert.expect(7);
     var modelData = {
       id: 5,
@@ -440,7 +440,7 @@
     assert.equal(passed, true);
   });
 
-  QUnit.test("remove same model in multiple collection", function(assert) {
+  QUnit.test('remove same model in multiple collection', function(assert) {
     assert.expect(16);
     var counter = 0;
     var e = new Backbone.Model({id: 5, title: 'Othello'});
@@ -475,7 +475,7 @@
     assert.equal(counter, 2);
   });
 
-  QUnit.test("model destroy removes from all collections", function(assert) {
+  QUnit.test('model destroy removes from all collections', function(assert) {
     assert.expect(3);
     var e = new Backbone.Model({id: 5, title: 'Othello'});
     e.sync = function(method, model, options) { options.success(); };
@@ -487,10 +487,10 @@
     assert.equal(undefined, e.collection);
   });
 
-  QUnit.test("Collection: non-persisted model destroy removes from all collections", function(assert) {
+  QUnit.test('Collection: non-persisted model destroy removes from all collections', function(assert) {
     assert.expect(3);
     var e = new Backbone.Model({title: 'Othello'});
-    e.sync = function(method, model, options) { throw "should not be called"; };
+    e.sync = function(method, model, options) { throw 'should not be called'; };
     var colE = new Backbone.Collection([e]);
     var colF = new Backbone.Collection([e]);
     e.destroy();
@@ -499,7 +499,7 @@
     assert.equal(undefined, e.collection);
   });
 
-  QUnit.test("fetch", function(assert) {
+  QUnit.test('fetch', function(assert) {
     assert.expect(4);
     var collection = new Backbone.Collection;
     collection.url = '/test';
@@ -512,7 +512,7 @@
     assert.equal(this.syncArgs.options.parse, false);
   });
 
-  QUnit.test("fetch with an error response triggers an error event", function(assert) {
+  QUnit.test('fetch with an error response triggers an error event', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection();
     collection.on('error', function() {
@@ -522,7 +522,7 @@
     collection.fetch();
   });
 
-  QUnit.test("#3283 - fetch with an error response calls error with context", function(assert) {
+  QUnit.test('#3283 - fetch with an error response calls error with context', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection();
     var obj = {};
@@ -538,7 +538,7 @@
     collection.fetch(options);
   });
 
-  QUnit.test("ensure fetch only parses once", function(assert) {
+  QUnit.test('ensure fetch only parses once', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection;
     var counter = 0;
@@ -552,7 +552,7 @@
     assert.equal(counter, 1);
   });
 
-  QUnit.test("create", function(assert) {
+  QUnit.test('create', function(assert) {
     assert.expect(4);
     var collection = new Backbone.Collection;
     collection.url = '/test';
@@ -563,11 +563,11 @@
     assert.equal(model.collection, collection);
   });
 
-  QUnit.test("create with validate:true enforces validation", function(assert) {
+  QUnit.test('create with validate:true enforces validation', function(assert) {
     assert.expect(3);
     var ValidatingModel = Backbone.Model.extend({
       validate: function(attrs) {
-        return "fail";
+        return 'fail';
       }
     });
     var ValidatingCollection = Backbone.Collection.extend({
@@ -575,13 +575,13 @@
     });
     var col = new ValidatingCollection();
     col.on('invalid', function(collection, error, options) {
-      assert.equal(error, "fail");
+      assert.equal(error, 'fail');
       assert.equal(options.validationError, 'fail');
     });
-    assert.equal(col.create({"foo": "bar"}, {validate: true}), false);
+    assert.equal(col.create({'foo': 'bar'}, {validate: true}), false);
   });
 
-  QUnit.test("create will pass extra options to success callback", function(assert) {
+  QUnit.test('create will pass extra options to success callback', function(assert) {
     assert.expect(1);
     var Model = Backbone.Model.extend({
       sync: function(method, model, options) {
@@ -598,14 +598,14 @@
     var collection = new Collection;
 
     var success = function(model, response, options) {
-      assert.ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, 'Options were passed correctly to callback');
     };
 
     collection.create({}, {success: success});
     this.ajaxSettings.success();
   });
 
-  QUnit.test("create with wait:true should not call collection.parse", function(assert) {
+  QUnit.test('create with wait:true should not call collection.parse', function(assert) {
     assert.expect(0);
     var Collection = Backbone.Collection.extend({
       url: '/test',
@@ -620,22 +620,22 @@
     this.ajaxSettings.success();
   });
 
-  QUnit.test("a failing create returns model with errors", function(assert) {
+  QUnit.test('a failing create returns model with errors', function(assert) {
     var ValidatingModel = Backbone.Model.extend({
       validate: function(attrs) {
-        return "fail";
+        return 'fail';
       }
     });
     var ValidatingCollection = Backbone.Collection.extend({
       model: ValidatingModel
     });
     var col = new ValidatingCollection();
-    var m = col.create({"foo": "bar"});
+    var m = col.create({'foo': 'bar'});
     assert.equal(m.validationError, 'fail');
     assert.equal(col.length, 1);
   });
 
-  QUnit.test("initialize", function(assert) {
+  QUnit.test('initialize', function(assert) {
     assert.expect(1);
     var Collection = Backbone.Collection.extend({
       initialize: function() {
@@ -646,12 +646,12 @@
     assert.equal(coll.one, 1);
   });
 
-  QUnit.test("toJSON", function(assert) {
+  QUnit.test('toJSON', function(assert) {
     assert.expect(1);
     assert.equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
   });
 
-  QUnit.test("where and findWhere", function(assert) {
+  QUnit.test('where and findWhere', function(assert) {
     assert.expect(8);
     var model = new Backbone.Model({a: 1});
     var coll = new Backbone.Collection([
@@ -671,7 +671,7 @@
     assert.equal(coll.findWhere({a: 4}), void 0);
   });
 
-  QUnit.test("Underscore methods", function(assert) {
+  QUnit.test('Underscore methods', function(assert) {
     assert.expect(21);
     assert.equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
     assert.equal(col.some(function(model){ return model.id === 100; }), false);
@@ -703,7 +703,7 @@
     assert.ok(col.indexBy('id')[first.id] === first);
   });
 
-  QUnit.test("Underscore methods with object-style and property-style iteratee", function(assert) {
+  QUnit.test('Underscore methods with object-style and property-style iteratee', function(assert) {
     assert.expect(26);
     var model = new Backbone.Model({a: 4, b: 1, e: 3});
     var coll = new Backbone.Collection([
@@ -740,7 +740,7 @@
     assert.equal(coll.findLastIndex({b: 9}), -1);
   });
 
-  QUnit.test("reset", function(assert) {
+  QUnit.test('reset', function(assert) {
     assert.expect(16);
     var resetCount = 0;
     var models = col.models;
@@ -772,20 +772,20 @@
     assert.equal(resetCount, 6);
   });
 
-  QUnit.test("reset with different values", function(assert) {
+  QUnit.test('reset with different values', function(assert) {
     var col = new Backbone.Collection({id: 1});
     col.reset({id: 1, a: 1});
     assert.equal(col.get(1).get('a'), 1);
   });
 
-  QUnit.test("same references in reset", function(assert) {
+  QUnit.test('same references in reset', function(assert) {
     var model = new Backbone.Model({id: 1});
     var collection = new Backbone.Collection({id: 1});
     collection.reset(model);
     assert.equal(collection.get(1), model);
   });
 
-  QUnit.test("reset passes caller options", function(assert) {
+  QUnit.test('reset passes caller options', function(assert) {
     assert.expect(3);
     var Model = Backbone.Model.extend({
       initialize: function(attrs, options) {
@@ -793,33 +793,33 @@
       }
     });
     var col = new (Backbone.Collection.extend({model: Model}))();
-    col.reset([{astring: "green", anumber: 1}, {astring: "blue", anumber: 2}], {model_parameter: 'model parameter'});
+    col.reset([{astring: 'green', anumber: 1}, {astring: 'blue', anumber: 2}], {model_parameter: 'model parameter'});
     assert.equal(col.length, 2);
     col.each(function(model) {
       assert.equal(model.model_parameter, 'model parameter');
     });
   });
 
-  QUnit.test("reset does not alter options by reference", function(assert) {
+  QUnit.test('reset does not alter options by reference', function(assert) {
     assert.expect(2);
     var col = new Backbone.Collection([{id: 1}]);
     var origOpts = {};
-    col.on("reset", function(col, opts){
+    col.on('reset', function(col, opts){
       assert.equal(origOpts.previousModels, undefined);
       assert.equal(opts.previousModels[0].id, 1);
     });
     col.reset([], origOpts);
   });
 
-  QUnit.test("trigger custom events on models", function(assert) {
+  QUnit.test('trigger custom events on models', function(assert) {
     assert.expect(1);
     var fired = null;
-    a.on("custom", function() { fired = true; });
-    a.trigger("custom");
+    a.on('custom', function() { fired = true; });
+    a.trigger('custom');
     assert.equal(fired, true);
   });
 
-  QUnit.test("add does not alter arguments", function(assert) {
+  QUnit.test('add does not alter arguments', function(assert) {
     assert.expect(2);
     var attrs = {};
     var models = [attrs];
@@ -828,7 +828,7 @@
     assert.ok(attrs === models[0]);
   });
 
-  QUnit.test("#714: access `model.collection` in a brand new model.", function(assert) {
+  QUnit.test('#714: access `model.collection` in a brand new model.', function(assert) {
     assert.expect(2);
     var collection = new Backbone.Collection;
     collection.url = '/test';
@@ -843,7 +843,7 @@
     collection.create({prop: 'value'});
   });
 
-  QUnit.test("#574, remove its own reference to the .models array.", function(assert) {
+  QUnit.test('#574, remove its own reference to the .models array.', function(assert) {
     assert.expect(2);
     var col = new Backbone.Collection([
       {id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}
@@ -853,7 +853,7 @@
     assert.equal(col.length, 0);
   });
 
-  QUnit.test("#861, adding models to a collection which do not pass validation, with validate:true", function(assert) {
+  QUnit.test('#861, adding models to a collection which do not pass validation, with validate:true', function(assert) {
     assert.expect(2);
     var Model = Backbone.Model.extend({
       validate: function(attrs) {
@@ -866,13 +866,13 @@
     });
 
     var collection = new Collection;
-    collection.on("invalid", function() { assert.ok(true); });
+    collection.on('invalid', function() { assert.ok(true); });
 
     collection.add([{id: 1}, {id: 2}, {id: 3}, {id: 4}, {id: 5}, {id: 6}], {validate: true});
-    assert.deepEqual(collection.pluck("id"), [1, 2, 4, 5, 6]);
+    assert.deepEqual(collection.pluck('id'), [1, 2, 4, 5, 6]);
   });
 
-  QUnit.test("Invalid models are discarded with validate:true.", function(assert) {
+  QUnit.test('Invalid models are discarded with validate:true.', function(assert) {
     assert.expect(5);
     var collection = new Backbone.Collection;
     collection.on('test', function() { assert.ok(true); });
@@ -888,7 +888,7 @@
     assert.equal(collection.length, 1);
   });
 
-  QUnit.test("multiple copies of the same model", function(assert) {
+  QUnit.test('multiple copies of the same model', function(assert) {
     assert.expect(3);
     var col = new Backbone.Collection();
     var model = new Backbone.Model();
@@ -899,14 +899,14 @@
     assert.equal(col.last().id, 1);
   });
 
-  QUnit.test("#964 - collection.get return inconsistent", function(assert) {
+  QUnit.test('#964 - collection.get return inconsistent', function(assert) {
     assert.expect(2);
     var c = new Backbone.Collection();
     assert.ok(c.get(null) === undefined);
     assert.ok(c.get() === undefined);
   });
 
-  QUnit.test("#1112 - passing options.model sets collection.model", function(assert) {
+  QUnit.test('#1112 - passing options.model sets collection.model', function(assert) {
     assert.expect(2);
     var Model = Backbone.Model.extend({});
     var c = new Backbone.Collection([{id: 1}], {model: Model});
@@ -914,7 +914,7 @@
     assert.ok(c.at(0) instanceof Model);
   });
 
-  QUnit.test("null and undefined are invalid ids.", function(assert) {
+  QUnit.test('null and undefined are invalid ids.', function(assert) {
     assert.expect(2);
     var model = new Backbone.Model({id: 1});
     var collection = new Backbone.Collection([model]);
@@ -925,7 +925,7 @@
     assert.ok(!collection.get('undefined'));
   });
 
-  QUnit.test("falsy comparator", function(assert) {
+  QUnit.test('falsy comparator', function(assert) {
     assert.expect(4);
     var Col = Backbone.Collection.extend({
       comparator: function(model){ return model.id; }
@@ -940,7 +940,7 @@
     assert.ok(colUndefined.comparator);
   });
 
-  QUnit.test("#1355 - `options` is passed to success callbacks", function(assert) {
+  QUnit.test('#1355 - `options` is passed to success callbacks', function(assert) {
     assert.expect(2);
     var m = new Backbone.Model({x: 1});
     var col = new Backbone.Collection();
@@ -982,7 +982,7 @@
     collection.off();
   });
 
-  QUnit.test("#3283 - fetch, create calls success with context", function(assert) {
+  QUnit.test('#3283 - fetch, create calls success with context', function(assert) {
     assert.expect(2);
     var collection = new Backbone.Collection;
     collection.url = '/test';
@@ -1001,7 +1001,7 @@
     collection.create({id: 1}, options);
   });
 
-  QUnit.test("#1447 - create with wait adds model.", function(assert) {
+  QUnit.test('#1447 - create with wait adds model.', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection;
     var model = new Backbone.Model;
@@ -1010,7 +1010,7 @@
     collection.create(model, {wait: true});
   });
 
-  QUnit.test("#1448 - add sorts collection after merge.", function(assert) {
+  QUnit.test('#1448 - add sorts collection after merge.', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection([
       {id: 1, x: 1},
@@ -1021,7 +1021,7 @@
     assert.deepEqual(collection.pluck('id'), [2, 1]);
   });
 
-  QUnit.test("#1655 - groupBy can be used with a string argument.", function(assert) {
+  QUnit.test('#1655 - groupBy can be used with a string argument.', function(assert) {
     assert.expect(3);
     var collection = new Backbone.Collection([{x: 1}, {x: 2}]);
     var grouped = collection.groupBy('x');
@@ -1030,7 +1030,7 @@
     assert.strictEqual(grouped[2][0].get('x'), 2);
   });
 
-  QUnit.test("#1655 - sortBy can be used with a string argument.", function(assert) {
+  QUnit.test('#1655 - sortBy can be used with a string argument.', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection([{x: 3}, {x: 1}, {x: 2}]);
     var values = _.map(collection.sortBy('x'), function(model) {
@@ -1039,7 +1039,7 @@
     assert.deepEqual(values, [1, 2, 3]);
   });
 
-  QUnit.test("#1604 - Removal during iteration.", function(assert) {
+  QUnit.test('#1604 - Removal during iteration.', function(assert) {
     assert.expect(0);
     var collection = new Backbone.Collection([{}, {}]);
     collection.on('add', function() {
@@ -1048,7 +1048,7 @@
     collection.add({}, {at: 0});
   });
 
-  QUnit.test("#1638 - `sort` during `add` triggers correctly.", function(assert) {
+  QUnit.test('#1638 - `sort` during `add` triggers correctly.', function(assert) {
     var collection = new Backbone.Collection;
     collection.comparator = function(model) { return model.get('x'); };
     var added = [];
@@ -1061,7 +1061,7 @@
     assert.deepEqual(added, [1, 2]);
   });
 
-  QUnit.test("fetch parses models by default", function(assert) {
+  QUnit.test('fetch parses models by default', function(assert) {
     assert.expect(1);
     var model = {};
     var Collection = Backbone.Collection.extend({
@@ -1088,7 +1088,7 @@
     c.add({id: 4});
   });
 
-  QUnit.test("#1407 parse option on constructor parses collection and models", function(assert) {
+  QUnit.test('#1407 parse option on constructor parses collection and models', function(assert) {
     assert.expect(2);
     var model = {
       namespace: [{id: 1}, {id: 2}]
@@ -1110,7 +1110,7 @@
     assert.equal(c.at(0).get('name'), 'test');
   });
 
-  QUnit.test("#1407 parse option on reset parses collection and models", function(assert) {
+  QUnit.test('#1407 parse option on reset parses collection and models', function(assert) {
     assert.expect(2);
     var model = {
       namespace: [{id: 1}, {id: 2}]
@@ -1134,7 +1134,7 @@
   });
 
 
-  QUnit.test("Reset includes previous models in triggered event.", function(assert) {
+  QUnit.test('Reset includes previous models in triggered event.', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     var collection = new Backbone.Collection([model])
@@ -1144,7 +1144,7 @@
     collection.reset([]);
   });
 
-  QUnit.test("set", function(assert) {
+  QUnit.test('set', function(assert) {
     var m1 = new Backbone.Model();
     var m2 = new Backbone.Model({id: 2});
     var m3 = new Backbone.Model();
@@ -1197,7 +1197,7 @@
     assert.strictEqual(c.length, 1);
   });
 
-  QUnit.test("set with only cids", function(assert) {
+  QUnit.test('set with only cids', function(assert) {
     assert.expect(3);
     var m1 = new Backbone.Model;
     var m2 = new Backbone.Model;
@@ -1210,7 +1210,7 @@
     assert.equal(c.length, 2);
   });
 
-  QUnit.test("set with only idAttribute", function(assert) {
+  QUnit.test('set with only idAttribute', function(assert) {
     assert.expect(3);
     var m1 = {_id: 1};
     var m2 = {_id: 2};
@@ -1228,7 +1228,7 @@
     assert.equal(c.length, 2);
   });
 
-  QUnit.test("set + merge with default values defined", function(assert) {
+  QUnit.test('set + merge with default values defined', function(assert) {
     var Model = Backbone.Model.extend({
       defaults: {
         key: 'value'
@@ -1264,7 +1264,7 @@
     assert.deepEqual(collection.pluck('id'), [2, 1]);
   });
 
-  QUnit.test("`set` and model level `parse`", function(assert) {
+  QUnit.test('`set` and model level `parse`', function(assert) {
     var Model = Backbone.Model.extend({});
     var Collection = Backbone.Collection.extend({
       model: Model,
@@ -1279,7 +1279,7 @@
     assert.equal(collection.first(), model);
   });
 
-  QUnit.test("`set` data is only parsed once", function(assert) {
+  QUnit.test('`set` data is only parsed once', function(assert) {
     var collection = new Backbone.Collection();
     collection.model = Backbone.Model.extend({
       parse: function(data) {
@@ -1310,7 +1310,7 @@
     assert.deepEqual(collection.models, [one, two, three]);
   });
 
-  QUnit.test("#1894 - Push should not trigger a sort", function(assert) {
+  QUnit.test('#1894 - Push should not trigger a sort', function(assert) {
     assert.expect(0);
     var Collection = Backbone.Collection.extend({
       comparator: 'id',
@@ -1319,7 +1319,7 @@
     new Collection().push({id: 1});
   });
 
-  QUnit.test("#2428 - push duplicate models, return the correct one", function(assert) {
+  QUnit.test('#2428 - push duplicate models, return the correct one', function(assert) {
     assert.expect(1);
     var col = new Backbone.Collection;
     var model1 = col.push({id: 101});
@@ -1327,7 +1327,7 @@
     assert.ok(model2.cid == model1.cid);
   });
 
-  QUnit.test("`set` with non-normal id", function(assert) {
+  QUnit.test('`set` with non-normal id', function(assert) {
     var Collection = Backbone.Collection.extend({
       model: Backbone.Model.extend({idAttribute: '_id'})
     });
@@ -1336,7 +1336,7 @@
     assert.equal(collection.first().get('a'), 1);
   });
 
-  QUnit.test("#1894 - `sort` can optionally be turned off", function(assert) {
+  QUnit.test('#1894 - `sort` can optionally be turned off', function(assert) {
     assert.expect(0);
     var Collection = Backbone.Collection.extend({
       comparator: 'id',
@@ -1345,7 +1345,7 @@
     new Collection().add({id: 1}, {sort: false});
   });
 
-  QUnit.test("#1915 - `parse` data in the right order in `set`", function(assert) {
+  QUnit.test('#1915 - `parse` data in the right order in `set`', function(assert) {
     var collection = new (Backbone.Collection.extend({
       parse: function(data) {
         assert.strictEqual(data.status, 'ok');
@@ -1356,7 +1356,7 @@
     collection.set(res, {parse: true});
   });
 
-  QUnit.test("#1939 - `parse` is passed `options`", function(assert) {
+  QUnit.test('#1939 - `parse` is passed `options`', function(assert) {
     var done = assert.async();
     assert.expect(1);
     var collection = new (Backbone.Collection.extend({
@@ -1377,7 +1377,7 @@
     Backbone.ajax = ajax;
   });
 
-  QUnit.test("fetch will pass extra options to success callback", function(assert) {
+  QUnit.test('fetch will pass extra options to success callback', function(assert) {
     assert.expect(1);
     var SpecialSyncCollection = Backbone.Collection.extend({
       url: '/test',
@@ -1390,14 +1390,14 @@
     var collection = new SpecialSyncCollection();
 
     var onSuccess = function(collection, resp, options) {
-      assert.ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, 'Options were passed correctly to callback');
     };
 
     collection.fetch({success: onSuccess});
     this.ajaxSettings.success();
   });
 
-  QUnit.test("`add` only `sort`s when necessary", function(assert) {
+  QUnit.test('`add` only `sort`s when necessary', function(assert) {
     assert.expect(2);
     var collection = new (Backbone.Collection.extend({
       comparator: 'a'
@@ -1411,7 +1411,7 @@
     collection.add(collection.models, {merge: true}); // don't sort
   });
 
-  QUnit.test("`add` only `sort`s when necessary with comparator function", function(assert) {
+  QUnit.test('`add` only `sort`s when necessary with comparator function', function(assert) {
     assert.expect(3);
     var collection = new (Backbone.Collection.extend({
       comparator: function(a, b) {
@@ -1427,7 +1427,7 @@
     collection.add(collection.models, {merge: true}); // don't sort
   });
 
-  QUnit.test("Attach options to collection.", function(assert) {
+  QUnit.test('Attach options to collection.', function(assert) {
     assert.expect(2);
     var Model = Backbone.Model;
     var comparator = function(){};
@@ -1441,7 +1441,7 @@
     assert.ok(collection.comparator === comparator);
   });
 
-  QUnit.test("Pass falsey for `models` for empty Col with `options`", function(assert) {
+  QUnit.test('Pass falsey for `models` for empty Col with `options`', function(assert) {
     assert.expect(9);
     var opts = {a: 1, b: 2};
     _.forEach([undefined, null, false], function(falsey) {
@@ -1457,7 +1457,7 @@
     });
   });
 
-  QUnit.test("`add` overrides `set` flags", function(assert) {
+  QUnit.test('`add` overrides `set` flags', function(assert) {
     var collection = new Backbone.Collection();
     collection.once('add', function(model, collection, options) {
       collection.add({id: 2}, options);
@@ -1466,7 +1466,7 @@
     assert.equal(collection.length, 2);
   });
 
-  QUnit.test("#2606 - Collection#create, success arguments", function(assert) {
+  QUnit.test('#2606 - Collection#create, success arguments', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection;
     collection.url = 'test';
@@ -1478,7 +1478,7 @@
     this.ajaxSettings.success('response');
   });
 
-  QUnit.test("#2612 - nested `parse` works with `Collection#set`", function(assert) {
+  QUnit.test('#2612 - nested `parse` works with `Collection#set`', function(assert) {
 
     var Job = Backbone.Model.extend({
       constructor: function() {
@@ -1614,7 +1614,7 @@
     assert.strictEqual(collection.models.length, 0);
   });
 
-  QUnit.test("create with wait, model instance, #3028", function(assert) {
+  QUnit.test('create with wait, model instance, #3028', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection();
     var model = new Backbone.Model({id: 1});
@@ -1624,7 +1624,7 @@
     collection.create(model, {wait: true});
   });
 
-  QUnit.test("modelId", function(assert) {
+  QUnit.test('modelId', function(assert) {
     var Stooge = Backbone.Model.extend();
     var StoogeCollection = Backbone.Collection.extend({model: Stooge});
 
@@ -1686,7 +1686,7 @@
     assert.equal(collection.at(1), collection.get('b-1'));
   });
 
-  QUnit.test("#3039: adding at index fires with correct at", function(assert) {
+  QUnit.test('#3039: adding at index fires with correct at', function(assert) {
     assert.expect(3);
     var col = new Backbone.Collection([{at: 0}, {at: 4}]);
     col.on('add', function(model, col, options) {
@@ -1695,7 +1695,7 @@
     col.add([{at: 1}, {at: 2}, {at: 3}], {at: 1});
   });
 
-  QUnit.test("#3039: index is not sent when at is not specified", function(assert) {
+  QUnit.test('#3039: index is not sent when at is not specified', function(assert) {
     assert.expect(2);
     var col = new Backbone.Collection([{at: 0}]);
     col.on('add', function(model, col, options) {
@@ -1740,58 +1740,58 @@
     collection.set([{id: 1}, {id: 2}, {id: 3}]);
   });
 
-  QUnit.test("add supports negative indexes", function(assert) {
+  QUnit.test('add supports negative indexes', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection([{id: 1}]);
     collection.add([{id: 2}, {id: 3}], {at: -1});
     collection.add([{id: 2.5}], {at: -2});
     collection.add([{id: 0.5}], {at: -6});
-    assert.equal(collection.pluck('id').join(','), "0.5,1,2,2.5,3");
+    assert.equal(collection.pluck('id').join(','), '0.5,1,2,2.5,3');
   });
 
-  QUnit.test("#set accepts options.at as a string", function(assert) {
+  QUnit.test('#set accepts options.at as a string', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
     collection.add([{id: 3}], {at: '1'});
     assert.deepEqual(collection.pluck('id'), [1, 3, 2]);
   });
 
-  QUnit.test("adding multiple models triggers `update` event once", function(assert) {
+  QUnit.test('adding multiple models triggers `update` event once', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection;
     collection.on('update', function() { assert.ok(true); });
     collection.add([{id: 1}, {id: 2}, {id: 3}]);
   });
 
-  QUnit.test("removing models triggers `update` event once", function(assert) {
+  QUnit.test('removing models triggers `update` event once', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}, {id: 3}]);
     collection.on('update', function() { assert.ok(true); });
     collection.remove([{id: 1}, {id: 2}]);
   });
 
-  QUnit.test("remove does not trigger `set` when nothing removed", function(assert) {
+  QUnit.test('remove does not trigger `set` when nothing removed', function(assert) {
     assert.expect(0);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
     collection.on('update', function() { assert.ok(false); });
     collection.remove([{id: 3}]);
   });
 
-  QUnit.test("set triggers `set` event once", function(assert) {
+  QUnit.test('set triggers `set` event once', function(assert) {
     assert.expect(1);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
     collection.on('update', function() { assert.ok(true); });
     collection.set([{id: 1}, {id: 3}]);
   });
 
-  QUnit.test("set does not trigger `update` event when nothing added nor removed", function(assert) {
+  QUnit.test('set does not trigger `update` event when nothing added nor removed', function(assert) {
     assert.expect(0);
     var collection = new Backbone.Collection([{id: 1}, {id: 2}]);
     collection.on('update', function() { assert.ok(false); });
     collection.set([{id: 1}, {id: 2}]);
   });
 
-  QUnit.test("#3610 - invoke collects arguments", function(assert) {
+  QUnit.test('#3610 - invoke collects arguments', function(assert) {
     assert.expect(3);
     var Model = Backbone.Model.extend({
       method: function(a, b, c) {

--- a/test/collection.js
+++ b/test/collection.js
@@ -1139,7 +1139,7 @@
     var model = new Backbone.Model();
     var collection = new Backbone.Collection([model])
     .on('reset', function(collection, options) {
-      deepEqual(options.previousModels, [model]);
+      assert.deepEqual(options.previousModels, [model]);
     });
     collection.reset([]);
   });
@@ -1402,7 +1402,7 @@
     var collection = new (Backbone.Collection.extend({
       comparator: 'a'
     }))([{id: 1}, {id: 2}, {id: 3}]);
-    collection.on('sort', function() { ok(true); });
+    collection.on('sort', function() { assert.ok(true); });
     collection.add({id: 4}); // do sort, new model
     collection.add({id: 1, a: 1}, {merge: true}); // do sort, comparator change
     collection.add({id: 1, b: 1}, {merge: true}); // don't sort, no comparator change
@@ -1418,7 +1418,7 @@
         return a.get('a') > b.get('a') ? 1 : (a.get('a') < b.get('a') ? -1 : 0);
       }
     }))([{id: 1}, {id: 2}, {id: 3}]);
-    collection.on('sort', function() { ok(true); });
+    collection.on('sort', function() { assert.ok(true); });
     collection.add({id: 4}); // do sort, new model
     collection.add({id: 1, a: 1}, {merge: true}); // do sort, model change
     collection.add({id: 1, b: 1}, {merge: true}); // do sort, model change

--- a/test/collection.js
+++ b/test/collection.js
@@ -676,8 +676,8 @@
     assert.equal(col.map(function(model){ return model.get('label'); }).join(' '), 'a b c d');
     assert.equal(col.some(function(model){ return model.id === 100; }), false);
     assert.equal(col.some(function(model){ return model.id === 0; }), true);
-    assert.equal(col.reduce(function(a, b) {return a.id > b.id ? a : b}).id, 3);
-    assert.equal(col.reduceRight(function(a, b) {return a.id > b.id ? a : b}).id, 3);
+    assert.equal(col.reduce(function(a, b) {return a.id > b.id ? a : b;}).id, 3);
+    assert.equal(col.reduceRight(function(a, b) {return a.id > b.id ? a : b;}).id, 3);
     assert.equal(col.indexOf(b), 1);
     assert.equal(col.size(), 4);
     assert.equal(col.rest().length, 3);

--- a/test/collection.js
+++ b/test/collection.js
@@ -630,7 +630,7 @@
       model: ValidatingModel
     });
     var col = new ValidatingCollection();
-    var m = col.create({'foo': 'bar'});
+    var m = col.create({foo: 'bar'});
     assert.equal(m.validationError, 'fail');
     assert.equal(col.length, 1);
   });

--- a/test/collection.js
+++ b/test/collection.js
@@ -789,14 +789,14 @@
     assert.expect(3);
     var Model = Backbone.Model.extend({
       initialize: function(attrs, options) {
-        this.model_parameter = options.model_parameter;
+        this.modelParameter = options.modelParameter;
       }
     });
     var col = new (Backbone.Collection.extend({model: Model}))();
-    col.reset([{astring: 'green', anumber: 1}, {astring: 'blue', anumber: 2}], {model_parameter: 'model parameter'});
+    col.reset([{astring: 'green', anumber: 1}, {astring: 'blue', anumber: 2}], {modelParameter: 'model parameter'});
     assert.equal(col.length, 2);
     col.each(function(model) {
-      assert.equal(model.model_parameter, 'model parameter');
+      assert.equal(model.modelParameter, 'model parameter');
     });
   });
 

--- a/test/events.js
+++ b/test/events.js
@@ -1,8 +1,8 @@
 (function() {
 
-  QUnit.module("Backbone.Events");
+  QUnit.module('Backbone.Events');
 
-  QUnit.test("on and trigger", function(assert) {
+  QUnit.test('on and trigger', function(assert) {
     assert.expect(2);
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
@@ -16,7 +16,7 @@
     assert.equal(obj.counter, 5, 'counter should be incremented five times.');
   });
 
-  QUnit.test("binding and triggering multiple events", function(assert) {
+  QUnit.test('binding and triggering multiple events', function(assert) {
     assert.expect(4);
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
@@ -37,7 +37,7 @@
     assert.equal(obj.counter, 5);
   });
 
-  QUnit.test("binding and triggering with event maps", function(assert) {
+  QUnit.test('binding and triggering with event maps', function(assert) {
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
 
@@ -68,7 +68,7 @@
     assert.equal(obj.counter, 5);
   });
 
-  QUnit.test("binding and triggering multiple event names with event maps", function(assert) {
+  QUnit.test('binding and triggering multiple event names with event maps', function(assert) {
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
 
@@ -96,7 +96,7 @@
     assert.equal(obj.counter, 5);
   });
 
-  QUnit.test("binding and trigger with event maps context", function(assert) {
+  QUnit.test('binding and trigger with event maps context', function(assert) {
     assert.expect(2);
     var obj = {counter: 0};
     var context = {};
@@ -115,7 +115,7 @@
     }, this, context).trigger('a');
   });
 
-  QUnit.test("listenTo and stopListening", function(assert) {
+  QUnit.test('listenTo and stopListening', function(assert) {
     assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -126,7 +126,7 @@
     b.trigger('anything');
   });
 
-  QUnit.test("listenTo and stopListening with event maps", function(assert) {
+  QUnit.test('listenTo and stopListening with event maps', function(assert) {
     assert.expect(4);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -141,7 +141,7 @@
     b.trigger('event event2');
   });
 
-  QUnit.test("stopListening with omitted args", function(assert) {
+  QUnit.test('stopListening with omitted args', function(assert) {
     assert.expect(2);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -158,7 +158,7 @@
     b.trigger('event2');
   });
 
-  QUnit.test("listenToOnce", function(assert) {
+  QUnit.test('listenToOnce', function(assert) {
     assert.expect(2);
     // Same as the previous test, but we use once rather than having to explicitly unbind
     var obj = {counterA: 0, counterB: 0};
@@ -172,7 +172,7 @@
     assert.equal(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
 
-  QUnit.test("listenToOnce and stopListening", function(assert) {
+  QUnit.test('listenToOnce and stopListening', function(assert) {
     assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -184,7 +184,7 @@
     b.trigger('anything');
   });
 
-  QUnit.test("listenTo, listenToOnce and stopListening", function(assert) {
+  QUnit.test('listenTo, listenToOnce and stopListening', function(assert) {
     assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -196,7 +196,7 @@
     b.trigger('anything');
   });
 
-  QUnit.test("listenTo and stopListening with event maps", function(assert) {
+  QUnit.test('listenTo and stopListening with event maps', function(assert) {
     assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -207,23 +207,23 @@
     b.trigger('change');
   });
 
-  QUnit.test("listenTo yourself", function(assert) {
+  QUnit.test('listenTo yourself', function(assert) {
     assert.expect(1);
     var e = _.extend({}, Backbone.Events);
-    e.listenTo(e, "foo", function(){ assert.ok(true); });
-    e.trigger("foo");
+    e.listenTo(e, 'foo', function(){ assert.ok(true); });
+    e.trigger('foo');
   });
 
-  QUnit.test("listenTo yourself cleans yourself up with stopListening", function(assert) {
+  QUnit.test('listenTo yourself cleans yourself up with stopListening', function(assert) {
     assert.expect(1);
     var e = _.extend({}, Backbone.Events);
-    e.listenTo(e, "foo", function(){ assert.ok(true); });
-    e.trigger("foo");
+    e.listenTo(e, 'foo', function(){ assert.ok(true); });
+    e.trigger('foo');
     e.stopListening();
-    e.trigger("foo");
+    e.trigger('foo');
   });
 
-  QUnit.test("stopListening cleans up references", function(assert) {
+  QUnit.test('stopListening cleans up references', function(assert) {
     assert.expect(12);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -247,7 +247,7 @@
     assert.equal(_.size(b._listeners), 0);
   });
 
-  QUnit.test("stopListening cleans up references from listenToOnce", function(assert) {
+  QUnit.test('stopListening cleans up references from listenToOnce', function(assert) {
     assert.expect(12);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -271,7 +271,7 @@
     assert.equal(_.size(b._listeners), 0);
   });
 
-  QUnit.test("listenTo and off cleaning up references", function(assert) {
+  QUnit.test('listenTo and off cleaning up references', function(assert) {
     assert.expect(8);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -294,7 +294,7 @@
     assert.equal(_.size(b._listeners), 0);
   });
 
-  QUnit.test("listenTo and stopListening cleaning up references", function(assert) {
+  QUnit.test('listenTo and stopListening cleaning up references', function(assert) {
     assert.expect(2);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -306,7 +306,7 @@
     assert.equal(_.size(a._listeningTo), 0);
   });
 
-  QUnit.test("listenToOnce without context cleans up references after the event has fired", function(assert) {
+  QUnit.test('listenToOnce without context cleans up references after the event has fired', function(assert) {
     assert.expect(2);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -315,7 +315,7 @@
     assert.equal(_.size(a._listeningTo), 0);
   });
 
-  QUnit.test("listenToOnce with event maps cleans up references", function(assert) {
+  QUnit.test('listenToOnce with event maps cleans up references', function(assert) {
     assert.expect(2);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -327,7 +327,7 @@
     assert.equal(_.size(a._listeningTo), 1);
   });
 
-  QUnit.test("listenToOnce with event maps binds the correct `this`", function(assert) {
+  QUnit.test('listenToOnce with event maps binds the correct `this`', function(assert) {
     assert.expect(1);
     var a = _.extend({}, Backbone.Events);
     var b = _.extend({}, Backbone.Events);
@@ -341,12 +341,12 @@
   QUnit.test("listenTo with empty callback doesn't throw an error", function(assert) {
     assert.expect(1);
     var e = _.extend({}, Backbone.Events);
-    e.listenTo(e, "foo", null);
-    e.trigger("foo");
+    e.listenTo(e, 'foo', null);
+    e.trigger('foo');
     assert.ok(true);
   });
 
-  QUnit.test("trigger all for each event", function(assert) {
+  QUnit.test('trigger all for each event', function(assert) {
     assert.expect(3);
     var a, b, obj = {counter: 0};
     _.extend(obj, Backbone.Events);
@@ -361,7 +361,7 @@
     assert.equal(obj.counter, 2);
   });
 
-  QUnit.test("on, then unbind all functions", function(assert) {
+  QUnit.test('on, then unbind all functions', function(assert) {
     assert.expect(1);
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
@@ -373,7 +373,7 @@
     assert.equal(obj.counter, 1, 'counter should have only been incremented once.');
   });
 
-  QUnit.test("bind two callbacks, unbind only one", function(assert) {
+  QUnit.test('bind two callbacks, unbind only one', function(assert) {
     assert.expect(2);
     var obj = {counterA: 0, counterB: 0};
     _.extend(obj, Backbone.Events);
@@ -387,7 +387,7 @@
     assert.equal(obj.counterB, 2, 'counterB should have been incremented twice.');
   });
 
-  QUnit.test("unbind a callback in the midst of it firing", function(assert) {
+  QUnit.test('unbind a callback in the midst of it firing', function(assert) {
     assert.expect(1);
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
@@ -402,7 +402,7 @@
     assert.equal(obj.counter, 1, 'the callback should have been unbound.');
   });
 
-  QUnit.test("two binds that unbind themeselves", function(assert) {
+  QUnit.test('two binds that unbind themeselves', function(assert) {
     assert.expect(2);
     var obj = {counterA: 0, counterB: 0};
     _.extend(obj, Backbone.Events);
@@ -417,7 +417,7 @@
     assert.equal(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
 
-  QUnit.test("bind a callback with a supplied context", function(assert) {
+  QUnit.test('bind a callback with a supplied context', function(assert) {
     assert.expect(1);
     var TestClass = function() {
       return this;
@@ -431,7 +431,7 @@
     obj.trigger('event');
   });
 
-  QUnit.test("nested trigger with unbind", function(assert) {
+  QUnit.test('nested trigger with unbind', function(assert) {
     assert.expect(1);
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
@@ -443,7 +443,7 @@
     assert.equal(obj.counter, 3, 'counter should have been incremented three times');
   });
 
-  QUnit.test("callback list is not altered during trigger", function(assert) {
+  QUnit.test('callback list is not altered during trigger', function(assert) {
     assert.expect(2);
     var counter = 0, obj = _.extend({}, Backbone.Events);
     var incr = function(){ counter++; };
@@ -469,12 +469,12 @@
     assert.strictEqual(counter, 2);
   });
 
-  QUnit.test("if no callback is provided, `on` is a noop", function(assert) {
+  QUnit.test('if no callback is provided, `on` is a noop', function(assert) {
     assert.expect(0);
     _.extend({}, Backbone.Events).on('test').trigger('test');
   });
 
-  QUnit.test("if callback is truthy but not a function, `on` should throw an error just like jQuery", function(assert) {
+  QUnit.test('if callback is truthy but not a function, `on` should throw an error just like jQuery', function(assert) {
     assert.expect(1);
     var view = _.extend({}, Backbone.Events).on('test', 'noop');
     assert.throws(function() {
@@ -482,7 +482,7 @@
     });
   });
 
-  QUnit.test("remove all events for a specific context", function(assert) {
+  QUnit.test('remove all events for a specific context', function(assert) {
     assert.expect(4);
     var obj = _.extend({}, Backbone.Events);
     obj.on('x y all', function() { assert.ok(true); });
@@ -491,7 +491,7 @@
     obj.trigger('x y');
   });
 
-  QUnit.test("remove all events for a specific callback", function(assert) {
+  QUnit.test('remove all events for a specific callback', function(assert) {
     assert.expect(4);
     var obj = _.extend({}, Backbone.Events);
     var success = function() { assert.ok(true); };
@@ -502,7 +502,7 @@
     obj.trigger('x y');
   });
 
-  QUnit.test("#1310 - off does not skip consecutive events", function(assert) {
+  QUnit.test('#1310 - off does not skip consecutive events', function(assert) {
     assert.expect(0);
     var obj = _.extend({}, Backbone.Events);
     obj.on('event', function() { assert.ok(false); }, obj);
@@ -511,7 +511,7 @@
     obj.trigger('event');
   });
 
-  QUnit.test("once", function(assert) {
+  QUnit.test('once', function(assert) {
     assert.expect(2);
     // Same as the previous test, but we use once rather than having to explicitly unbind
     var obj = {counterA: 0, counterB: 0};
@@ -525,7 +525,7 @@
     assert.equal(obj.counterB, 1, 'counterB should have only been incremented once.');
   });
 
-  QUnit.test("once variant one", function(assert) {
+  QUnit.test('once variant one', function(assert) {
     assert.expect(3);
     var f = function(){ assert.ok(true); };
 
@@ -538,7 +538,7 @@
     b.trigger('event');
   });
 
-  QUnit.test("once variant two", function(assert) {
+  QUnit.test('once variant two', function(assert) {
     assert.expect(3);
     var f = function(){ assert.ok(true); };
     var obj = _.extend({}, Backbone.Events);
@@ -550,7 +550,7 @@
       .trigger('event');
   });
 
-  QUnit.test("once with off", function(assert) {
+  QUnit.test('once with off', function(assert) {
     assert.expect(0);
     var f = function(){ assert.ok(true); };
     var obj = _.extend({}, Backbone.Events);
@@ -560,7 +560,7 @@
     obj.trigger('event');
   });
 
-  QUnit.test("once with event maps", function(assert) {
+  QUnit.test('once with event maps', function(assert) {
     var obj = {counter: 0};
     _.extend(obj, Backbone.Events);
 
@@ -587,7 +587,7 @@
     assert.equal(obj.counter, 3);
   });
 
-  QUnit.test("once with off only by context", function(assert) {
+  QUnit.test('once with off only by context', function(assert) {
     assert.expect(0);
     var context = {};
     var obj = _.extend({}, Backbone.Events);
@@ -596,11 +596,11 @@
     obj.trigger('event');
   });
 
-  QUnit.test("Backbone object inherits Events", function(assert) {
+  QUnit.test('Backbone object inherits Events', function(assert) {
     assert.ok(Backbone.on === Backbone.Events.on);
   });
 
-  QUnit.test("once with asynchronous events", function(assert) {
+  QUnit.test('once with asynchronous events', function(assert) {
     var done = assert.async();
     assert.expect(1);
     var func = _.debounce(function() { assert.ok(true); done(); }, 50);
@@ -610,14 +610,14 @@
     obj.trigger('async');
   });
 
-  QUnit.test("once with multiple events.", function(assert) {
+  QUnit.test('once with multiple events.', function(assert) {
     assert.expect(2);
     var obj = _.extend({}, Backbone.Events);
     obj.once('x y', function() { assert.ok(true); });
     obj.trigger('x y');
   });
 
-  QUnit.test("Off during iteration with once.", function(assert) {
+  QUnit.test('Off during iteration with once.', function(assert) {
     assert.expect(2);
     var obj = _.extend({}, Backbone.Events);
     var f = function(){ this.off('event', f); };
@@ -629,7 +629,7 @@
     obj.trigger('event');
   });
 
-  QUnit.test("`once` on `all` should work as expected", function(assert) {
+  QUnit.test('`once` on `all` should work as expected', function(assert) {
     assert.expect(1);
     Backbone.once('all', function() {
       assert.ok(true);
@@ -638,18 +638,18 @@
     Backbone.trigger('all');
   });
 
-  QUnit.test("once without a callback is a noop", function(assert) {
+  QUnit.test('once without a callback is a noop', function(assert) {
     assert.expect(0);
     _.extend({}, Backbone.Events).once('event').trigger('event');
   });
 
-  QUnit.test("listenToOnce without a callback is a noop", function(assert) {
+  QUnit.test('listenToOnce without a callback is a noop', function(assert) {
     assert.expect(0);
     var obj = _.extend({}, Backbone.Events);
     obj.listenToOnce(obj, 'event').trigger('event');
   });
 
-  QUnit.test("event functions are chainable", function(assert) {
+  QUnit.test('event functions are chainable', function(assert) {
     var obj = _.extend({}, Backbone.Events);
     var obj2 = _.extend({}, Backbone.Events);
     var fn = function() {};
@@ -666,7 +666,7 @@
     assert.equal(obj, obj.stopListening());
   });
 
-  QUnit.test("#3448 - listenToOnce with space-separated events", function(assert) {
+  QUnit.test('#3448 - listenToOnce with space-separated events', function(assert) {
     assert.expect(2);
     var one = _.extend({}, Backbone.Events);
     var two = _.extend({}, Backbone.Events);

--- a/test/events.js
+++ b/test/events.js
@@ -110,7 +110,7 @@
 
     obj.off().on({
       a: function() {
-        strictEqual(this, context, 'will not override explicit `context` param');
+        assert.strictEqual(this, context, 'will not override explicit `context` param');
       }
     }, this, context).trigger('a');
   });

--- a/test/model.js
+++ b/test/model.js
@@ -61,13 +61,13 @@
     assert.expect(2);
     var Model = Backbone.Model.extend({
       defaults: {
-        first_name: 'Unknown',
-        last_name: 'Unknown'
+        firstName: 'Unknown',
+        lastName: 'Unknown'
       }
     });
-    var model = new Model({'first_name': 'John'});
-    assert.equal(model.get('first_name'), 'John');
-    assert.equal(model.get('last_name'), 'Unknown');
+    var model = new Model({'firstName': 'John'});
+    assert.equal(model.get('firstName'), 'John');
+    assert.equal(model.get('lastName'), 'Unknown');
   });
 
   QUnit.test('parse can return null', function(assert) {
@@ -108,11 +108,11 @@
     assert.expect(2);
     var Model = Backbone.Model.extend({
       urlRoot: function() {
-        return '/nested/' + this.get('parent_id') + '/collection';
+        return '/nested/' + this.get('parentId') + '/collection';
       }
     });
 
-    var model = new Model({parent_id: 1});
+    var model = new Model({parentId: 1});
     assert.equal(model.url(), '/nested/1/collection');
     model.set({id: 2});
     assert.equal(model.url(), '/nested/1/collection/2');

--- a/test/model.js
+++ b/test/model.js
@@ -6,13 +6,13 @@
   });
   var doc, collection;
 
-  QUnit.module("Backbone.Model", {
+  QUnit.module('Backbone.Model', {
 
     beforeEach: function(assert) {
       doc = new ProxyModel({
         id: '1-the-tempest',
-        title: "The Tempest",
-        author: "Bill Shakespeare",
+        title: 'The Tempest',
+        author: 'Bill Shakespeare',
         length: 123
       });
       collection = new Klass();
@@ -21,7 +21,7 @@
 
   });
 
-  QUnit.test("initialize", function(assert) {
+  QUnit.test('initialize', function(assert) {
     assert.expect(3);
     var Model = Backbone.Model.extend({
       initialize: function() {
@@ -34,7 +34,7 @@
     assert.equal(model.collection, collection);
   });
 
-  QUnit.test("initialize with attributes and options", function(assert) {
+  QUnit.test('initialize with attributes and options', function(assert) {
     assert.expect(1);
     var Model = Backbone.Model.extend({
       initialize: function(attributes, options) {
@@ -45,7 +45,7 @@
     assert.equal(model.one, 1);
   });
 
-  QUnit.test("initialize with parsed attributes", function(assert) {
+  QUnit.test('initialize with parsed attributes', function(assert) {
     assert.expect(1);
     var Model = Backbone.Model.extend({
       parse: function(attrs) {
@@ -57,7 +57,7 @@
     assert.equal(model.get('value'), 2);
   });
 
-  QUnit.test("initialize with defaults", function(assert) {
+  QUnit.test('initialize with defaults', function(assert) {
     assert.expect(2);
     var Model = Backbone.Model.extend({
       defaults: {
@@ -70,7 +70,7 @@
     assert.equal(model.get('last_name'), 'Unknown');
   });
 
-  QUnit.test("parse can return null", function(assert) {
+  QUnit.test('parse can return null', function(assert) {
     assert.expect(1);
     var Model = Backbone.Model.extend({
       parse: function(attrs) {
@@ -79,10 +79,10 @@
       }
     });
     var model = new Model({value: 1}, {parse: true});
-    assert.equal(JSON.stringify(model.toJSON()), "{}");
+    assert.equal(JSON.stringify(model.toJSON()), '{}');
   });
 
-  QUnit.test("url", function(assert) {
+  QUnit.test('url', function(assert) {
     assert.expect(3);
     doc.urlRoot = null;
     assert.equal(doc.url(), '/collection/1-the-tempest');
@@ -93,7 +93,7 @@
     doc.collection = collection;
   });
 
-  QUnit.test("url when using urlRoot, and uri encoding", function(assert) {
+  QUnit.test('url when using urlRoot, and uri encoding', function(assert) {
     assert.expect(2);
     var Model = Backbone.Model.extend({
       urlRoot: '/collection'
@@ -104,7 +104,7 @@
     assert.equal(model.url(), '/collection/%2B1%2B');
   });
 
-  QUnit.test("url when using urlRoot as a function to determine urlRoot at runtime", function(assert) {
+  QUnit.test('url when using urlRoot as a function to determine urlRoot at runtime', function(assert) {
     assert.expect(2);
     var Model = Backbone.Model.extend({
       urlRoot: function() {
@@ -118,7 +118,7 @@
     assert.equal(model.url(), '/nested/1/collection/2');
   });
 
-  QUnit.test("underscore methods", function(assert) {
+  QUnit.test('underscore methods', function(assert) {
     assert.expect(5);
     var model = new Backbone.Model({'foo': 'a', 'bar': 'b', 'baz': 'c'});
     var model2 = model.clone();
@@ -129,24 +129,24 @@
     assert.deepEqual(model.omit('foo', 'bar'), {'baz': 'c'});
   });
 
-  QUnit.test("chain", function(assert) {
+  QUnit.test('chain', function(assert) {
     var model = new Backbone.Model({a: 0, b: 1, c: 2});
-    assert.deepEqual(model.chain().pick("a", "b", "c").values().compact().value(), [1, 2]);
+    assert.deepEqual(model.chain().pick('a', 'b', 'c').values().compact().value(), [1, 2]);
   });
 
-  QUnit.test("clone", function(assert) {
+  QUnit.test('clone', function(assert) {
     assert.expect(10);
     var a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3});
     var b = a.clone();
     assert.equal(a.get('foo'), 1);
     assert.equal(a.get('bar'), 2);
     assert.equal(a.get('baz'), 3);
-    assert.equal(b.get('foo'), a.get('foo'), "Foo should be the same on the clone.");
-    assert.equal(b.get('bar'), a.get('bar'), "Bar should be the same on the clone.");
-    assert.equal(b.get('baz'), a.get('baz'), "Baz should be the same on the clone.");
+    assert.equal(b.get('foo'), a.get('foo'), 'Foo should be the same on the clone.');
+    assert.equal(b.get('bar'), a.get('bar'), 'Bar should be the same on the clone.');
+    assert.equal(b.get('baz'), a.get('baz'), 'Baz should be the same on the clone.');
     a.set({foo: 100});
     assert.equal(a.get('foo'), 100);
-    assert.equal(b.get('foo'), 1, "Changing a parent attribute does not change the clone.");
+    assert.equal(b.get('foo'), 1, 'Changing a parent attribute does not change the clone.');
 
     var foo = new Backbone.Model({p: 1});
     var bar = new Backbone.Model({p: 2});
@@ -155,26 +155,26 @@
     assert.equal(bar.get('p'), undefined);
   });
 
-  QUnit.test("isNew", function(assert) {
+  QUnit.test('isNew', function(assert) {
     assert.expect(6);
     var a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3});
-    assert.ok(a.isNew(), "it should be new");
+    assert.ok(a.isNew(), 'it should be new');
     a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3, 'id': -5});
-    assert.ok(!a.isNew(), "any defined ID is legal, negative or positive");
+    assert.ok(!a.isNew(), 'any defined ID is legal, negative or positive');
     a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3, 'id': 0});
-    assert.ok(!a.isNew(), "any defined ID is legal, including zero");
-    assert.ok(new Backbone.Model().isNew(), "is true when there is no id");
-    assert.ok(!new Backbone.Model({'id': 2}).isNew(), "is false for a positive integer");
-    assert.ok(!new Backbone.Model({'id': -5}).isNew(), "is false for a negative integer");
+    assert.ok(!a.isNew(), 'any defined ID is legal, including zero');
+    assert.ok(new Backbone.Model().isNew(), 'is true when there is no id');
+    assert.ok(!new Backbone.Model({'id': 2}).isNew(), 'is false for a positive integer');
+    assert.ok(!new Backbone.Model({'id': -5}).isNew(), 'is false for a negative integer');
   });
 
-  QUnit.test("get", function(assert) {
+  QUnit.test('get', function(assert) {
     assert.expect(2);
     assert.equal(doc.get('title'), 'The Tempest');
     assert.equal(doc.get('author'), 'Bill Shakespeare');
   });
 
-  QUnit.test("escape", function(assert) {
+  QUnit.test('escape', function(assert) {
     assert.expect(5);
     assert.equal(doc.escape('title'), 'The Tempest');
     doc.set({audience: 'Bill & Bob'});
@@ -187,7 +187,7 @@
     assert.equal(doc.escape('audience'), '');
   });
 
-  QUnit.test("has", function(assert) {
+  QUnit.test('has', function(assert) {
     assert.expect(10);
     var model = new Backbone.Model();
 
@@ -218,7 +218,7 @@
     assert.strictEqual(model.has('undefined'), false);
   });
 
-  QUnit.test("matches", function(assert) {
+  QUnit.test('matches', function(assert) {
     assert.expect(4);
     var model = new Backbone.Model();
 
@@ -231,7 +231,7 @@
     assert.strictEqual(model.matches({'name': 'Jonas', 'cool': false}), false);
   });
 
-  QUnit.test("matches with predicate", function(assert) {
+  QUnit.test('matches with predicate', function(assert) {
     var model = new Backbone.Model({a: 0});
 
     assert.strictEqual(model.matches(function(attr) {
@@ -245,38 +245,38 @@
     }), true);
   });
 
-  QUnit.test("set and unset", function(assert) {
+  QUnit.test('set and unset', function(assert) {
     assert.expect(8);
     var a = new Backbone.Model({id: 'id', foo: 1, bar: 2, baz: 3});
     var changeCount = 0;
-    a.on("change:foo", function() { changeCount += 1; });
+    a.on('change:foo', function() { changeCount += 1; });
     a.set({'foo': 2});
-    assert.ok(a.get('foo') == 2, "Foo should have changed.");
-    assert.ok(changeCount == 1, "Change count should have incremented.");
+    assert.ok(a.get('foo') == 2, 'Foo should have changed.');
+    assert.ok(changeCount == 1, 'Change count should have incremented.');
     // set with value that is not new shouldn't fire change event
     a.set({'foo': 2});
-    assert.ok(a.get('foo') == 2, "Foo should NOT have changed, still 2");
-    assert.ok(changeCount == 1, "Change count should NOT have incremented.");
+    assert.ok(a.get('foo') == 2, 'Foo should NOT have changed, still 2');
+    assert.ok(changeCount == 1, 'Change count should NOT have incremented.');
 
     a.validate = function(attrs) {
-      assert.equal(attrs.foo, void 0, "validate:true passed while unsetting");
+      assert.equal(attrs.foo, void 0, 'validate:true passed while unsetting');
     };
     a.unset('foo', {validate: true});
-    assert.equal(a.get('foo'), void 0, "Foo should have changed");
+    assert.equal(a.get('foo'), void 0, 'Foo should have changed');
     delete a.validate;
-    assert.ok(changeCount == 2, "Change count should have incremented for unset.");
+    assert.ok(changeCount == 2, 'Change count should have incremented for unset.');
 
     a.unset('id');
-    assert.equal(a.id, undefined, "Unsetting the id should remove the id property.");
+    assert.equal(a.id, undefined, 'Unsetting the id should remove the id property.');
   });
 
-  QUnit.test("#2030 - set with failed validate, followed by another set triggers change", function(assert) {
+  QUnit.test('#2030 - set with failed validate, followed by another set triggers change', function(assert) {
     var attr = 0, main = 0, error = 0;
     var Model = Backbone.Model.extend({
       validate: function(attr) {
         if (attr.x > 1) {
           error++;
-          return "this is an error";
+          return 'this is an error';
         }
       }
     });
@@ -288,7 +288,7 @@
     assert.deepEqual([attr, main, error], [1, 1, 1]);
   });
 
-  QUnit.test("set triggers changes in the correct order", function(assert) {
+  QUnit.test('set triggers changes in the correct order', function(assert) {
     var value = null;
     var model = new Backbone.Model;
     model.on('last', function(){ value = 'last'; });
@@ -298,7 +298,7 @@
     assert.equal(value, 'last');
   });
 
-  QUnit.test("set falsy values in the correct order", function(assert) {
+  QUnit.test('set falsy values in the correct order', function(assert) {
     assert.expect(2);
     var model = new Backbone.Model({result: 'result'});
     model.on('change', function() {
@@ -311,7 +311,7 @@
     model.set({result: void 0});
   });
 
-  QUnit.test("nested set triggers with the correct options", function(assert) {
+  QUnit.test('nested set triggers with the correct options', function(assert) {
     var model = new Backbone.Model();
     var o1 = {};
     var o2 = {};
@@ -331,19 +331,19 @@
     model.set('a', 1, o1);
   });
 
-  QUnit.test("multiple unsets", function(assert) {
+  QUnit.test('multiple unsets', function(assert) {
     assert.expect(1);
     var i = 0;
     var counter = function(){ i++; };
     var model = new Backbone.Model({a: 1});
-    model.on("change:a", counter);
+    model.on('change:a', counter);
     model.set({a: 2});
     model.unset('a');
     model.unset('a');
     assert.equal(i, 2, 'Unset does not fire an event for missing attributes.');
   });
 
-  QUnit.test("unset and changedAttributes", function(assert) {
+  QUnit.test('unset and changedAttributes', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model({a: 1});
     model.on('change', function() {
@@ -352,7 +352,7 @@
     model.unset('a');
   });
 
-  QUnit.test("using a non-default id attribute.", function(assert) {
+  QUnit.test('using a non-default id attribute.', function(assert) {
     assert.expect(5);
     var MongoModel = Backbone.Model.extend({idAttribute: '_id'});
     var model = new MongoModel({id: 'eye-dee', _id: 25, title: 'Model'});
@@ -364,7 +364,7 @@
     assert.equal(model.isNew(), true);
   });
 
-  QUnit.test("setting an alternative cid prefix", function(assert) {
+  QUnit.test('setting an alternative cid prefix', function(assert) {
     assert.expect(4);
     var Model = Backbone.Model.extend({
       cidPrefix: 'm'
@@ -390,14 +390,14 @@
     assert.ok(collection.get('c6').has('value'));
   });
 
-  QUnit.test("set an empty string", function(assert) {
+  QUnit.test('set an empty string', function(assert) {
     assert.expect(1);
-    var model = new Backbone.Model({name: "Model"});
+    var model = new Backbone.Model({name: 'Model'});
     model.set({name: ''});
     assert.equal(model.get('name'), '');
   });
 
-  QUnit.test("setting an object", function(assert) {
+  QUnit.test('setting an object', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model({
       custom: {foo: 1}
@@ -413,12 +413,12 @@
     });
   });
 
-  QUnit.test("clear", function(assert) {
+  QUnit.test('clear', function(assert) {
     assert.expect(3);
     var changed;
-    var model = new Backbone.Model({id: 1, name: "Model"});
-    model.on("change:name", function(){ changed = true; });
-    model.on("change", function() {
+    var model = new Backbone.Model({id: 1, name: 'Model'});
+    model.on('change:name', function(){ changed = true; });
+    model.on('change', function() {
       var changedAttrs = model.changedAttributes();
       assert.ok('name' in changedAttrs);
     });
@@ -427,12 +427,12 @@
     assert.equal(model.get('name'), undefined);
   });
 
-  QUnit.test("defaults", function(assert) {
+  QUnit.test('defaults', function(assert) {
     assert.expect(4);
     var Defaulted = Backbone.Model.extend({
       defaults: {
-        "one": 1,
-        "two": 2
+        'one': 1,
+        'two': 2
       }
     });
     var model = new Defaulted({two: undefined});
@@ -441,8 +441,8 @@
     Defaulted = Backbone.Model.extend({
       defaults: function() {
         return {
-          "one": 3,
-          "two": 4
+          'one': 3,
+          'two': 4
         };
       }
     });
@@ -451,16 +451,16 @@
     assert.equal(model.get('two'), 4);
   });
 
-  QUnit.test("change, hasChanged, changedAttributes, previous, previousAttributes", function(assert) {
+  QUnit.test('change, hasChanged, changedAttributes, previous, previousAttributes', function(assert) {
     assert.expect(9);
-    var model = new Backbone.Model({name: "Tim", age: 10});
+    var model = new Backbone.Model({name: 'Tim', age: 10});
     assert.deepEqual(model.changedAttributes(), false);
     model.on('change', function() {
       assert.ok(model.hasChanged('name'), 'name changed');
       assert.ok(!model.hasChanged('age'), 'age did not');
       assert.ok(_.isEqual(model.changedAttributes(), {name: 'Rob'}), 'changedAttributes returns the changed attrs');
       assert.equal(model.previous('name'), 'Tim');
-      assert.ok(_.isEqual(model.previousAttributes(), {name: "Tim", age: 10}), 'previousAttributes is correct');
+      assert.ok(_.isEqual(model.previousAttributes(), {name: 'Tim', age: 10}), 'previousAttributes is correct');
     });
     assert.equal(model.hasChanged(), false);
     assert.equal(model.hasChanged(undefined), false);
@@ -468,7 +468,7 @@
     assert.equal(model.get('name'), 'Rob');
   });
 
-  QUnit.test("changedAttributes", function(assert) {
+  QUnit.test('changedAttributes', function(assert) {
     assert.expect(3);
     var model = new Backbone.Model({a: 'a', b: 'b'});
     assert.deepEqual(model.changedAttributes(), false);
@@ -476,7 +476,7 @@
     assert.equal(model.changedAttributes({a: 'b'}).a, 'b');
   });
 
-  QUnit.test("change with options", function(assert) {
+  QUnit.test('change with options', function(assert) {
     assert.expect(2);
     var value;
     var model = new Backbone.Model({name: 'Rob'});
@@ -489,7 +489,7 @@
     assert.equal(value, 'Ms. Sue');
   });
 
-  QUnit.test("change after initialize", function(assert) {
+  QUnit.test('change after initialize', function(assert) {
     assert.expect(1);
     var changed = 0;
     var attrs = {id: 1, label: 'c'};
@@ -499,10 +499,10 @@
     assert.equal(changed, 0);
   });
 
-  QUnit.test("save within change event", function(assert) {
+  QUnit.test('save within change event', function(assert) {
     assert.expect(1);
     var env = this;
-    var model = new Backbone.Model({firstName: "Taylor", lastName: "Swift"});
+    var model = new Backbone.Model({firstName: 'Taylor', lastName: 'Swift'});
     model.url = '/test';
     model.on('change', function() {
       model.save();
@@ -511,7 +511,7 @@
     model.set({lastName: 'Hicks'});
   });
 
-  QUnit.test("validate after save", function(assert) {
+  QUnit.test('validate after save', function(assert) {
     assert.expect(2);
     var lastError, model = new Backbone.Model();
     model.validate = function(attrs) {
@@ -529,14 +529,14 @@
     assert.equal(model.validationError, "Can't change admin status.");
   });
 
-  QUnit.test("save", function(assert) {
+  QUnit.test('save', function(assert) {
     assert.expect(2);
-    doc.save({title: "Henry V"});
+    doc.save({title: 'Henry V'});
     assert.equal(this.syncArgs.method, 'update');
     assert.ok(_.isEqual(this.syncArgs.model, doc));
   });
 
-  QUnit.test("save, fetch, destroy triggers error event when an error occurs", function(assert) {
+  QUnit.test('save, fetch, destroy triggers error event when an error occurs', function(assert) {
     assert.expect(3);
     var model = new Backbone.Model();
     model.on('error', function() {
@@ -550,7 +550,7 @@
     model.destroy();
   });
 
-  QUnit.test("#3283 - save, fetch, destroy calls success with context", function(assert) {
+  QUnit.test('#3283 - save, fetch, destroy calls success with context', function(assert) {
     assert.expect(3);
     var model = new Backbone.Model();
     var obj = {};
@@ -568,7 +568,7 @@
     model.destroy(options);
   });
 
-  QUnit.test("#3283 - save, fetch, destroy calls error with context", function(assert) {
+  QUnit.test('#3283 - save, fetch, destroy calls error with context', function(assert) {
     assert.expect(3);
     var model = new Backbone.Model();
     var obj = {};
@@ -586,7 +586,7 @@
     model.destroy(options);
   });
 
-  QUnit.test("#3470 - save and fetch with parse false", function(assert) {
+  QUnit.test('#3470 - save and fetch with parse false', function(assert) {
     assert.expect(2);
     var i = 0;
     var model = new Backbone.Model();
@@ -602,7 +602,7 @@
     assert.equal(model.get('i'), i);
   });
 
-  QUnit.test("save with PATCH", function(assert) {
+  QUnit.test('save with PATCH', function(assert) {
     doc.clear().set({id: 1, a: 1, b: 2, c: 3, d: 4});
     doc.save();
     assert.equal(this.syncArgs.method, 'update');
@@ -613,18 +613,18 @@
     assert.equal(_.size(this.syncArgs.options.attrs), 2);
     assert.equal(this.syncArgs.options.attrs.d, 4);
     assert.equal(this.syncArgs.options.attrs.a, undefined);
-    assert.equal(this.ajaxSettings.data, "{\"b\":2,\"d\":4}");
+    assert.equal(this.ajaxSettings.data, '{"b":2,"d":4}');
   });
 
-  QUnit.test("save with PATCH and different attrs", function(assert) {
+  QUnit.test('save with PATCH and different attrs', function(assert) {
     doc.clear().save({b: 2, d: 4}, {patch: true, attrs: {B: 1, D: 3}});
     assert.equal(this.syncArgs.options.attrs.D, 3);
     assert.equal(this.syncArgs.options.attrs.d, undefined);
-    assert.equal(this.ajaxSettings.data, "{\"B\":1,\"D\":3}");
+    assert.equal(this.ajaxSettings.data, '{"B":1,"D":3}');
     assert.deepEqual(doc.attributes, {b: 2, d: 4});
   });
 
-  QUnit.test("save in positional style", function(assert) {
+  QUnit.test('save in positional style', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     model.sync = function(method, model, options) {
@@ -634,7 +634,7 @@
     assert.equal(model.get('title'), 'Twelfth Night');
   });
 
-  QUnit.test("save with non-object success response", function(assert) {
+  QUnit.test('save with non-object success response', function(assert) {
     assert.expect(2);
     var model = new Backbone.Model();
     model.sync = function(method, model, options) {
@@ -648,7 +648,7 @@
     });
   });
 
-  QUnit.test("save with wait and supplied id", function(assert) {
+  QUnit.test('save with wait and supplied id', function(assert) {
     var Model = Backbone.Model.extend({
       urlRoot: '/collection'
     });
@@ -657,7 +657,7 @@
     assert.equal(this.ajaxSettings.url, '/collection/42');
   });
 
-  QUnit.test("save will pass extra options to success callback", function(assert) {
+  QUnit.test('save will pass extra options to success callback', function(assert) {
     assert.expect(1);
     var SpecialSyncModel = Backbone.Model.extend({
       sync: function(method, model, options) {
@@ -670,21 +670,21 @@
     var model = new SpecialSyncModel();
 
     var onSuccess = function(model, response, options) {
-      assert.ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, 'Options were passed correctly to callback');
     };
 
     model.save(null, {success: onSuccess});
     this.ajaxSettings.success();
   });
 
-  QUnit.test("fetch", function(assert) {
+  QUnit.test('fetch', function(assert) {
     assert.expect(2);
     doc.fetch();
     assert.equal(this.syncArgs.method, 'read');
     assert.ok(_.isEqual(this.syncArgs.model, doc));
   });
 
-  QUnit.test("fetch will pass extra options to success callback", function(assert) {
+  QUnit.test('fetch will pass extra options to success callback', function(assert) {
     assert.expect(1);
     var SpecialSyncModel = Backbone.Model.extend({
       sync: function(method, model, options) {
@@ -697,14 +697,14 @@
     var model = new SpecialSyncModel();
 
     var onSuccess = function(model, response, options) {
-      assert.ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, 'Options were passed correctly to callback');
     };
 
     model.fetch({success: onSuccess});
     this.ajaxSettings.success();
   });
 
-  QUnit.test("destroy", function(assert) {
+  QUnit.test('destroy', function(assert) {
     assert.expect(3);
     doc.destroy();
     assert.equal(this.syncArgs.method, 'delete');
@@ -714,7 +714,7 @@
     assert.equal(newModel.destroy(), false);
   });
 
-  QUnit.test("destroy will pass extra options to success callback", function(assert) {
+  QUnit.test('destroy will pass extra options to success callback', function(assert) {
     assert.expect(1);
     var SpecialSyncModel = Backbone.Model.extend({
       sync: function(method, model, options) {
@@ -727,22 +727,22 @@
     var model = new SpecialSyncModel({id: 'id'});
 
     var onSuccess = function(model, response, options) {
-      assert.ok(options.specialSync, "Options were passed correctly to callback");
+      assert.ok(options.specialSync, 'Options were passed correctly to callback');
     };
 
     model.destroy({success: onSuccess});
     this.ajaxSettings.success();
   });
 
-  QUnit.test("non-persisted destroy", function(assert) {
+  QUnit.test('non-persisted destroy', function(assert) {
     assert.expect(1);
     var a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3});
-    a.sync = function() { throw "should not be called"; };
+    a.sync = function() { throw 'should not be called'; };
     a.destroy();
-    assert.ok(true, "non-persisted model should not call sync");
+    assert.ok(true, 'non-persisted model should not call sync');
   });
 
-  QUnit.test("validate", function(assert) {
+  QUnit.test('validate', function(assert) {
     var lastError;
     var model = new Backbone.Model();
     model.validate = function(attrs) {
@@ -763,17 +763,17 @@
     assert.equal(model.get('a'), 100);
   });
 
-  QUnit.test("validate on unset and clear", function(assert) {
+  QUnit.test('validate on unset and clear', function(assert) {
     assert.expect(6);
     var error;
-    var model = new Backbone.Model({name: "One"});
+    var model = new Backbone.Model({name: 'One'});
     model.validate = function(attrs) {
       if (!attrs.name) {
         error = true;
-        return "No thanks.";
+        return 'No thanks.';
       }
     };
-    model.set({name: "Two"});
+    model.set({name: 'Two'});
     assert.equal(model.get('name'), 'Two');
     assert.equal(error, undefined);
     model.unset('name', {validate: true});
@@ -786,7 +786,7 @@
     assert.equal(model.get('name'), undefined);
   });
 
-  QUnit.test("validate with error callback", function(assert) {
+  QUnit.test('validate with error callback', function(assert) {
     assert.expect(8);
     var lastError, boundError;
     var model = new Backbone.Model();
@@ -808,7 +808,7 @@
     assert.equal(boundError, true);
   });
 
-  QUnit.test("defaults always extend attrs (#459)", function(assert) {
+  QUnit.test('defaults always extend attrs (#459)', function(assert) {
     assert.expect(2);
     var Defaulted = Backbone.Model.extend({
       defaults: {one: 1},
@@ -820,7 +820,7 @@
     var emptyattrs = new Defaulted();
   });
 
-  QUnit.test("Inherit class properties", function(assert) {
+  QUnit.test('Inherit class properties', function(assert) {
     assert.expect(6);
     var Parent = Backbone.Model.extend({
       instancePropSame: function() {},
@@ -861,7 +861,7 @@
     .set({state: 'hello'});
   });
 
-  QUnit.test("hasChanged/set should use same comparison", function(assert) {
+  QUnit.test('hasChanged/set should use same comparison', function(assert) {
     assert.expect(2);
     var changed = 0, model = new Backbone.Model({a: null});
     model.on('change', function() {
@@ -874,7 +874,7 @@
     assert.equal(changed, 1);
   });
 
-  QUnit.test("#582, #425, change:attribute callbacks should fire after all changes have occurred", function(assert) {
+  QUnit.test('#582, #425, change:attribute callbacks should fire after all changes have occurred', function(assert) {
     assert.expect(9);
     var model = new Backbone.Model;
 
@@ -891,14 +891,14 @@
     model.set({a: 'a', b: 'b', c: 'c'});
   });
 
-  QUnit.test("#871, set with attributes property", function(assert) {
+  QUnit.test('#871, set with attributes property', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     model.set({attributes: true});
     assert.ok(model.has('attributes'));
   });
 
-  QUnit.test("set value regardless of equality/change", function(assert) {
+  QUnit.test('set value regardless of equality/change', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model({x: []});
     var a = [];
@@ -906,7 +906,7 @@
     assert.ok(model.get('x') === a);
   });
 
-  QUnit.test("set same value does not trigger change", function(assert) {
+  QUnit.test('set same value does not trigger change', function(assert) {
     assert.expect(0);
     var model = new Backbone.Model({x: 1});
     model.on('change change:x', function() { assert.ok(false); });
@@ -914,20 +914,20 @@
     model.set({x: 1});
   });
 
-  QUnit.test("unset does not fire a change for undefined attributes", function(assert) {
+  QUnit.test('unset does not fire a change for undefined attributes', function(assert) {
     assert.expect(0);
     var model = new Backbone.Model({x: undefined});
     model.on('change:x', function(){ assert.ok(false); });
     model.unset('x');
   });
 
-  QUnit.test("set: undefined values", function(assert) {
+  QUnit.test('set: undefined values', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model({x: undefined});
     assert.ok('x' in model.attributes);
   });
 
-  QUnit.test("hasChanged works outside of change events, and true within", function(assert) {
+  QUnit.test('hasChanged works outside of change events, and true within', function(assert) {
     assert.expect(6);
     var model = new Backbone.Model({x: 1});
     model.on('change:x', function() {
@@ -942,7 +942,7 @@
     assert.equal(model.hasChanged('x'), true);
   });
 
-  QUnit.test("hasChanged gets cleared on the following set", function(assert) {
+  QUnit.test('hasChanged gets cleared on the following set', function(assert) {
     assert.expect(4);
     var model = new Backbone.Model;
     model.set({x: 1});
@@ -955,7 +955,7 @@
     assert.ok(!model.hasChanged());
   });
 
-  QUnit.test("save with `wait` succeeds without `validate`", function(assert) {
+  QUnit.test('save with `wait` succeeds without `validate`', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     model.url = '/test';
@@ -979,7 +979,7 @@
     assert.equal(times, 1);
   });
 
-  QUnit.test("`hasChanged` for falsey keys", function(assert) {
+  QUnit.test('`hasChanged` for falsey keys', function(assert) {
     assert.expect(2);
     var model = new Backbone.Model();
     model.set({x: true}, {silent: true});
@@ -987,7 +987,7 @@
     assert.ok(!model.hasChanged(''));
   });
 
-  QUnit.test("`previous` for falsey keys", function(assert) {
+  QUnit.test('`previous` for falsey keys', function(assert) {
     assert.expect(2);
     var model = new Backbone.Model({0: true, '': true});
     model.set({0: false, '': false}, {silent: true});
@@ -995,7 +995,7 @@
     assert.equal(model.previous(''), true);
   });
 
-  QUnit.test("`save` with `wait` sends correct attributes", function(assert) {
+  QUnit.test('`save` with `wait` sends correct attributes', function(assert) {
     assert.expect(5);
     var changed = 0;
     var model = new Backbone.Model({x: 1, y: 2});
@@ -1018,25 +1018,25 @@
     assert.equal(model.get('x'), void 0);
   });
 
-  QUnit.test("#1030 - `save` with `wait` results in correct attributes if success is called during sync", function(assert) {
+  QUnit.test('#1030 - `save` with `wait` results in correct attributes if success is called during sync', function(assert) {
     assert.expect(2);
     var model = new Backbone.Model({x: 1, y: 2});
     model.sync = function(method, model, options) {
       options.success();
     };
-    model.on("change:x", function() { assert.ok(true); });
+    model.on('change:x', function() { assert.ok(true); });
     model.save({x: 3}, {wait: true});
     assert.equal(model.get('x'), 3);
   });
 
-  QUnit.test("save with wait validates attributes", function(assert) {
+  QUnit.test('save with wait validates attributes', function(assert) {
     var model = new Backbone.Model();
     model.url = '/test';
     model.validate = function() { assert.ok(true); };
     model.save({x: 1}, {wait: true});
   });
 
-  QUnit.test("save turns on parse flag", function(assert) {
+  QUnit.test('save turns on parse flag', function(assert) {
     var Model = Backbone.Model.extend({
       sync: function(method, model, options) { assert.ok(options.parse); }
     });
@@ -1061,7 +1061,7 @@
     assert.deepEqual(events, []);
   });
 
-  QUnit.test("nested `change` only fires once", function(assert) {
+  QUnit.test('nested `change` only fires once', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     model.on('change', function() {
@@ -1098,7 +1098,7 @@
     model.set({x: true});
   });
 
-  QUnit.test("nested `change` with silent", function(assert) {
+  QUnit.test('nested `change` with silent', function(assert) {
     assert.expect(3);
     var count = 0;
     var model = new Backbone.Model();
@@ -1124,7 +1124,7 @@
     model.set({z: false});
   });
 
-  QUnit.test("nested `change:attr` with silent", function(assert) {
+  QUnit.test('nested `change:attr` with silent', function(assert) {
     assert.expect(0);
     var model = new Backbone.Model();
     model.on('change:y', function(){ assert.ok(false); });
@@ -1135,7 +1135,7 @@
     model.set({x: true});
   });
 
-  QUnit.test("multiple nested changes with silent", function(assert) {
+  QUnit.test('multiple nested changes with silent', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     model.on('change:x', function() {
@@ -1148,7 +1148,7 @@
     model.set({x: true});
   });
 
-  QUnit.test("multiple nested changes with silent", function(assert) {
+  QUnit.test('multiple nested changes with silent', function(assert) {
     assert.expect(1);
     var changes = [];
     var model = new Backbone.Model();
@@ -1160,7 +1160,7 @@
     assert.deepEqual(changes, [0, 1]);
   });
 
-  QUnit.test("basic silent change semantics", function(assert) {
+  QUnit.test('basic silent change semantics', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model;
     model.set({x: 1});
@@ -1169,7 +1169,7 @@
     model.set({x: 1});
   });
 
-  QUnit.test("nested set multiple times", function(assert) {
+  QUnit.test('nested set multiple times', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     model.on('change:b', function() {
@@ -1182,7 +1182,7 @@
     model.set({a: true});
   });
 
-  QUnit.test("#1122 - clear does not alter options.", function(assert) {
+  QUnit.test('#1122 - clear does not alter options.', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     var options = {};
@@ -1190,7 +1190,7 @@
     assert.ok(!options.unset);
   });
 
-  QUnit.test("#1122 - unset does not alter options.", function(assert) {
+  QUnit.test('#1122 - unset does not alter options.', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     var options = {};
@@ -1198,7 +1198,7 @@
     assert.ok(!options.unset);
   });
 
-  QUnit.test("#1355 - `options` is passed to success callbacks", function(assert) {
+  QUnit.test('#1355 - `options` is passed to success callbacks', function(assert) {
     assert.expect(3);
     var model = new Backbone.Model();
     var opts = {
@@ -1224,7 +1224,7 @@
     model.destroy();
   });
 
-  QUnit.test("#1365 - Destroy: New models execute success callback.", function(assert) {
+  QUnit.test('#1365 - Destroy: New models execute success callback.', function(assert) {
     var done = assert.async();
     assert.expect(2);
     new Backbone.Model()
@@ -1236,7 +1236,7 @@
     }});
   });
 
-  QUnit.test("#1433 - Save: An invalid model cannot be persisted.", function(assert) {
+  QUnit.test('#1433 - Save: An invalid model cannot be persisted.', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model;
     model.validate = function(){ return 'invalid'; };
@@ -1256,7 +1256,7 @@
     model.save();
   });
 
-  QUnit.test("#1545 - `undefined` can be passed to a model constructor without coersion", function(assert) {
+  QUnit.test('#1545 - `undefined` can be passed to a model constructor without coersion', function(assert) {
     var Model = Backbone.Model.extend({
       defaults: {one: 1},
       initialize: function(attrs, opts) {
@@ -1267,7 +1267,7 @@
     var undefinedattrs = new Model(undefined);
   });
 
-  QUnit.test("#1478 - Model `save` does not trigger change on unchanged attributes", function(assert) {
+  QUnit.test('#1478 - Model `save` does not trigger change on unchanged attributes', function(assert) {
     var done = assert.async();
     assert.expect(0);
     var Model = Backbone.Model.extend({
@@ -1283,7 +1283,7 @@
     .save(null, {wait: true});
   });
 
-  QUnit.test("#1664 - Changing from one value, silently to another, back to original triggers a change.", function(assert) {
+  QUnit.test('#1664 - Changing from one value, silently to another, back to original triggers a change.', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model({x: 1});
     model.on('change:x', function() { assert.ok(true); });
@@ -1292,7 +1292,7 @@
     model.set({x: 1});
   });
 
-  QUnit.test("#1664 - multiple silent changes nested inside a change event", function(assert) {
+  QUnit.test('#1664 - multiple silent changes nested inside a change event', function(assert) {
     assert.expect(2);
     var changes = [];
     var model = new Backbone.Model();
@@ -1307,7 +1307,7 @@
     assert.deepEqual(model.attributes, {a: 'c', b: 2});
   });
 
-  QUnit.test("#1791 - `attributes` is available for `parse`", function(assert) {
+  QUnit.test('#1791 - `attributes` is available for `parse`', function(assert) {
     var Model = Backbone.Model.extend({
       parse: function() { this.has('a'); } // shouldn't throw an error
     });
@@ -1315,7 +1315,7 @@
     assert.expect(0);
   });
 
-  QUnit.test("silent changes in last `change` event back to original triggers change", function(assert) {
+  QUnit.test('silent changes in last `change` event back to original triggers change', function(assert) {
     assert.expect(2);
     var changes = [];
     var model = new Backbone.Model();
@@ -1329,13 +1329,13 @@
     assert.deepEqual(changes, ['a', 'a']);
   });
 
-  QUnit.test("#1943 change calculations should use _.isEqual", function(assert) {
+  QUnit.test('#1943 change calculations should use _.isEqual', function(assert) {
     var model = new Backbone.Model({a: {key: 'value'}});
     model.set('a', {key: 'value'}, {silent: true});
     assert.equal(model.changedAttributes(), false);
   });
 
-  QUnit.test("#1964 - final `change` event is always fired, regardless of interim changes", function(assert) {
+  QUnit.test('#1964 - final `change` event is always fired, regardless of interim changes', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     model.on('change:property', function() {
@@ -1347,10 +1347,10 @@
     model.set('property', 'foo');
   });
 
-  QUnit.test("isValid", function(assert) {
+  QUnit.test('isValid', function(assert) {
     var model = new Backbone.Model({valid: true});
     model.validate = function(attrs) {
-      if (!attrs.valid) return "invalid";
+      if (!attrs.valid) return 'invalid';
     };
     assert.equal(model.isValid(), true);
     assert.equal(model.set({valid: false}, {validate: true}), false);
@@ -1360,14 +1360,14 @@
     assert.ok(!model.set('valid', false, {validate: true}));
   });
 
-  QUnit.test("#1179 - isValid returns true in the absence of validate.", function(assert) {
+  QUnit.test('#1179 - isValid returns true in the absence of validate.', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     model.validate = null;
     assert.ok(model.isValid());
   });
 
-  QUnit.test("#1961 - Creating a model with {validate:true} will call validate and use the error callback", function(assert) {
+  QUnit.test('#1961 - Creating a model with {validate:true} will call validate and use the error callback', function(assert) {
     var Model = Backbone.Model.extend({
       validate: function(attrs) {
         if (attrs.id === 1) return "This shouldn't happen";
@@ -1377,7 +1377,7 @@
     assert.equal(model.validationError, "This shouldn't happen");
   });
 
-  QUnit.test("toJSON receives attrs during save(..., {wait: true})", function(assert) {
+  QUnit.test('toJSON receives attrs during save(..., {wait: true})', function(assert) {
     assert.expect(1);
     var Model = Backbone.Model.extend({
       url: '/test',
@@ -1390,7 +1390,7 @@
     model.save({x: 1}, {wait: true});
   });
 
-  QUnit.test("#2034 - nested set with silent only triggers one change", function(assert) {
+  QUnit.test('#2034 - nested set with silent only triggers one change', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();
     model.on('change', function() {

--- a/test/model.js
+++ b/test/model.js
@@ -849,14 +849,14 @@
     assert.expect(4);
     new Backbone.Model()
     .on('change:state', function(model, newState) {
-      equal(model.previous('state'), undefined);
-      equal(newState, 'hello');
+      assert.equal(model.previous('state'), undefined);
+      assert.equal(newState, 'hello');
       // Fire a nested change event.
       model.set({other: 'whatever'});
     })
     .on('change:state', function(model, newState) {
-      equal(model.previous('state'), undefined);
-      equal(newState, 'hello');
+      assert.equal(model.previous('state'), undefined);
+      assert.equal(newState, 'hello');
     })
     .set({state: 'hello'});
   });

--- a/test/model.js
+++ b/test/model.js
@@ -120,13 +120,13 @@
 
   QUnit.test('underscore methods', function(assert) {
     assert.expect(5);
-    var model = new Backbone.Model({'foo': 'a', 'bar': 'b', 'baz': 'c'});
+    var model = new Backbone.Model({foo: 'a', bar: 'b', baz: 'c'});
     var model2 = model.clone();
     assert.deepEqual(model.keys(), ['foo', 'bar', 'baz']);
     assert.deepEqual(model.values(), ['a', 'b', 'c']);
-    assert.deepEqual(model.invert(), {'a': 'foo', 'b': 'bar', 'c': 'baz'});
-    assert.deepEqual(model.pick('foo', 'baz'), {'foo': 'a', 'baz': 'c'});
-    assert.deepEqual(model.omit('foo', 'bar'), {'baz': 'c'});
+    assert.deepEqual(model.invert(), {a: 'foo', b: 'bar', c: 'baz'});
+    assert.deepEqual(model.pick('foo', 'baz'), {foo: 'a', baz: 'c'});
+    assert.deepEqual(model.omit('foo', 'bar'), {baz: 'c'});
   });
 
   QUnit.test('chain', function(assert) {
@@ -136,7 +136,7 @@
 
   QUnit.test('clone', function(assert) {
     assert.expect(10);
-    var a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3});
+    var a = new Backbone.Model({foo: 1, bar: 2, baz: 3});
     var b = a.clone();
     assert.equal(a.get('foo'), 1);
     assert.equal(a.get('bar'), 2);
@@ -157,15 +157,15 @@
 
   QUnit.test('isNew', function(assert) {
     assert.expect(6);
-    var a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3});
+    var a = new Backbone.Model({foo: 1, bar: 2, baz: 3});
     assert.ok(a.isNew(), 'it should be new');
-    a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3, 'id': -5});
+    a = new Backbone.Model({foo: 1, bar: 2, baz: 3, id: -5});
     assert.ok(!a.isNew(), 'any defined ID is legal, negative or positive');
-    a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3, 'id': 0});
+    a = new Backbone.Model({foo: 1, bar: 2, baz: 3, id: 0});
     assert.ok(!a.isNew(), 'any defined ID is legal, including zero');
     assert.ok(new Backbone.Model().isNew(), 'is true when there is no id');
-    assert.ok(!new Backbone.Model({'id': 2}).isNew(), 'is false for a positive integer');
-    assert.ok(!new Backbone.Model({'id': -5}).isNew(), 'is false for a negative integer');
+    assert.ok(!new Backbone.Model({id: 2}).isNew(), 'is false for a positive integer');
+    assert.ok(!new Backbone.Model({id: -5}).isNew(), 'is false for a negative integer');
   });
 
   QUnit.test('get', function(assert) {
@@ -222,13 +222,13 @@
     assert.expect(4);
     var model = new Backbone.Model();
 
-    assert.strictEqual(model.matches({'name': 'Jonas', 'cool': true}), false);
+    assert.strictEqual(model.matches({name: 'Jonas', cool: true}), false);
 
-    model.set({name: 'Jonas', 'cool': true});
+    model.set({name: 'Jonas', cool: true});
 
-    assert.strictEqual(model.matches({'name': 'Jonas'}), true);
-    assert.strictEqual(model.matches({'name': 'Jonas', 'cool': true}), true);
-    assert.strictEqual(model.matches({'name': 'Jonas', 'cool': false}), false);
+    assert.strictEqual(model.matches({name: 'Jonas'}), true);
+    assert.strictEqual(model.matches({name: 'Jonas', cool: true}), true);
+    assert.strictEqual(model.matches({name: 'Jonas', cool: false}), false);
   });
 
   QUnit.test('matches with predicate', function(assert) {
@@ -250,11 +250,11 @@
     var a = new Backbone.Model({id: 'id', foo: 1, bar: 2, baz: 3});
     var changeCount = 0;
     a.on('change:foo', function() { changeCount += 1; });
-    a.set({'foo': 2});
+    a.set({foo: 2});
     assert.ok(a.get('foo') == 2, 'Foo should have changed.');
     assert.ok(changeCount == 1, 'Change count should have incremented.');
     // set with value that is not new shouldn't fire change event
-    a.set({'foo': 2});
+    a.set({foo: 2});
     assert.ok(a.get('foo') == 2, 'Foo should NOT have changed, still 2');
     assert.ok(changeCount == 1, 'Change count should NOT have incremented.');
 
@@ -431,8 +431,8 @@
     assert.expect(4);
     var Defaulted = Backbone.Model.extend({
       defaults: {
-        'one': 1,
-        'two': 2
+        one: 1,
+        two: 2
       }
     });
     var model = new Defaulted({two: undefined});
@@ -441,8 +441,8 @@
     Defaulted = Backbone.Model.extend({
       defaults: function() {
         return {
-          'one': 3,
-          'two': 4
+          one: 3,
+          two: 4
         };
       }
     });
@@ -736,7 +736,7 @@
 
   QUnit.test('non-persisted destroy', function(assert) {
     assert.expect(1);
-    var a = new Backbone.Model({'foo': 1, 'bar': 2, 'baz': 3});
+    var a = new Backbone.Model({foo: 1, bar: 2, baz: 3});
     a.sync = function() { throw 'should not be called'; };
     a.destroy();
     assert.ok(true, 'non-persisted model should not call sync');

--- a/test/noconflict.js
+++ b/test/noconflict.js
@@ -1,6 +1,6 @@
 (function() {
 
-  QUnit.module("Backbone.noConflict");
+  QUnit.module('Backbone.noConflict');
 
   QUnit.test('noConflict', function(assert) {
     assert.expect(2);

--- a/test/router.js
+++ b/test/router.js
@@ -40,7 +40,7 @@
 
   });
 
-  QUnit.module("Backbone.Router", {
+  QUnit.module('Backbone.Router', {
 
     setup: function() {
       location = new Location('http://example.com');
@@ -74,25 +74,25 @@
     count: 0,
 
     routes: {
-      "noCallback": "noCallback",
-      "counter": "counter",
-      "search/:query": "search",
-      "search/:query/p:page": "search",
-      "charñ": "charUTF",
-      "char%C3%B1": "charEscaped",
-      "contacts": "contacts",
-      "contacts/new": "newContact",
-      "contacts/:id": "loadContact",
-      "route-event/:arg": "routeEvent",
-      "optional(/:item)": "optionalItem",
-      "named/optional/(y:z)": "namedOptional",
-      "splat/*args/end": "splat",
-      ":repo/compare/*from...*to": "github",
-      "decode/:named/*splat": "decode",
-      "*first/complex-*part/*rest": "complex",
-      "query/:entity": "query",
-      "function/:value": ExternalObject.routingFunction,
-      "*anything": "anything"
+      'noCallback': 'noCallback',
+      'counter': 'counter',
+      'search/:query': 'search',
+      'search/:query/p:page': 'search',
+      'charñ': 'charUTF',
+      'char%C3%B1': 'charEscaped',
+      'contacts': 'contacts',
+      'contacts/new': 'newContact',
+      'contacts/:id': 'loadContact',
+      'route-event/:arg': 'routeEvent',
+      'optional(/:item)': 'optionalItem',
+      'named/optional/(y:z)': 'namedOptional',
+      'splat/*args/end': 'splat',
+      ':repo/compare/*from...*to': 'github',
+      'decode/:named/*splat': 'decode',
+      '*first/complex-*part/*rest': 'complex',
+      'query/:entity': 'query',
+      'function/:value': ExternalObject.routingFunction,
+      '*anything': 'anything'
     },
 
     initialize: function(options) {
@@ -176,12 +176,12 @@
 
   });
 
-  QUnit.test("initialize", function(assert) {
+  QUnit.test('initialize', function(assert) {
     assert.expect(1);
     assert.equal(router.testing, 101);
   });
 
-  QUnit.test("routes (simple)", function(assert) {
+  QUnit.test('routes (simple)', function(assert) {
     assert.expect(4);
     location.replace('http://example.com#search/news');
     Backbone.history.checkUrl();
@@ -191,17 +191,17 @@
     assert.equal(lastArgs[0], 'news');
   });
 
-  QUnit.test("routes (simple, but unicode)", function(assert) {
+  QUnit.test('routes (simple, but unicode)', function(assert) {
     assert.expect(4);
     location.replace('http://example.com#search/тест');
     Backbone.history.checkUrl();
-    assert.equal(router.query, "тест");
+    assert.equal(router.query, 'тест');
     assert.equal(router.page, void 0);
     assert.equal(lastRoute, 'search');
-    assert.equal(lastArgs[0], "тест");
+    assert.equal(lastArgs[0], 'тест');
   });
 
-  QUnit.test("routes (two part)", function(assert) {
+  QUnit.test('routes (two part)', function(assert) {
     assert.expect(2);
     location.replace('http://example.com#search/nyc/p10');
     Backbone.history.checkUrl();
@@ -209,32 +209,32 @@
     assert.equal(router.page, '10');
   });
 
-  QUnit.test("routes via navigate", function(assert) {
+  QUnit.test('routes via navigate', function(assert) {
     assert.expect(2);
     Backbone.history.navigate('search/manhattan/p20', {trigger: true});
     assert.equal(router.query, 'manhattan');
     assert.equal(router.page, '20');
   });
 
-  QUnit.test("routes via navigate with params", function(assert) {
+  QUnit.test('routes via navigate with params', function(assert) {
     assert.expect(1);
     Backbone.history.navigate('query/test?a=b', {trigger: true});
     assert.equal(router.queryArgs, 'a=b');
   });
 
-  QUnit.test("routes via navigate for backwards-compatibility", function(assert) {
+  QUnit.test('routes via navigate for backwards-compatibility', function(assert) {
     assert.expect(2);
     Backbone.history.navigate('search/manhattan/p20', true);
     assert.equal(router.query, 'manhattan');
     assert.equal(router.page, '20');
   });
 
-  QUnit.test("reports matched route via nagivate", function(assert) {
+  QUnit.test('reports matched route via nagivate', function(assert) {
     assert.expect(1);
     assert.ok(Backbone.history.navigate('search/manhattan/p20', true));
   });
 
-  QUnit.test("route precedence via navigate", function(assert){
+  QUnit.test('route precedence via navigate', function(assert){
     assert.expect(6);
     // check both 0.9.x and backwards-compatibility options
     _.each([{trigger: true}, true], function( options ){
@@ -247,7 +247,7 @@
     });
   });
 
-  QUnit.test("loadUrl is not called for identical routes.", function(assert) {
+  QUnit.test('loadUrl is not called for identical routes.', function(assert) {
     assert.expect(0);
     Backbone.history.loadUrl = function(){ assert.ok(false); };
     location.replace('http://example.com#route');
@@ -256,14 +256,14 @@
     Backbone.history.navigate('/route');
   });
 
-  QUnit.test("use implicit callback if none provided", function(assert) {
+  QUnit.test('use implicit callback if none provided', function(assert) {
     assert.expect(1);
     router.count = 0;
     router.navigate('implicit', {trigger: true});
     assert.equal(router.count, 1);
   });
 
-  QUnit.test("routes via navigate with {replace: true}", function(assert) {
+  QUnit.test('routes via navigate with {replace: true}', function(assert) {
     assert.expect(1);
     location.replace('http://example.com#start_here');
     Backbone.history.checkUrl();
@@ -273,14 +273,14 @@
     Backbone.history.navigate('end_here', {replace: true});
   });
 
-  QUnit.test("routes (splats)", function(assert) {
+  QUnit.test('routes (splats)', function(assert) {
     assert.expect(1);
     location.replace('http://example.com#splat/long-list/of/splatted_99args/end');
     Backbone.history.checkUrl();
     assert.equal(router.args, 'long-list/of/splatted_99args');
   });
 
-  QUnit.test("routes (github)", function(assert) {
+  QUnit.test('routes (github)', function(assert) {
     assert.expect(3);
     location.replace('http://example.com#backbone/compare/1.0...braddunbar:with/slash');
     Backbone.history.checkUrl();
@@ -289,7 +289,7 @@
     assert.equal(router.to, 'braddunbar:with/slash');
   });
 
-  QUnit.test("routes (optional)", function(assert) {
+  QUnit.test('routes (optional)', function(assert) {
     assert.expect(2);
     location.replace('http://example.com#optional');
     Backbone.history.checkUrl();
@@ -299,7 +299,7 @@
     assert.equal(router.arg, 'thing');
   });
 
-  QUnit.test("routes (complex)", function(assert) {
+  QUnit.test('routes (complex)', function(assert) {
     assert.expect(3);
     location.replace('http://example.com#one/two/three/complex-part/four/five/six/seven');
     Backbone.history.checkUrl();
@@ -308,7 +308,7 @@
     assert.equal(router.rest, 'four/five/six/seven');
   });
 
-  QUnit.test("routes (query)", function(assert) {
+  QUnit.test('routes (query)', function(assert) {
     assert.expect(5);
     location.replace('http://example.com#query/mandel?a=b&c=d');
     Backbone.history.checkUrl();
@@ -319,14 +319,14 @@
     assert.equal(lastArgs[1], 'a=b&c=d');
   });
 
-  QUnit.test("routes (anything)", function(assert) {
+  QUnit.test('routes (anything)', function(assert) {
     assert.expect(1);
     location.replace('http://example.com#doesnt-match-a-route');
     Backbone.history.checkUrl();
     assert.equal(router.anything, 'doesnt-match-a-route');
   });
 
-  QUnit.test("routes (function)", function(assert) {
+  QUnit.test('routes (function)', function(assert) {
     assert.expect(3);
     router.on('route', function(name) {
       assert.ok(name === '');
@@ -337,7 +337,7 @@
     assert.equal(ExternalObject.value, 'set');
   });
 
-  QUnit.test("Decode named parameters, not splats.", function(assert) {
+  QUnit.test('Decode named parameters, not splats.', function(assert) {
     assert.expect(2);
     location.replace('http://example.com#decode/a%2Fb/c%2Fd/e');
     Backbone.history.checkUrl();
@@ -347,12 +347,12 @@
 
   QUnit.test("fires event when router doesn't have callback on it", function(assert) {
     assert.expect(1);
-    router.on("route:noCallback", function(){ assert.ok(true); });
+    router.on('route:noCallback', function(){ assert.ok(true); });
     location.replace('http://example.com#noCallback');
     Backbone.history.checkUrl();
   });
 
-  QUnit.test("No events are triggered if #execute returns false.", function(assert) {
+  QUnit.test('No events are triggered if #execute returns false.', function(assert) {
     assert.expect(1);
     var Router = Backbone.Router.extend({
 
@@ -383,7 +383,7 @@
     Backbone.history.checkUrl();
   });
 
-  QUnit.test("#933, #908 - leading slash", function(assert) {
+  QUnit.test('#933, #908 - leading slash', function(assert) {
     assert.expect(2);
     location.replace('http://example.com/root/foo');
 
@@ -398,7 +398,7 @@
     assert.strictEqual(Backbone.history.getFragment(), 'foo');
   });
 
-  QUnit.test("#967 - Route callback gets passed encoded values.", function(assert) {
+  QUnit.test('#967 - Route callback gets passed encoded values.', function(assert) {
     assert.expect(3);
     var route = 'has%2Fslash/complex-has%23hash/has%20space';
     Backbone.history.navigate(route, {trigger: true});
@@ -407,7 +407,7 @@
     assert.strictEqual(router.rest, 'has space');
   });
 
-  QUnit.test("correctly handles URLs with % (#868)", function(assert) {
+  QUnit.test('correctly handles URLs with % (#868)', function(assert) {
     assert.expect(3);
     location.replace('http://example.com#search/fat%3A1.5%25');
     Backbone.history.checkUrl();
@@ -418,7 +418,7 @@
     assert.equal(lastRoute, 'search');
   });
 
-  QUnit.test("#2666 - Hashes with UTF8 in them.", function(assert) {
+  QUnit.test('#2666 - Hashes with UTF8 in them.', function(assert) {
     assert.expect(2);
     Backbone.history.navigate('charñ', {trigger: true});
     assert.equal(router.charType, 'UTF');
@@ -426,7 +426,7 @@
     assert.equal(router.charType, 'UTF');
   });
 
-  QUnit.test("#1185 - Use pathname when hashChange is not wanted.", function(assert) {
+  QUnit.test('#1185 - Use pathname when hashChange is not wanted.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/path/name#hash');
@@ -436,7 +436,7 @@
     assert.strictEqual(fragment, location.pathname.replace(/^\//, ''));
   });
 
-  QUnit.test("#1206 - Strip leading slash before location.assign.", function(assert) {
+  QUnit.test('#1206 - Strip leading slash before location.assign.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root/');
@@ -448,7 +448,7 @@
     Backbone.history.navigate('/fragment');
   });
 
-  QUnit.test("#1387 - Root fragment without trailing slash.", function(assert) {
+  QUnit.test('#1387 - Root fragment without trailing slash.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root');
@@ -457,7 +457,7 @@
     assert.strictEqual(Backbone.history.getFragment(), '');
   });
 
-  QUnit.test("#1366 - History does not prepend root to fragment.", function(assert) {
+  QUnit.test('#1366 - History does not prepend root to fragment.', function(assert) {
     assert.expect(2);
     Backbone.history.stop();
     location.replace('http://example.com/root/');
@@ -478,7 +478,7 @@
     assert.strictEqual(Backbone.history.fragment, 'x');
   });
 
-  QUnit.test("Normalize root.", function(assert) {
+  QUnit.test('Normalize root.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root');
@@ -498,7 +498,7 @@
     Backbone.history.navigate('fragment');
   });
 
-  QUnit.test("Normalize root.", function(assert) {
+  QUnit.test('Normalize root.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root#fragment');
@@ -517,7 +517,7 @@
     });
   });
 
-  QUnit.test("Normalize root.", function(assert) {
+  QUnit.test('Normalize root.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root');
@@ -529,7 +529,7 @@
     });
   });
 
-  QUnit.test("Normalize root - leading slash.", function(assert) {
+  QUnit.test('Normalize root - leading slash.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root');
@@ -544,7 +544,7 @@
     assert.strictEqual(Backbone.history.root, '/root/');
   });
 
-  QUnit.test("Transition from hashChange to pushState.", function(assert) {
+  QUnit.test('Transition from hashChange to pushState.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root#x/y');
@@ -563,7 +563,7 @@
     });
   });
 
-  QUnit.test("#1619: Router: Normalize empty root", function(assert) {
+  QUnit.test('#1619: Router: Normalize empty root', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/');
@@ -578,7 +578,7 @@
     assert.strictEqual(Backbone.history.root, '/');
   });
 
-  QUnit.test("#1619: Router: nagivate with empty root", function(assert) {
+  QUnit.test('#1619: Router: nagivate with empty root', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/');
@@ -598,7 +598,7 @@
     Backbone.history.navigate('fragment');
   });
 
-  QUnit.test("Transition from pushState to hashChange.", function(assert) {
+  QUnit.test('Transition from pushState to hashChange.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root/x/y?a=b');
@@ -618,7 +618,7 @@
     });
   });
 
-  QUnit.test("#1695 - hashChange to pushState with search.", function(assert) {
+  QUnit.test('#1695 - hashChange to pushState with search.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/root#x/y?a=b');
@@ -637,7 +637,7 @@
     });
   });
 
-  QUnit.test("#1746 - Router allows empty route.", function(assert) {
+  QUnit.test('#1746 - Router allows empty route.', function(assert) {
     assert.expect(1);
     var Router = Backbone.Router.extend({
       routes: {'': 'empty'},
@@ -649,18 +649,18 @@
     new Router;
   });
 
-  QUnit.test("#1794 - Trailing space in fragments.", function(assert) {
+  QUnit.test('#1794 - Trailing space in fragments.', function(assert) {
     assert.expect(1);
     var history = new Backbone.History;
     assert.strictEqual(history.getFragment('fragment   '), 'fragment');
   });
 
-  QUnit.test("#1820 - Leading slash and trailing space.", 1, function(assert) {
+  QUnit.test('#1820 - Leading slash and trailing space.', 1, function(assert) {
     var history = new Backbone.History;
     assert.strictEqual(history.getFragment('/fragment '), 'fragment');
   });
 
-  QUnit.test("#1980 - Optional parameters.", function(assert) {
+  QUnit.test('#1980 - Optional parameters.', function(assert) {
     assert.expect(2);
     location.replace('http://example.com#named/optional/y');
     Backbone.history.checkUrl();
@@ -680,13 +680,13 @@
     Backbone.history.checkUrl();
   });
 
-  QUnit.test("#2255 - Extend routes by making routes a function.", function(assert) {
+  QUnit.test('#2255 - Extend routes by making routes a function.', function(assert) {
     assert.expect(1);
     var RouterBase = Backbone.Router.extend({
       routes: function() {
         return {
-          home: "root",
-          index: "index.html"
+          home: 'root',
+          index: 'index.html'
         };
       }
     });
@@ -694,15 +694,15 @@
     var RouterExtended = RouterBase.extend({
       routes: function() {
         var _super = RouterExtended.__super__.routes;
-        return _.extend(_super(), {show: "show", search: "search"});
+        return _.extend(_super(), {show: 'show', search: 'search'});
       }
     });
 
     var router = new RouterExtended();
-    assert.deepEqual({home: "root", index: "index.html", show: "show", search: "search"}, router.routes);
+    assert.deepEqual({home: 'root', index: 'index.html', show: 'show', search: 'search'}, router.routes);
   });
 
-  QUnit.test("#2538 - hashChange to pushState only if both requested.", function(assert) {
+  QUnit.test('#2538 - hashChange to pushState only if both requested.', function(assert) {
     assert.expect(0);
     Backbone.history.stop();
     location.replace('http://example.com/root?a=b#x/y');
@@ -932,7 +932,7 @@
     Backbone.history.start();
   });
 
-  QUnit.test("pushState to hashChange with only search params.", function(assert) {
+  QUnit.test('pushState to hashChange with only search params.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com?a=b');
@@ -946,7 +946,7 @@
     Backbone.history.start({pushState: true});
   });
 
-  QUnit.test("#3123 - History#navigate decodes before comparison.", function(assert) {
+  QUnit.test('#3123 - History#navigate decodes before comparison.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();
     location.replace('http://example.com/shop/search?keyword=short%20dress');
@@ -1023,7 +1023,7 @@
     Backbone.history.start({root: 'root', pushState: true});
   });
 
-  QUnit.test("roots with regex characters", function(assert) {
+  QUnit.test('roots with regex characters', function(assert) {
     assert.expect(1);
     location.replace('http://example.com/x+y.z/foo');
     Backbone.history.stop();
@@ -1035,7 +1035,7 @@
     Backbone.history.start({root: 'x+y.z', pushState: true});
   });
 
-  QUnit.test("roots with unicode characters", function(assert) {
+  QUnit.test('roots with unicode characters', function(assert) {
     assert.expect(1);
     location.replace('http://example.com/®ooτ/foo');
     Backbone.history.stop();
@@ -1047,7 +1047,7 @@
     Backbone.history.start({root: '®ooτ', pushState: true});
   });
 
-  QUnit.test("roots without slash", function(assert) {
+  QUnit.test('roots without slash', function(assert) {
     assert.expect(1);
     location.replace('http://example.com/®ooτ');
     Backbone.history.stop();

--- a/test/sync.js
+++ b/test/sync.js
@@ -6,12 +6,12 @@
   var library;
 
   var attrs = {
-    title: "The Tempest",
-    author: "Bill Shakespeare",
+    title: 'The Tempest',
+    author: 'Bill Shakespeare',
     length: 123
   };
 
-  QUnit.module("Backbone.sync", {
+  QUnit.module('Backbone.sync', {
 
     beforeEach: function(assert) {
       library = new Library;
@@ -24,7 +24,7 @@
 
   });
 
-  QUnit.test("read", function(assert) {
+  QUnit.test('read', function(assert) {
     assert.expect(4);
     library.fetch();
     assert.equal(this.ajaxSettings.url, '/library');
@@ -33,7 +33,7 @@
     assert.ok(_.isEmpty(this.ajaxSettings.data));
   });
 
-  QUnit.test("passing data", function(assert) {
+  QUnit.test('passing data', function(assert) {
     assert.expect(3);
     library.fetch({data: {a: 'a', one: 1}});
     assert.equal(this.ajaxSettings.url, '/library');
@@ -41,7 +41,7 @@
     assert.equal(this.ajaxSettings.data.one, 1);
   });
 
-  QUnit.test("create", function(assert) {
+  QUnit.test('create', function(assert) {
     assert.expect(6);
     assert.equal(this.ajaxSettings.url, '/library');
     assert.equal(this.ajaxSettings.type, 'POST');
@@ -52,7 +52,7 @@
     assert.equal(data.length, 123);
   });
 
-  QUnit.test("update", function(assert) {
+  QUnit.test('update', function(assert) {
     assert.expect(7);
     library.first().save({id: '1-the-tempest', author: 'William Shakespeare'});
     assert.equal(this.ajaxSettings.url, '/library/1-the-tempest');
@@ -65,7 +65,7 @@
     assert.equal(data.length, 123);
   });
 
-  QUnit.test("update with emulateHTTP and emulateJSON", function(assert) {
+  QUnit.test('update with emulateHTTP and emulateJSON', function(assert) {
     assert.expect(7);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'}, {
       emulateHTTP: true,
@@ -81,7 +81,7 @@
     assert.equal(data.length, 123);
   });
 
-  QUnit.test("update with just emulateHTTP", function(assert) {
+  QUnit.test('update with just emulateHTTP', function(assert) {
     assert.expect(6);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'}, {
       emulateHTTP: true
@@ -95,7 +95,7 @@
     assert.equal(data.length, 123);
   });
 
-  QUnit.test("update with just emulateJSON", function(assert) {
+  QUnit.test('update with just emulateJSON', function(assert) {
     assert.expect(6);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'}, {
       emulateJSON: true
@@ -109,7 +109,7 @@
     assert.equal(data.length, 123);
   });
 
-  QUnit.test("read model", function(assert) {
+  QUnit.test('read model', function(assert) {
     assert.expect(3);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().fetch();
@@ -118,7 +118,7 @@
     assert.ok(_.isEmpty(this.ajaxSettings.data));
   });
 
-  QUnit.test("destroy", function(assert) {
+  QUnit.test('destroy', function(assert) {
     assert.expect(3);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().destroy({wait: true});
@@ -127,7 +127,7 @@
     assert.equal(this.ajaxSettings.data, null);
   });
 
-  QUnit.test("destroy with emulateHTTP", function(assert) {
+  QUnit.test('destroy with emulateHTTP', function(assert) {
     assert.expect(3);
     library.first().save({id: '2-the-tempest', author: 'Tim Shakespeare'});
     library.first().destroy({
@@ -139,7 +139,7 @@
     assert.equal(JSON.stringify(this.ajaxSettings.data), '{"_method":"DELETE"}');
   });
 
-  QUnit.test("urlError", function(assert) {
+  QUnit.test('urlError', function(assert) {
     assert.expect(2);
     var model = new Backbone.Model();
     assert.throws(function() {
@@ -149,14 +149,14 @@
     assert.equal(this.ajaxSettings.url, '/one/two');
   });
 
-  QUnit.test("#1052 - `options` is optional.", function(assert) {
+  QUnit.test('#1052 - `options` is optional.', function(assert) {
     assert.expect(0);
     var model = new Backbone.Model();
     model.url = '/test';
     Backbone.sync('create', model);
   });
 
-  QUnit.test("Backbone.ajax", function(assert) {
+  QUnit.test('Backbone.ajax', function(assert) {
     assert.expect(1);
     Backbone.ajax = function(settings){
       assert.strictEqual(settings.url, '/test');
@@ -166,7 +166,7 @@
     Backbone.sync('create', model);
   });
 
-  QUnit.test("Call provided error callback on error.", function(assert) {
+  QUnit.test('Call provided error callback on error.', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model;
     model.url = '/test';
@@ -204,7 +204,7 @@
     assert.strictEqual(this.ajaxSettings.emulateJSON, false);
   });
 
-  QUnit.test("#1756 - Call user provided beforeSend function.", function(assert) {
+  QUnit.test('#1756 - Call user provided beforeSend function.', function(assert) {
     assert.expect(4);
     Backbone.emulateHTTP = true;
     var model = new Backbone.Model;

--- a/test/view.js
+++ b/test/view.js
@@ -2,7 +2,7 @@
 
   var view;
 
-  QUnit.module("Backbone.View", {
+  QUnit.module('Backbone.View', {
 
     beforeEach: function(assert) {
       $('#qunit-fixture').append(
@@ -18,14 +18,14 @@
 
   });
 
-  QUnit.test("constructor", function(assert) {
+  QUnit.test('constructor', function(assert) {
     assert.expect(3);
     assert.equal(view.el.id, 'test-view');
     assert.equal(view.el.className, 'test-view');
     assert.equal(view.el.other, void 0);
   });
 
-  QUnit.test("$", function(assert) {
+  QUnit.test('$', function(assert) {
     assert.expect(2);
     var view = new Backbone.View;
     view.setElement('<p><a><b>test</b></a></p>');
@@ -35,7 +35,7 @@
     assert.ok(result.length === +result.length);
   });
 
-  QUnit.test("$el", function(assert) {
+  QUnit.test('$el', function(assert) {
     assert.expect(3);
     var view = new Backbone.View;
     view.setElement('<p><a><b>test</b></a></p>');
@@ -45,7 +45,7 @@
     assert.strictEqual(view.$el[0], view.el);
   });
 
-  QUnit.test("initialize", function(assert) {
+  QUnit.test('initialize', function(assert) {
     assert.expect(1);
     var View = Backbone.View.extend({
       initialize: function() {
@@ -56,13 +56,13 @@
     assert.strictEqual(new View().one, 1);
   });
 
-  QUnit.test("render", function(assert) {
+  QUnit.test('render', function(assert) {
     assert.expect(1);
     var view = new Backbone.View;
     assert.equal(view.render(), view, '#render returns the view instance');
   });
 
-  QUnit.test("delegateEvents", function(assert) {
+  QUnit.test('delegateEvents', function(assert) {
     assert.expect(6);
     var counter1 = 0, counter2 = 0;
 
@@ -87,7 +87,7 @@
     assert.equal(counter2, 3);
   });
 
-  QUnit.test("delegate", function(assert) {
+  QUnit.test('delegate', function(assert) {
     assert.expect(3);
     var view = new Backbone.View({el: '#testElement'});
     view.delegate('click', 'h1', function() {
@@ -101,7 +101,7 @@
     assert.equal(view.delegate(), view, '#delegate returns the view instance');
   });
 
-  QUnit.test("delegateEvents allows functions for callbacks", function(assert) {
+  QUnit.test('delegateEvents allows functions for callbacks', function(assert) {
     assert.expect(3);
     var view = new Backbone.View({el: '<p></p>'});
     view.counter = 0;
@@ -125,14 +125,14 @@
   });
 
 
-  QUnit.test("delegateEvents ignore undefined methods", function(assert) {
+  QUnit.test('delegateEvents ignore undefined methods', function(assert) {
     assert.expect(0);
     var view = new Backbone.View({el: '<p></p>'});
     view.delegateEvents({'click': 'undefinedMethod'});
     view.$el.trigger('click');
   });
 
-  QUnit.test("undelegateEvents", function(assert) {
+  QUnit.test('undelegateEvents', function(assert) {
     assert.expect(7);
     var counter1 = 0, counter2 = 0;
 
@@ -160,7 +160,7 @@
     assert.equal(view.undelegateEvents(), view, '#undelegateEvents returns the view instance');
   });
 
-  QUnit.test("undelegate", function(assert) {
+  QUnit.test('undelegate', function(assert) {
     assert.expect(1);
     view = new Backbone.View({el: '#testElement'});
     view.delegate('click', function() { assert.ok(false); });
@@ -174,7 +174,7 @@
     assert.equal(view.undelegate(), view, '#undelegate returns the view instance');
   });
 
-  QUnit.test("undelegate with passed handler", function(assert) {
+  QUnit.test('undelegate with passed handler', function(assert) {
     assert.expect(1);
     view = new Backbone.View({el: '#testElement'});
     var listener = function() { assert.ok(false); };
@@ -184,7 +184,7 @@
     view.$el.trigger('click');
   });
 
-  QUnit.test("undelegate with selector", function(assert) {
+  QUnit.test('undelegate with selector', function(assert) {
     assert.expect(2);
     view = new Backbone.View({el: '#testElement'});
     view.delegate('click', function() { assert.ok(true); });
@@ -194,7 +194,7 @@
     view.$el.trigger('click');
   });
 
-  QUnit.test("undelegate with handler and selector", function(assert) {
+  QUnit.test('undelegate with handler and selector', function(assert) {
     assert.expect(2);
     view = new Backbone.View({el: '#testElement'});
     view.delegate('click', function() { assert.ok(true); });
@@ -205,7 +205,7 @@
     view.$el.trigger('click');
   });
 
-  QUnit.test("tagName can be provided as a string", function(assert) {
+  QUnit.test('tagName can be provided as a string', function(assert) {
     assert.expect(1);
     var View = Backbone.View.extend({
       tagName: 'span'
@@ -214,7 +214,7 @@
     assert.equal(new View().el.tagName, 'SPAN');
   });
 
-  QUnit.test("tagName can be provided as a function", function(assert) {
+  QUnit.test('tagName can be provided as a function', function(assert) {
     assert.expect(1);
     var View = Backbone.View.extend({
       tagName: function() {
@@ -225,7 +225,7 @@
     assert.ok(new View().$el.is('p'));
   });
 
-  QUnit.test("_ensureElement with DOM node el", function(assert) {
+  QUnit.test('_ensureElement with DOM node el', function(assert) {
     assert.expect(1);
     var View = Backbone.View.extend({
       el: document.body
@@ -234,25 +234,25 @@
     assert.equal(new View().el, document.body);
   });
 
-  QUnit.test("_ensureElement with string el", function(assert) {
+  QUnit.test('_ensureElement with string el', function(assert) {
     assert.expect(3);
     var View = Backbone.View.extend({
-      el: "body"
+      el: 'body'
     });
     assert.strictEqual(new View().el, document.body);
 
     View = Backbone.View.extend({
-      el: "#testElement > h1"
+      el: '#testElement > h1'
     });
-    assert.strictEqual(new View().el, $("#testElement > h1").get(0));
+    assert.strictEqual(new View().el, $('#testElement > h1').get(0));
 
     View = Backbone.View.extend({
-      el: "#nonexistent"
+      el: '#nonexistent'
     });
     assert.ok(!new View().el);
   });
 
-  QUnit.test("with className and id functions", function(assert) {
+  QUnit.test('with className and id functions', function(assert) {
     assert.expect(2);
     var View = Backbone.View.extend({
       className: function() {
@@ -267,7 +267,7 @@
     assert.strictEqual(new View().el.id, 'id');
   });
 
-  QUnit.test("with attributes", function(assert) {
+  QUnit.test('with attributes', function(assert) {
     assert.expect(2);
     var View = Backbone.View.extend({
       attributes: {
@@ -280,7 +280,7 @@
     assert.strictEqual(new View().el.id, 'id');
   });
 
-  QUnit.test("with attributes as a function", function(assert) {
+  QUnit.test('with attributes as a function', function(assert) {
     assert.expect(1);
     var View = Backbone.View.extend({
       attributes: function() {
@@ -291,7 +291,7 @@
     assert.strictEqual(new View().el.className, 'dynamic');
   });
 
-  QUnit.test("should default to className/id properties", function(assert) {
+  QUnit.test('should default to className/id properties', function(assert) {
     assert.expect(4);
     var View = Backbone.View.extend({
       className: 'backboneClass',
@@ -309,7 +309,7 @@
     assert.strictEqual(view.$el.attr('id'), 'backboneId');
   });
 
-  QUnit.test("multiple views per element", function(assert) {
+  QUnit.test('multiple views per element', function(assert) {
     assert.expect(3);
     var count = 0;
     var $el = $('<p></p>');
@@ -324,24 +324,24 @@
     });
 
     var view1 = new View;
-    $el.trigger("click");
+    $el.trigger('click');
     assert.equal(1, count);
 
     var view2 = new View;
-    $el.trigger("click");
+    $el.trigger('click');
     assert.equal(3, count);
 
     view1.delegateEvents();
-    $el.trigger("click");
+    $el.trigger('click');
     assert.equal(5, count);
   });
 
-  QUnit.test("custom events", function(assert) {
+  QUnit.test('custom events', function(assert) {
     assert.expect(2);
     var View = Backbone.View.extend({
       el: $('body'),
       events: {
-        "fake$event": function() { assert.ok(true); }
+        'fake$event': function() { assert.ok(true); }
       }
     });
 
@@ -352,7 +352,7 @@
     $('body').trigger('fake$event');
   });
 
-  QUnit.test("#1048 - setElement uses provided object.", function(assert) {
+  QUnit.test('#1048 - setElement uses provided object.', function(assert) {
     assert.expect(2);
     var $el = $('body');
 
@@ -363,7 +363,7 @@
     assert.ok(view.$el === $el);
   });
 
-  QUnit.test("#986 - Undelegate before changing element.", function(assert) {
+  QUnit.test('#986 - Undelegate before changing element.', function(assert) {
     assert.expect(1);
     var button1 = $('<button></button>');
     var button2 = $('<button></button>');
@@ -383,7 +383,7 @@
     button2.trigger('click');
   });
 
-  QUnit.test("#1172 - Clone attributes object", function(assert) {
+  QUnit.test('#1172 - Clone attributes object', function(assert) {
     assert.expect(2);
     var View = Backbone.View.extend({
       attributes: {foo: 'bar'}
@@ -396,7 +396,7 @@
     assert.ok(!view2.el.id);
   });
 
-  QUnit.test("views stopListening", function(assert) {
+  QUnit.test('views stopListening', function(assert) {
     assert.expect(0);
     var View = Backbone.View.extend({
       initialize: function() {
@@ -415,11 +415,11 @@
     view.collection.trigger('x');
   });
 
-  QUnit.test("Provide function for el.", function(assert) {
+  QUnit.test('Provide function for el.', function(assert) {
     assert.expect(2);
     var View = Backbone.View.extend({
       el: function() {
-        return "<p><a></a></p>";
+        return '<p><a></a></p>';
       }
     });
 
@@ -428,7 +428,7 @@
     assert.ok(view.$el.has('a'));
   });
 
-  QUnit.test("events passed in options", function(assert) {
+  QUnit.test('events passed in options', function(assert) {
     assert.expect(1);
     var counter = 0;
 
@@ -449,7 +449,7 @@
     assert.equal(counter, 2);
   });
 
-  QUnit.test("remove", function(assert) {
+  QUnit.test('remove', function(assert) {
     assert.expect(2);
     var view = new Backbone.View;
     document.body.appendChild(view.el);
@@ -465,7 +465,7 @@
     assert.notEqual(view.el.parentNode, document.body);
   });
 
-  QUnit.test("setElement", function(assert) {
+  QUnit.test('setElement', function(assert) {
     assert.expect(3);
     var view = new Backbone.View({
       events: {

--- a/test/view.js
+++ b/test/view.js
@@ -271,7 +271,7 @@
     assert.expect(2);
     var View = Backbone.View.extend({
       attributes: {
-        id: 'id',
+        'id': 'id',
         'class': 'class'
       }
     });
@@ -341,7 +341,7 @@
     var View = Backbone.View.extend({
       el: $('body'),
       events: {
-        'fake$event': function() { assert.ok(true); }
+        fake$event: function() { assert.ok(true); }
       }
     });
 


### PR DESCRIPTION
In an attempt to batch these changes together, this pull request includes a number of new rules (all taken from Underscore's `.eslintrc`).

Each commit reflects the changes needed for a single rule, so I would recommend reviewing by commit.

@akre54, @megawac c4b27bd May be controversial in the same way that https://github.com/jashkenas/backbone/pull/3893 was.

If we want some but not all of these, I'm happy to go back to submitting them as individual pull requests.