### PR TITLE
Add ESLint warning: no-extra-parens

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -38,6 +38,7 @@
     "no-ex-assign": 2,
     "no-extend-native": 2,
     "no-extra-boolean-cast": 2,
+    "no-extra-parens": 1,
     "no-extra-semi": 2,
     "no-fallthrough": 2,
     "no-floating-decimal": 2,

--- a/backbone.js
+++ b/backbone.js
@@ -840,7 +840,7 @@
       var remove = options.remove;
 
       var sort = false;
-      var sortable = this.comparator && (at == null) && options.sort !== false;
+      var sortable = this.comparator && at == null && options.sort !== false;
       var sortAttr = _.isString(this.comparator) ? this.comparator : null;
 
       // Turn bare objects into model references, and prevent invalid models
@@ -1802,7 +1802,7 @@
       // fragment to store history.
       } else if (this._wantsHashChange) {
         this._updateHash(this.location, fragment, options.replace);
-        if (this.iframe && (fragment !== this.getHash(this.iframe.contentWindow))) {
+        if (this.iframe && fragment !== this.getHash(this.iframe.contentWindow)) {
           var iWindow = this.iframe.contentWindow;
 
           // Opening and closing the iframe tricks IE7 and earlier to push a

--- a/test/events.js
+++ b/test/events.js
@@ -427,7 +427,7 @@
     };
 
     var obj = _.extend({}, Backbone.Events);
-    obj.on('event', function() { this.assertTrue(); }, (new TestClass));
+    obj.on('event', function() { this.assertTrue(); }, new TestClass);
     obj.trigger('event');
   });
 


### PR DESCRIPTION
This is only enabled as a warning, since in some cases I think it adds clarity. I left the "gratuitous parentheses" when they were clarifying nested ternary operators or clarifying the evaluation order of `&&`s and `||`s.