### PR TITLE
remove unnecessary logic

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1074,7 +1074,7 @@
 
     // Define how to uniquely identify models in the collection.
     modelId: function(attrs) {
-      return attrs[this.model.prototype.idAttribute || 'id'];
+      return attrs[this.model.prototype.idAttribute];
     },
 
     // Private method to reset all internal state. Called when the collection


### PR DESCRIPTION
I'd also be in favor of changing the comment for `modelId` if there's interest, from `Define how to uniquely identify models in the collection` to `Returns the unique identification of a model for the collection` ..even though that's only half the story since it's stored by cid as well.