### PR TITLE
Add ESLint rule: wrap-iife (inside)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -71,6 +71,7 @@
     "space-return-throw-case": 2,
     "space-unary-ops": [2, { "words": true, "nonwords": false }],
     "use-isnan": 2,
-    "valid-typeof": 2
+    "valid-typeof": 2,
+    "wrap-iife": [2, "inside"]
   }
 }

--- a/backbone.js
+++ b/backbone.js
@@ -31,7 +31,7 @@
     root.Backbone = factory(root, {}, root._, (root.jQuery || root.Zepto || root.ender || root.$));
   }
 
-}(function(root, Backbone, _, $) {
+})(function(root, Backbone, _, $) {
 
   // Initial Setup
   // -------------
@@ -1894,4 +1894,4 @@
 
   return Backbone;
 
-}));
+});


### PR DESCRIPTION
An alternative to #3898. Note that while this allows us to keep our tests in their current state, it brings `backbone.js` slightly farther away from the UMD template (https://github.com/umdjs/umd/blob/master/templates/amdWebGlobal.js)