### PR TITLE
Test for 3 parameters in Router.prototype.execute

### DIFF
--- a/test/router.js
+++ b/test/router.js
@@ -1058,5 +1058,14 @@
     var myRouter = new MyRouter;
     Backbone.history.start({root: '®ooτ', pushState: true});
   });
-
+  
+  QUnit.test('Router.prototype.execute function definition should have 3 parameters (callback, args, name)', function(assert) {
+    // The name parameter isn't used in the default Router.prototype.execute function, but having the name parameter
+    // in the Router.prototype.execute function is useful because it serves as documentation for people who want to 
+    // extend Router.prototype.execute to use the name parameter.
+    assert.expect(1);
+    assert.ok(/function\s*\(\s*callback\s*,\s*args\s*,\s*name\s*\)/.test(Backbone.Router.prototype.execute.toString()),
+      'Router.prototype.execute should have 3 parameters: callback, args, name');
+  });
+  
 })();

--- a/test/router.js
+++ b/test/router.js
@@ -1058,7 +1058,7 @@
     var myRouter = new MyRouter;
     Backbone.history.start({root: '®ooτ', pushState: true});
   });
-  
+
   QUnit.test('Router.prototype.execute function definition should have 3 parameters (callback, args, name)', function(assert) {
     // The name parameter isn't used in the default Router.prototype.execute function, but having the name parameter
     // in the Router.prototype.execute function is useful because it serves as documentation for people who want to

--- a/test/router.js
+++ b/test/router.js
@@ -1061,11 +1061,10 @@
   
   QUnit.test('Router.prototype.execute function definition should have 3 parameters (callback, args, name)', function(assert) {
     // The name parameter isn't used in the default Router.prototype.execute function, but having the name parameter
-    // in the Router.prototype.execute function is useful because it serves as documentation for people who want to 
+    // in the Router.prototype.execute function is useful because it serves as documentation for people who want to
     // extend Router.prototype.execute to use the name parameter.
     assert.expect(1);
     assert.ok(/function\s*\(\s*callback\s*,\s*args\s*,\s*name\s*\)/.test(Backbone.Router.prototype.execute.toString()),
       'Router.prototype.execute should have 3 parameters: callback, args, name');
   });
-  
 })();


### PR DESCRIPTION
This test saves time by automatically failing pull requests that remove the third parameter (the "name" parameter) from Router.prototype.execute. This test also serves as documentation for why Router.prototype.execute has a third parameter, despite the third parameter not being used by default.

See https://github.com/jashkenas/backbone/pull/3973