### PR TITLE
Fix failing global tests

### DIFF
--- a/test/view.js
+++ b/test/view.js
@@ -14,6 +14,11 @@
         className: 'test-view',
         other: 'non-special-option'
       });
+    },
+
+    afterEach: function() {
+      $('#testElement').remove();
+      $('#test-view').remove();
     }
 
   });


### PR DESCRIPTION
This should fix two of the failures in the test cases.

The other failure seems to be that in IE8 `onhashchange` is added to `window`. I'm not familiar enough with `attachEvent` (does it automatically create a global `onhashchange`?), but it seems that us calling `Backbone.history.stop()` isn't enough to remove the global. Anyone with IE experience care to shed some light?

There were a few other failures in https://travis-ci.org/jashkenas/backbone/builds/119075098 around default model attributes in IE8 too.