### PR TITLE
add `has` method to collection

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -973,6 +973,11 @@
       return this._byId[obj] || this._byId[id] || this._byId[obj.cid];
     },
 
+    // Returns `true` if the model is in the collection.
+    has: function(obj) {
+      return this.get(obj) != null;
+    },
+
     // Get the model at the given index.
     at: function(index) {
       if (index < 0) index += this.length;

--- a/test/collection.js
+++ b/test/collection.js
@@ -106,6 +106,26 @@
     assert.equal(collection.get(1).id, 1);
   });
 
+  QUnit.test('has', function(assert) {
+    assert.expect(15);
+    assert.ok(col.has(a));
+    assert.ok(col.has(b));
+    assert.ok(col.has(c));
+    assert.ok(col.has(d));
+    assert.ok(col.has(a.id));
+    assert.ok(col.has(b.id));
+    assert.ok(col.has(c.id));
+    assert.ok(col.has(d.id));
+    assert.ok(col.has(a.cid));
+    assert.ok(col.has(b.cid));
+    assert.ok(col.has(c.cid));
+    assert.ok(col.has(d.cid));
+    var outsider = new Backbone.Model({id: 4});
+    assert.notOk(col.has(outsider));
+    assert.notOk(col.has(outsider.id));
+    assert.notOk(col.has(outsider.cid));
+  });
+
   QUnit.test('update index when id changes', function(assert) {
     assert.expect(4);
     var col = new Backbone.Collection();


### PR DESCRIPTION
Adds a `has` method to the collection prototype. Analogous to Model#[has](https://github.com/jashkenas/backbone/blob/master/backbone.js#L451)