### PR TITLE
add tests for undefined id

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -984,7 +984,7 @@
     // properties, or an attributes object that is transformed through modelId.
     get: function(obj) {
       if (obj == null) return void 0;
-      return this._byId[obj] ||
+      return (_.isString(obj) || _.isNumber(obj)) && this._byId[obj] ||
         this._byId[this.modelId(obj.attributes || obj)] ||
         obj.cid && this._byId[obj.cid];
     },

--- a/test/collection.js
+++ b/test/collection.js
@@ -111,6 +111,11 @@
     assert.equal(collection.get(1).id, 1);
   });
 
+  QUnit.test('get with "[object Object]" key', function(assert) {
+    var collection = new Backbone.Collection([{id: '[object Object]'}, {id: 1}]);
+    assert.equal(collection.get(1).id, 1);
+  });
+
   QUnit.test('has', function(assert) {
     assert.expect(15);
     assert.ok(col.has(a));

--- a/test/collection.js
+++ b/test/collection.js
@@ -101,6 +101,16 @@
     assert.equal(collection2.get(model.clone()), collection2.first());
   });
 
+  QUnit.test('get with "undefined" id', function(assert) {
+    var collection = new Backbone.Collection([{id: 1}, {id: 'undefined'}]);
+    assert.equal(collection.get(1).id, 1);
+  });
+
+  QUnit.test('get with "undefined" id first', function(assert) {
+    var collection = new Backbone.Collection([{id: 'undefined'}, {id: 1}]);
+    assert.equal(collection.get(1).id, 1);
+  });
+
   QUnit.test('has', function(assert) {
     assert.expect(15);
     assert.ok(col.has(a));


### PR DESCRIPTION
I would like to re-propose these test. These were removed from https://github.com/jashkenas/backbone/pull/3936 under the impression that there is no need to ensure support for unreasonable values. I believe backbone should be un-opinionated about what values are legitimate. Examples are contrived, until they're not. The second test in particular is important to ensure _byId doesn't evaluate for an `undefined` return.