### PR TITLE
Fixing object notation for Events.once

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -309,7 +309,7 @@
   Events.once = function(name, callback, context) {
     // Map the event into a `{event: once}` object.
     var events = eventsApi(onceMap, {}, name, callback, _.bind(this.off, this));
-    return this.on(events, void 0, context);
+    return this.on(events, callback, context);
   };
 
   // Inversion-of-control versions of `once`.

--- a/test/events.js
+++ b/test/events.js
@@ -587,6 +587,19 @@
     assert.equal(obj.counter, 3);
   });
 
+  QUnit.test('bind a callback with a supplied context using once with object notation', function(assert) {
+    assert.expect(1);
+    var obj = {counter: 0};
+    var context = {};
+    _.extend(obj, Backbone.Events);
+
+    obj.once({
+      a: function() {
+        assert.strictEqual(this, context, 'defaults `context` to `callback` param');
+      }
+    }, context).trigger('a');
+  });
+
   QUnit.test('once with off only by context', function(assert) {
     assert.expect(0);
     var context = {};


### PR DESCRIPTION
Upon upgrading, I found that Events.once was no longer passing context through when using object notation.

```javascript
this.once({closed: this.onClosed, shown: this.onShown}, this);
```

Other event handling forms were still functioning properly:

```javascript
this.on({closed: this.onClosed, shown: this.onShown}, this);
this.once('closed', this.onClosed, this);
this.once('shown', this.onShown, this);
```

I couldn't find a changeset explaining why `undefined` was being passed through instead of the callback object, but doing so drops the context when two arguments were used.