### PR TITLE
fix modelId example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1796,10 +1796,9 @@ var Library = Backbone.Collection.extend({
 var Library = Backbone.Collection.extend({
   modelId: function(attrs) {
     if (attrs.type === 'dvd') {
-      return 'dvd' + attrs.dvd_id;
-    } else {
-      return 'vhs' + attrs.vhs_id;
+      return 'dvd' + attrs.id;
     }
+    return 'vhs' + attrs.id;
   }
 });
 
@@ -1808,7 +1807,9 @@ var library = new Library([
   {type: 'vhs', id: 1}
 ]);
 
-alert('dvd: ' + library.get('dvd1').id + ', vhs: ' + library.get('vhs1').id);
+var dvdId = library.get('dvd1').id;
+var vhsId = library.get('vhs1').id;
+alert('dvd: ' + dvdId + ', vhs: ' + vhsId);
 
 </pre>
 


### PR DESCRIPTION
The modelId docs on backbonejs.org were [fixed](https://github.com/jashkenas/backbone/commit/8011b5c75b60a88a61abe0a3779b70b1b2bbeda9) (though not yet on backbonejs.org). This fixes an oversight which results in `dvdundefined` and `vhsundefined` being stored and accessed in the _byId object :) 

Also, breaks the final line up for display reasons
![screen shot 2016-01-23 at 10 59 57 pm](https://cloud.githubusercontent.com/assets/6545515/12534387/31210520-c225-11e5-8466-6c71e1f3fd68.png)
