### PR TITLE
Enable ESLint brace-style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
   },
   "rules": {
     "array-bracket-spacing": [2],
+    "brace-style": [1, "1tbs", {"allowSingleLine": true}],
     "camelcase": 2,
     "comma-dangle": [2, "never"],
     "comma-spacing": 2,


### PR DESCRIPTION
By allowing the single-line exception, we can add this rule with no changes.