### PR TITLE
add a collection modelIdAttribute

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -381,6 +381,8 @@
   // want global "pubsub" in a convenient place.
   _.extend(Backbone, Events);
 
+  var defaultIdAttribute = 'id';
+
   // Backbone.Model
   // --------------
 
@@ -415,7 +417,7 @@
 
     // The default name for the JSON `id` attribute is `"id"`. MongoDB and
     // CouchDB users may want to set this to `"_id"`.
-    idAttribute: 'id',
+    idAttribute: defaultIdAttribute,
 
     // The prefix is used to create the client id which is used to identify models locally.
     // You may want to override this if you're experiencing name clashes with model ids.
@@ -755,6 +757,7 @@
     options || (options = {});
     if (options.model) this.model = options.model;
     if (options.comparator !== void 0) this.comparator = options.comparator;
+    if (options.modelIdAttribute !== void 0) this.modelIdAttribute = options.modelIdAttribute;
     this._reset();
     this.initialize.apply(this, arguments);
     if (models) this.reset(models, _.extend({silent: true}, options));
@@ -1068,13 +1071,19 @@
     clone: function() {
       return new this.constructor(this.models, {
         model: this.model,
-        comparator: this.comparator
+        comparator: this.comparator,
+        modelIdAttribute: this.modelIdAttribute
       });
     },
 
-    // Define how to uniquely identify models in the collection.
+    // Returns the value by which the model is uniquely
+    // identified in the colleciton.
     modelId: function(attrs) {
-      return attrs[this.model.prototype.idAttribute || 'id'];
+      return attrs [
+        this.modelIdAttribute ||
+        this.model.prototype.idAttribute ||
+        defaultIdAttribute
+      ];
     },
 
     // Private method to reset all internal state. Called when the collection

--- a/index.html
+++ b/index.html
@@ -378,6 +378,7 @@
       <li>– <a href="#Collection-extend">extend</a></li>
       <li>– <a href="#Collection-model">model</a></li>
       <li>– <a href="#Collection-modelId">modelId</a></li>
+      <li>– <a href="#Collection-modelIdAttribute">modelIdAttribute</a></li>
       <li>– <a href="#Collection-constructor">constructor / initialize</a></li>
       <li>– <a href="#Collection-models">models</a></li>
       <li>– <a href="#Collection-toJSON">toJSON</a></li>
@@ -1784,12 +1785,16 @@ var Library = Backbone.Collection.extend({
     </p>
 
     <p>
-      By default returns the value of the attributes'
+      If a <a href="#Collection-modelIdAttribute"><tt>modelIdAttribute</tt></a>
+      is present, <tt>modelId</tt> returns the value of the attributes'
+      <tt>modelIdAttribute</tt>. Otherwise, returns the value of the attributes'
       <a href="#Model-idAttribute"><tt>idAttribute</tt></a>
-      from the collection's model class or failing that, <tt>id</tt>. If
+      from the collection's model class or failing that
+      (eg, in the case of a <a href="#Collection-model">model factory</a>, <tt>id</tt>. If
       your collection uses a <a href="#Collection-model">model factory</a> and
       those models have an <tt>idAttribute</tt> other than <tt>id</tt> you must
-      override this method.
+      either define a <a href="#Collection-modelIdAttribute"><tt>modelIdAttribute</tt></a>
+      or override this method.
     </p>
 
 <pre class="runnable">
@@ -1812,13 +1817,49 @@ alert('dvd: ' + library.get('dvd1').id + ', vhs: ' + library.get('vhs1').id);
 
 </pre>
 
+    <p id="Collection-modelIdAttribute">
+      <b class="header">modelIdAttribute</b><code>collection.modelIdAttribute</code>
+      <br />
+      Optionally you may define the key for <a href="#Collection-modelId"><tt>modelId</tt></a>
+      by which models in the collection are uniquely identified.
+    </p>
+
+    <p>
+      If your collection uses a
+      <a href="#Collection-model">model factory</a> and those models
+      have an <tt>idAttribute</tt> other than <tt>id</tt> you must
+      define this property or override
+      <a href="#Collection-modelId"><tt>modelId</tt></a>.
+    </p>
+
+<pre class="runnable">
+      var Book = Backbone.Model.extend({
+        idAttribute: '_id'
+      });
+      var Magazine = Backbone.Model.extend({
+        idAttribute: '_id'
+      });
+      var Library = Backbone.Collection.extend({
+        modelIdAttribute: '_id',
+        model: function(attrs) {
+          return attrs.type === 'book'
+            ? new Book(attrs)
+            : new Magazine(attrs);
+        }
+      });
+      var library = new Library({'type': 'book', '_id': 1});
+      alert('The first item is a ' + library.get(1).get('type'));
+</pre>
+
     <p id="Collection-constructor">
       <b class="header">constructor / initialize</b><code>new Backbone.Collection([models], [options])</code>
       <br />
       When creating a Collection, you may choose to pass in the initial array
       of <b>models</b>.  The collection's <a href="#Collection-comparator">comparator</a>
       may be included as an option. Passing <tt>false</tt> as the
-      comparator option will prevent sorting. If you define an
+      comparator option will prevent sorting. The collection's
+      <a href="#Collection-modelIdAttribute"><tt>modelIdAttribute</tt></a> may be included
+      as an option to define the models' uniquely identifying key in the collection.
       <b>initialize</b> function, it will be invoked when the collection is
       created. There are a couple of options that, if provided, are attached to
       the collection directly: <tt>model</tt> and <tt>comparator</tt>.<br />

--- a/test/collection.js
+++ b/test/collection.js
@@ -1719,6 +1719,7 @@
     assert.equal(c1.modelId({id: 1}), 1);
 
     // If the polymorphic models define their own idAttribute,
+    // either a modelIdAttribute should be provided or
     // the modelId method should be overridden, for the reason below.
     var M = Backbone.Model.extend({
       idAttribute: '_id'
@@ -1735,6 +1736,30 @@
     c2.add(m);
     assert.equal(c2.get(2), void 0);
     assert.equal(c2.modelId(m.attributes), void 0);
+  });
+
+  QUnit.test('Collection with polymorphic models using modelIdAttribute', function(assert) {
+    assert.expect(3);
+
+    var collection = new Backbone.Collection([], {modelIdAttribute: '_id'});
+    collection.add({'_id': 10});
+    assert.equal(collection.get(10), collection.at(0));
+
+    var M = Backbone.Model.extend({
+      idAttribute: '_id'
+    });
+    var Coll = Backbone.Collection.extend({
+      modelIdAttribute: '_id',
+      model: function(attrs) {
+        return new M(attrs);
+      }
+    });
+    var m = new M({'_id': 100});
+    var coll = new Coll(m);
+    assert.equal(coll.get(100), coll.at(0));
+
+    var collClone = coll.clone();
+    assert.equal(collClone.get(100), collClone.at(0));
   });
 
   QUnit.test('#3039: adding at index fires with correct at', function(assert) {


### PR DESCRIPTION
Define an optional `modelIdAttribute` for collections. If present it is used as the key by which models are uniquely identified in a collection. Useful for when using a model factory.