### PR TITLE
Fixes typo in docs

### DIFF
--- a/docs/backbone.localStorage.html
+++ b/docs/backbone.localStorage.html
@@ -185,7 +185,7 @@ to make things work even if they are removed from the global namespace</p>
               </div>
               <p>Our Store is represented by a single JS object in <em>localStorage</em>. Create it
 with a meaningful name, like the name you’d give a table.
-window.Store is deprectated, use Backbone.LocalStorage instead</p>
+window.Store is deprecated, use Backbone.LocalStorage instead</p>
 
             </div>
             


### PR DESCRIPTION
Found a spelling mistake -
`deprectated` > `deprecated`