### PR TITLE
Update `modelId()` to Allow Polymorphic Collections with Different, Unknown, Model.idAttributes

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -984,7 +984,7 @@
     get: function(obj) {
       if (obj == null) return void 0;
       return this._byId[obj] ||
-        this._byId[this.modelId(obj.attributes || obj)] ||
+        this._byId[this.modelId(obj.attributes || obj, obj)] ||
         obj.cid && this._byId[obj.cid];
     },
 
@@ -1088,8 +1088,8 @@
     },
 
     // Define how to uniquely identify models in the collection.
-    modelId: function(attrs) {
-      return attrs[this.model.prototype.idAttribute || 'id'];
+    modelId: function(attrs, model) {
+      return attrs[(model && model.idAttribute) || this.model.prototype.idAttribute || 'id'];
     },
 
     // Private method to reset all internal state. Called when the collection
@@ -1129,7 +1129,7 @@
         // Remove references before triggering 'remove' event to prevent an
         // infinite loop. #3693
         delete this._byId[model.cid];
-        var id = this.modelId(model.attributes);
+        var id = this.modelId(model.attributes, model);
         if (id != null) delete this._byId[id];
 
         if (!options.silent) {
@@ -1152,7 +1152,7 @@
     // Internal method to create a model's ties to a collection.
     _addReference: function(model, options) {
       this._byId[model.cid] = model;
-      var id = this.modelId(model.attributes);
+      var id = this.modelId(model.attributes, model);
       if (id != null) this._byId[id] = model;
       model.on('all', this._onModelEvent, this);
     },
@@ -1160,7 +1160,7 @@
     // Internal method to sever a model's ties to a collection.
     _removeReference: function(model, options) {
       delete this._byId[model.cid];
-      var id = this.modelId(model.attributes);
+      var id = this.modelId(model.attributes, model);
       if (id != null) delete this._byId[id];
       if (this === model.collection) delete model.collection;
       model.off('all', this._onModelEvent, this);
@@ -1175,8 +1175,8 @@
         if ((event === 'add' || event === 'remove') && collection !== this) return;
         if (event === 'destroy') this.remove(model, options);
         if (event === 'change') {
-          var prevId = this.modelId(model.previousAttributes());
-          var id = this.modelId(model.attributes);
+          var prevId = this.modelId(model.previousAttributes(), model);
+          var id = this.modelId(model.attributes, model);
           if (prevId !== id) {
             if (prevId != null) delete this._byId[prevId];
             if (id != null) this._byId[id] = model;

--- a/backbone.js
+++ b/backbone.js
@@ -984,7 +984,7 @@
     get: function(obj) {
       if (obj == null) return void 0;
       return this._byId[obj] ||
-        this._byId[this.modelId(obj.attributes || obj, obj)] ||
+        this._byId[this.modelId(obj.attributes || obj, obj.idAttribute)] ||
         obj.cid && this._byId[obj.cid];
     },
 
@@ -1088,8 +1088,8 @@
     },
 
     // Define how to uniquely identify models in the collection.
-    modelId: function(attrs, model) {
-      return attrs[(model && model.idAttribute) || this.model.prototype.idAttribute || 'id'];
+    modelId: function(attrs, idAttribute) {
+      return attrs[idAttribute || this.model.prototype.idAttribute || 'id'];
     },
 
     // Private method to reset all internal state. Called when the collection
@@ -1129,7 +1129,7 @@
         // Remove references before triggering 'remove' event to prevent an
         // infinite loop. #3693
         delete this._byId[model.cid];
-        var id = this.modelId(model.attributes, model);
+        var id = this.modelId(model.attributes, model.idAttribute);
         if (id != null) delete this._byId[id];
 
         if (!options.silent) {
@@ -1152,7 +1152,7 @@
     // Internal method to create a model's ties to a collection.
     _addReference: function(model, options) {
       this._byId[model.cid] = model;
-      var id = this.modelId(model.attributes, model);
+      var id = this.modelId(model.attributes, model.idAttribute);
       if (id != null) this._byId[id] = model;
       model.on('all', this._onModelEvent, this);
     },
@@ -1160,7 +1160,7 @@
     // Internal method to sever a model's ties to a collection.
     _removeReference: function(model, options) {
       delete this._byId[model.cid];
-      var id = this.modelId(model.attributes, model);
+      var id = this.modelId(model.attributes, model.idAttribute);
       if (id != null) delete this._byId[id];
       if (this === model.collection) delete model.collection;
       model.off('all', this._onModelEvent, this);
@@ -1175,8 +1175,8 @@
         if ((event === 'add' || event === 'remove') && collection !== this) return;
         if (event === 'destroy') this.remove(model, options);
         if (event === 'change') {
-          var prevId = this.modelId(model.previousAttributes(), model);
-          var id = this.modelId(model.attributes, model);
+          var prevId = this.modelId(model.previousAttributes(), model.idAttribute);
+          var id = this.modelId(model.attributes, model.idAttribute);
           if (prevId !== id) {
             if (prevId != null) delete this._byId[prevId];
             if (id != null) this._byId[id] = model;

--- a/test/collection.js
+++ b/test/collection.js
@@ -1650,7 +1650,7 @@
     // Default to using `model::idAttribute` if present.
     Stooge.prototype.idAttribute = '_id';
     var model = new Stooge({_id: 1});
-    assert.equal(StoogeCollection.prototype.modelId(model.attributes, model), 1);
+    assert.equal(StoogeCollection.prototype.modelId(model.attributes, model.idAttribute), 1);
 
     // Default to using `Collection::model::idAttribute` if model::idAttribute not present.
     StoogeCollection.prototype.model = Stooge;
@@ -1735,11 +1735,11 @@
     });
     var c2 = new C2({'_id': 1});
     assert.equal(c2.get(1), c2.at(0));
-    assert.equal(c2.modelId(c2.at(0).attributes, c2.at(0)), 1);
+    assert.equal(c2.modelId(c2.at(0).attributes, c2.at(0).idAttribute), 1);
     var m = new M({'_id': 2});
     c2.add(m);
     assert.equal(c2.get(2), m);
-    assert.equal(c2.modelId(m.attributes, m), 2);
+    assert.equal(c2.modelId(m.attributes, m.idAttribute), 2);
   });
 
   QUnit.test('#3039 #3951: adding at index fires with correct at', function(assert) {


### PR DESCRIPTION
For Issue: https://github.com/jashkenas/backbone/issues/3965
## Changes
- `modelId()` now takes the idAttribute of the model in question as the second argument
- `modelId()` will use the passed `idAttribute` before falling back to `Collection.prototype.model.idAttribute` and then `'id'`
- Retains backwards compatibility
- Update tests to show default `modelId()` fallbacks
- Update tests to show default polymorphic collection behavior
## Rationale

Right now `modelId(attrs)` is only passed a plain-object representation of the model's attributes. This makes it difficult for application developers to create n-degree polymorphic Collection subclasses.

Contrived Example:

``` javascript
// A collection of mixed entity types that maintains sort order based 
// on their joinDate property

var Entities = Collection.extend({
  modelId(attrs){
    // What ID attribute to use? Not determined at runtime.
  },
  comparator: 'joinDate'
});


// These are only two entity types with different idAttributes, but assume 
// There may be up to (n) different entity types, each with different idAttributes, 
// determined by the database backing this example application.

var Company = Model.extend({
  idAttribute: 'companyId'
});

var Customer = Model.extend({
  idAttribute: 'customerId'
});

// Proceeding to add and remove Customers, Companies, etc, to the Entities
// Collection will mess up the `_byId` cache because the Entities collection
// is not aware of all the different possibilities for `idAttribute` at runtime and 
// a `modelId` method cannot be written to satisfy the needs of this app.

```

By making the modelId callback take the form `modelId(attrs, model)`, where the second argument is the model in question, Backbone can retain backwards compatibility but enable the default implementation to be:

``` javascript
// Always give precedence to the provided model's idAttribute. 
// Fall back to the Collection's idAttribute, and then to the default value `id`.

Entities.modelId = function modelId(attrs, idAttribute){
  return attrs[(idAttribute || this.model.prototype.idAttribute || 'id'];
};
```

It still maintains backwards compatibility: For any implementation that is not already polymorphic, Collections will still function normally – models will have their idAttribute set when added to the Collection by the Collection's model constructor. Those that are already polymorphic, or have some type of non-standard idAttributes, will already have this modelId method overwritten.
