### PR TITLE
Fix undefined attrs in modelId

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1069,7 +1069,7 @@
 
     // Define how to uniquely identify models in the collection.
     modelId: function(attrs) {
-      return attrs[this.model.prototype.idAttribute || 'id'];
+      return attrs ? attrs[this.model.prototype.idAttribute || 'id'] : null;
     },
 
     // Private method to reset all internal state. Called when the collection


### PR DESCRIPTION
When I use set method on a model it automatically trigger 'change' event and in my case I don't have previousAttributes.
The problem is that the method _onModelEvent send 'undefined' attrs to the modelId which end by crashing.