### PR TITLE
When model.id is set in model.initialize, Collection.get('mymodelid') will return undefined

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1153,7 +1153,7 @@
     // Internal method to create a model's ties to a collection.
     _addReference: function(model, options) {
       this._byId[model.cid] = model;
-      var id = this.modelId(model.attributes);
+      var id = model.id || this.modelId(model.attributes);
       if (id != null) this._byId[id] = model;
       model.on('all', this._onModelEvent, this);
     },

--- a/test/collection.js
+++ b/test/collection.js
@@ -1733,6 +1733,25 @@
     assert.equal(c2.modelId(m.attributes), void 0);
   });
 
+  QUnit.test('Calculating model.id in initialize makes it available to Collection.get', function(assert) {
+    assert.expect(2);
+    function get_id_from_date(date) {
+      return '' + (date.getFullYear() * 10000 +
+                   (1 + date.getMonth()) * 100 +
+                   date.getDate());
+    }
+    var Day = Backbone.Model.extend({
+      initialize: function() {
+          // set id to something like '20160402'
+          this.id = get_id_from_date(this.get('date'));
+      },
+    });
+    var day = new Day({'date': new Date(2016, 3, 2)});
+    var days = new Backbone.Collection([day]);
+    assert.equal(days.at(0).id, '20160402');  // this succeeds
+    assert.equal(days.at(0), days.get('20160402'));  // this fails
+  });
+
   QUnit.test('#3039 #3951: adding at index fires with correct at', function(assert) {
     assert.expect(4);
     var collection = new Backbone.Collection([{val: 0}, {val: 4}]);

--- a/test/collection.js
+++ b/test/collection.js
@@ -1734,22 +1734,20 @@
   });
 
   QUnit.test('Calculating model.id in initialize makes it available to Collection.get', function(assert) {
-    assert.expect(2);
-    function get_id_from_date(date) {
-      return '' + (date.getFullYear() * 10000 +
-                   (1 + date.getMonth()) * 100 +
-                   date.getDate());
-    }
+    assert.expect(3);
     var Day = Backbone.Model.extend({
       initialize: function() {
-          // set id to something like '20160402'
-          this.id = get_id_from_date(this.get('date'));
+        // set id to something like '20160402'
+        var date = this.get('date');
+        this.id = '' + (date.getFullYear() * 10000 +
+                        (date.getMonth()+1) * 100 +
+                        date.getDate());
       },
     });
     var day = new Day({'date': new Date(2016, 3, 2)});
     var days = new Backbone.Collection([day]);
     assert.equal(days.at(0).id, '20160402');  // this succeeds
-    assert.equal(days.at(0), days.get('20160402'));  // this fails
+    assert.notEqual(days.get('20160402'), void 0);  // this fails
   });
 
   QUnit.test('#3039 #3951: adding at index fires with correct at', function(assert) {


### PR DESCRIPTION
I have a model for a day that calculates its id like this:
```javascript
    var Day = Backbone.Model.extend({
      initialize: function() {
        // set id to something like '20160402'
        var date = this.get('date');
        this.id = '' + (date.getFullYear() * 10000 +
                        (date.getMonth()+1) * 100 +
                        date.getDate());
      },
    });
```
When I add this to a Collection I cannot retrieve it via Collection.get:
```javascript
    var day = new Day({'date': new Date(2016, 3, 2)});
    var days = new Backbone.Collection([day]);
    assert.equal(days.at(0).id, '20160402');  // this succeeds
    assert.notEqual(days.get('20160402'), void 0);  // this fails
```
This is somewhat unexpected. I can change that behaviour by changing Collection._addReference:
```javascript
    // Internal method to create a model's ties to a collection.
    _addReference: function(model, options) {
      this._byId[model.cid] = model;
      // var id = this.modelId(model.attributes); // changed to:
      var id = model.id || this.modelId(model.attributes);
      if (id != null) this._byId[id] = model;
      model.on('all', this._onModelEvent, this);
    },
```
But this breaks a different test ('Collection with polymorphic models receives default id from modelId').

I'm not sure, what the intended behaviour is. If the behaviour is meant like it is, it should be stated in the docs.