### PR TITLE
Enable ESLint rule: new-cap

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -17,6 +17,7 @@
     "linebreak-style": 2,
     "max-depth": [1, 4],
     "max-params": [1, 5],
+    "new-cap": [2, {"newIsCapExceptions": ["model"]}],
     "no-alert": 2,
     "no-caller": 2,
     "no-catch-shadow": 2,

--- a/test/collection.js
+++ b/test/collection.js
@@ -1214,12 +1214,12 @@
     assert.expect(3);
     var m1 = {_id: 1};
     var m2 = {_id: 2};
-    var col = Backbone.Collection.extend({
+    var Col = Backbone.Collection.extend({
       model: Backbone.Model.extend({
         idAttribute: '_id'
       })
     });
-    var c = new col;
+    var c = new Col;
     c.set([m1, m2]);
     assert.equal(c.length, 2);
     c.set([m1]);

--- a/test/model.js
+++ b/test/model.js
@@ -1,7 +1,7 @@
 (function() {
 
-  var proxy = Backbone.Model.extend();
-  var klass = Backbone.Collection.extend({
+  var ProxyModel = Backbone.Model.extend();
+  var Klass = Backbone.Collection.extend({
     url: function() { return '/collection'; }
   });
   var doc, collection;
@@ -9,13 +9,13 @@
   QUnit.module("Backbone.Model", {
 
     beforeEach: function(assert) {
-      doc = new proxy({
+      doc = new ProxyModel({
         id: '1-the-tempest',
         title: "The Tempest",
         author: "Bill Shakespeare",
         length: 123
       });
-      collection = new klass();
+      collection = new Klass();
       collection.add(doc);
     }
 


### PR DESCRIPTION
Constructor functions must start with a capital letter.

Since #3894 has been slow to merge, I'm going to try opening per-commit pull requests which should be easier to review/discuss.