### PR TITLE
Avoid nested ternary

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -822,10 +822,12 @@
       if (models == null) return;
 
       options = _.defaults({}, options, setOptions);
-      if (options.parse && !this._isModel(models)) models = this.parse(models, options);
+      if (options.parse && !this._isModel(models)) {
+        models = this.parse(models, options) || [];
+      }
 
       var singular = !_.isArray(models);
-      models = singular ? (models ? [models] : []) : models.slice();
+      models = singular ? [models] : models.slice();
 
       var at = options.at;
       if (at != null) at = +at;


### PR DESCRIPTION
While looking into adding the "no-nested-ternary" ESLint rule, I realized that this logic could be refactored a bit.

This nested ternary was introduced in pull request #3875 in order to handle falsy returns from `parse()`.

This refactor avoids the nested ternary and also makes the intent clearer by associating the empty array directly with `parse()`'s return.

It also more narrowly handles the falsy case (we never intended to allow you call `set(0)` for example.)

The only down side I can see is that if `parse()` returns falsy, we will unnecessarily slice/clone the empty array we just created.

(@jridgewell)
