### PR TITLE
Add ESLint rule: no-unused-expressions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -66,6 +66,7 @@
     "no-undefined": 2,
     "no-unneeded-ternary": 2,
     "no-unreachable": 2,
+    "no-unused-expressions": [2, {"allowTernary": true, "allowShortCircuit": true}],
     "no-with": 2,
     "object-curly-spacing": [2, "never"],
     "quote-props": [1, "consistent-as-needed"],


### PR DESCRIPTION
Unlike pull request #3904, this pull request includes the "allowShortCircuit" exception which allows us to keep our code as it is.