### PR TITLE
Make model parameter optional for Backbone.sync

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1441,7 +1441,9 @@
 
     // Make the request, allowing the user to override any Ajax options.
     var xhr = options.xhr = Backbone.ajax(_.extend(params, options));
-    model.trigger('request', model, xhr, options);
+    if (model){
+      model.trigger('request', model, xhr, options);
+    }
     return xhr;
   };
 

--- a/test/sync.js
+++ b/test/sync.js
@@ -236,4 +236,10 @@
     this.ajaxSettings.error({}, 'textStatus', 'errorThrown');
   });
 
+  QUnit.test('`model` is optional', function(assert) {
+    assert.expect(0);
+    Backbone.sync('read', null, {
+      url: '/library'
+    });
+  });
 })();


### PR DESCRIPTION
I encountered a situation in which I needed to call Backbone.sync directly, w/o a model, which works perfectly except it will throw when trying to trigger a 'request' event on `model`. Obviously I could easily pass a `trigger:noop` object or something, but thought this was cleaner.
Test included btw.