### PR TITLE
#3941 return decoded hash in getHash()

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1630,7 +1630,7 @@
     // in Firefox where location.hash will always be decoded.
     getHash: function(window) {
       var match = (window || this).location.href.match(/#(.*)$/);
-      return match ? match[1] : '';
+      return match ? this.decodeFragment(match[1]) : '';
     },
 
     // Get the pathname and search params, without the root.

--- a/test/router.js
+++ b/test/router.js
@@ -407,6 +407,17 @@
     assert.strictEqual(router.rest, 'has space');
   });
 
+  QUnit.test('#3941 - should return the decoded hash in getFragment().', function(assert) {
+    assert.expect(2);
+
+    Backbone.history.navigate('#foo%20bar');
+    assert.strictEqual(Backbone.history.fragment, 'foo bar');
+
+    location.replace('http://example.com/#foo%20bar');
+    assert.strictEqual(Backbone.history.getFragment(), 'foo bar');
+  });
+
+
   QUnit.test('correctly handles URLs with % (#868)', function(assert) {
     assert.expect(3);
     location.replace('http://example.com#search/fat%3A1.5%25');


### PR DESCRIPTION
...to compare correctly to cached fragment in navigate()
