### PR TITLE
Update Collection such that models created by a Collection have model urlRoot == collection.url

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1090,11 +1090,14 @@
     _prepareModel: function(attrs, options) {
       if (this._isModel(attrs)) {
         if (!attrs.collection) attrs.collection = this;
+        if (!attrs.urlRoot) attrs.urlRoot = this.url;
         return attrs;
       }
       options = options ? _.clone(options) : {};
       options.collection = this;
+      options.urlRoot = this.url;
       var model = new this.model(attrs, options);
+      if (!model.urlRoot) model.urlRoot = this.url;
       if (!model.validationError) return model;
       this.trigger('invalid', this, model.validationError, options);
       return false;


### PR DESCRIPTION
Minor change. refs #3944. `rootUrl` can now be set at Model.initialize() to allow Collection created models, or models gained via add() with no urlRoot set, to have their urlRoot set to collection.url. The rationale for this is explained in #3944. Please refer to that issue.