### PR TITLE
Clarification on the use of model.id

### DIFF
--- a/index.html
+++ b/index.html
@@ -1243,6 +1243,7 @@ if (note.has("title")) {
       A special property of models, the <b>id</b> is an arbitrary string
       (integer id or UUID). If you set the <b>id</b> in the
       attributes hash, it will be copied onto the model as a direct property.
+      <code>model.id</code> should not be manipulated directly.
       Models can be retrieved by id from collections, and the id is used to generate
       model URLs by default.
     </p>

--- a/index.html
+++ b/index.html
@@ -1243,7 +1243,8 @@ if (note.has("title")) {
       A special property of models, the <b>id</b> is an arbitrary string
       (integer id or UUID). If you set the <b>id</b> in the
       attributes hash, it will be copied onto the model as a direct property.
-      <code>model.id</code> should not be manipulated directly.
+      <code>model.id</code> should not be manipulated directly,
+      it should be modified only via <code>model.set('id', …)</code>.
       Models can be retrieved by id from collections, and the id is used to generate
       model URLs by default.
     </p>


### PR DESCRIPTION
The docs should state explicitly that `model.id` should not be manipulated directly. (See #4004)