### PR TITLE
Remove unused name parameter from Router.execute

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1501,7 +1501,7 @@
       var router = this;
       Backbone.history.route(route, function(fragment) {
         var args = router._extractParameters(route, fragment);
-        if (router.execute(callback, args, name) !== false) {
+        if (router.execute(callback, args) !== false) {
           router.trigger.apply(router, ['route:' + name].concat(args));
           router.trigger('route', name, args);
           Backbone.history.trigger('route', router, name, args);
@@ -1512,7 +1512,7 @@
 
     // Execute a route handler with the provided parameters.  This is an
     // excellent place to do pre-route setup or post-route cleanup.
-    execute: function(callback, args, name) {
+    execute: function(callback, args) {
       if (callback) callback.apply(this, args);
     },
 


### PR DESCRIPTION
The name parameter isn't ever used. Removing it reduces confusion.