### PR TITLE
fixed Safari related issue with wrong data put to location.hash

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1801,7 +1801,7 @@
       // If hash changes haven't been explicitly disabled, update the hash
       // fragment to store history.
       } else if (this._wantsHashChange) {
-        this._updateHash(this.location, fragment, options.replace);
+        this._updateHash(this.location, fragment);
         if (this.iframe && fragment !== this.getHash(this.iframe.contentWindow)) {
           var iWindow = this.iframe.contentWindow;
 
@@ -1813,7 +1813,7 @@
             iWindow.document.close();
           }
 
-          this._updateHash(iWindow.location, fragment, options.replace);
+          this._updateHash(iWindow.location, fragment);
         }
 
       // If you've told us that you explicitly don't want fallback hashchange-
@@ -1826,14 +1826,10 @@
 
     // Update the hash location, either replacing the current entry, or adding
     // a new one to the browser history.
-    _updateHash: function(location, fragment, replace) {
-      if (replace) {
-        var href = location.href.replace(/(javascript:|#).*$/, '');
-        location.replace(href + '#' + fragment);
-      } else {
-        // Some browsers require that `hash` contains a leading #.
-        location.hash = '#' + fragment;
-      }
+    _updateHash: function(location, fragment) {
+      location.hash = '#' + fragment;
+      var href = location.href.replace(/(javascript:|#).*$/, '');
+      location.replace(href + '#' + fragment);
     }
 
   });

--- a/test/router.js
+++ b/test/router.js
@@ -431,7 +431,7 @@
     var route = '#北їñ';
     var isSafari = navigator.appVersion.indexOf('Version/') != -1;
     //PhantomJS changes location.hash to unicode as well
-    var isPhantomJs = navigator.appVersion.indexOf'PhantomJS/') != -1;
+    var isPhantomJs = navigator.appVersion.indexOf('PhantomJS/') != -1;
     var result = isSafari || isPhantomJs ? '#%E5%8C%97%D1%97%C3%B1' : route;
 
     location.replace('http://example.com' + route);

--- a/test/router.js
+++ b/test/router.js
@@ -429,8 +429,10 @@
   QUnit.test('#2667 - Hashes with unicode in them. Safari related issue', function(assert) {
     assert.expect(2);
     var route = '#北їñ'
-    var isSafari = navigator.appVersion.indexOf("Version/") != -1;
-    var result = isSafari ? '#%E5%8C%97%D1%97%C3%B1' : route;
+    var isSafari = navigator.appVersion.indexOf("Version/") != -1
+    //PhantomJS does changes location.hash to unicode as well
+    var isPhantomJs = navigator.appVersion.indexOf("PhantomJS/") != -1
+    var result = isSafari || isPhantomJs ? '#%E5%8C%97%D1%97%C3%B1' : route;
 
     location.replace('http://example.com' + route);
     assert.equal(location.hash, result);

--- a/test/router.js
+++ b/test/router.js
@@ -428,10 +428,10 @@
 
   QUnit.test('#2667 - Hashes with unicode in them. Safari related issue', function(assert) {
     assert.expect(2);
-    var route = '#北їñ'
-    var isSafari = navigator.appVersion.indexOf("Version/") != -1
-    //PhantomJS does changes location.hash to unicode as well
-    var isPhantomJs = navigator.appVersion.indexOf("PhantomJS/") != -1
+    var route = '#北їñ';
+    var isSafari = navigator.appVersion.indexOf('Version/') != -1;
+    //PhantomJS changes location.hash to unicode as well
+    var isPhantomJs = navigator.appVersion.indexOf'PhantomJS/') != -1;
     var result = isSafari || isPhantomJs ? '#%E5%8C%97%D1%97%C3%B1' : route;
 
     location.replace('http://example.com' + route);

--- a/test/router.js
+++ b/test/router.js
@@ -426,6 +426,18 @@
     assert.equal(router.charType, 'UTF');
   });
 
+  QUnit.test('#2667 - Hashes with unicode in them. Safari related issue', function(assert) {
+    assert.expect(2);
+    var route = '#北їñ'
+    var isSafari = navigator.appVersion.indexOf("Version/") != -1;
+    var result = isSafari ? '#%E5%8C%97%D1%97%C3%B1' : route;
+
+    location.replace('http://example.com' + route);
+    assert.equal(location.hash, result);
+    Backbone.history.navigate(route);
+    assert.equal(location.hash, result);
+  });
+
   QUnit.test('#1185 - Use pathname when hashChange is not wanted.', function(assert) {
     assert.expect(1);
     Backbone.history.stop();


### PR DESCRIPTION
Fix for the issues https://github.com/jashkenas/backbone/issues/3857  and https://github.com/jashkenas/backbone/issues/3830
I'm not sure if everything was covered by tests previously, but changing the code does not affected old tests.
I've added Safari related test case to make them green when karma runs with safari.
> ./node_modules/.bin/karma start --browsers=Safari

The only problem now is that location.hash in Safari is encoded while in other browsers it is the same as in url. But anyway it works with no errors.
![safari](https://cloud.githubusercontent.com/assets/746383/12007344/7dbaf450-ac08-11e5-8f38-eeb250882570.gif)

![chrome](https://cloud.githubusercontent.com/assets/746383/12007346/8578c12c-ac08-11e5-84f8-7850a30495a4.gif)