### PR TITLE
Computed properties

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -427,8 +427,23 @@
     initialize: function(){},
 
     // Return a copy of the model's `attributes` object.
+    // When saving we dont want to pollute the attributes with computed
+    // properties but when serialising for use with the templates we do
     toJSON: function(options) {
-      return _.clone(this.attributes);
+      var isSaving = _.has(options, 'emulateHTTP');
+      if (isSaving) return _.clone(this.attributes);
+
+      var hasComputed = !!this.computed;
+      var computed    = {};
+
+      if (hasComputed) {
+        _.each(this.computed, function(value, key) {
+          computed[key] = _.isFunction(value) ? value.call(this) : value;
+        }, this);
+      }
+
+      // ensure non-computed property wins in property clash
+      return _.extend(computed, this.attributes);
     },
 
     // Proxy `Backbone.sync` by default -- but override this if you need
@@ -437,8 +452,18 @@
       return Backbone.sync.apply(this, arguments);
     },
 
-    // Get the value of an attribute.
+    // Get the value of an attribute or computed property.
+    // If we have a computed and non-computed property clash then the non-computed
+    // value should be returned
     get: function(attr) {
+      var hasComputed       = this.computed && _.has(this.computed, attr);
+      var hasNonComputed    = _.has(this.attributes, attr);
+
+      if (hasComputed && !hasNonComputed) {
+        var value = this.computed[attr];
+        return _.isFunction(value) ? value.call(this) : value;
+      }
+
       return this.attributes[attr];
     },
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -667,8 +667,22 @@
   });
 
   QUnit.test('toJSON', function(assert) {
-    assert.expect(1);
+    assert.expect(2);
     assert.equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"}]');
+    var Model = Backbone.Model.extend({
+      computed: {
+        joined: function() {
+          return this.get('id') + ' ' + this.get('label');
+        }
+      }
+    });
+    var model = new Model({
+      id: 5,
+      label: 'f'
+    });
+    col.add(model);
+    assert.equal(JSON.stringify(col), '[{"id":3,"label":"a"},{"id":2,"label":"b"},{"id":1,"label":"c"},{"id":0,"label":"d"},{"joined":"5 f","id":5,"label":"f"}]');
+    col.remove(model);
   });
 
   QUnit.test('where and findWhere', function(assert) {

--- a/test/model.js
+++ b/test/model.js
@@ -1395,6 +1395,56 @@
     model.save({x: 1}, {wait: true});
   });
 
+  QUnit.test('toJSON serialises computed properties', function(assert) {
+    assert.expect(1);
+    var expected = {
+      firstName: 'Tim',
+      lastName: 'Burton',
+      fullName: 'Tim Burton'
+    };
+    var Model = Backbone.Model.extend({
+      computed: {
+        fullName: function() {
+          return this.get('firstName') + ' ' + this.get('lastName');
+        }
+      }
+    });
+    var model = new Model({
+      firstName: 'Tim',
+      lastName: 'Burton'
+    });
+    assert.ok(_.isEqual(model.toJSON(), expected));
+  });
+
+  QUnit.test('computed property results can by accessed by get', function(assert) {
+    assert.expect(1);
+    var Model = Backbone.Model.extend({
+      computed: {
+        fullName: function() {
+          return this.get('firstName') + ' ' + this.get('lastName');
+        }
+      }
+    });
+    var model = new Model({
+      firstName: 'Tim',
+      lastName: 'Burton'
+    });
+    assert.equal(model.get('fullName'), 'Tim Burton');
+  });
+
+  QUnit.test('computed properties will not be serialised on save', function(assert) {
+    assert.expect(1);
+    var Model = Backbone.Model.extend({
+      url: '/test',
+      toJSON: function() {
+        assert.equal(this.attributes.fullName, undefined);
+        return _.clone(this.attributes);
+      }
+    });
+    var model = new Model;
+    model.save({firstName: 'Tim', lastName: 'Burton'});
+  });
+
   QUnit.test('#2034 - nested set with silent only triggers one change', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();


### PR DESCRIPTION
Hi I am opening this pull request as I think it could be very useful to include the ability to have computed properties on models in backbone.

These could/should be accessed by `get('field')` and the result of the function would be returned;
The computed result would also be serialised into the json object when `toJSON` gets invoked.
When `toJSON` is invoked as a result of calling `save()` on the model these computed properties should not be included in the serialised json object that gets sent to the server.

this would be incredibly helpful in conjunction with marionette views and or when using a template system such as handlebars.

here is an example of how this might get used:

```javascript
var Model = Backbone.Model.extend({
  computed: {
    fullName: function () {
      return this.get('firstName') + ' ' + this.get('lastName');
    }
  }
});
var model = new Model({
  firstName: 'Tim',
  lastName: 'Burton'
});

model.get('fullName'); // returns 'Tim Burton'
````
and when serialising...
```javascript
model.toJSON();
/**
 *  returns
 *  {
 *    firstName: 'Tim',
 *    lastName: 'Burton',
 *    fullName: 'Tim Burton'
 *  }
 */
```
but when saving the model data would serialise to...
```javascript
model.save();
/**
 *  serialised:
 *  {
 *    firstName: 'Tim',
 *    lastName: 'Burton',
 *  }
 */
```

let me know what you think, I have included tests in the pull request.