### PR TITLE
model defaults deep copy for array params

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -399,7 +399,22 @@
     if (options.collection) this.collection = options.collection;
     if (options.parse) attrs = this.parse(attrs, options) || {};
     var defaults = _.result(this, 'defaults');
-    attrs = _.defaults(_.extend({}, defaults, attrs), defaults);
+    // do deep copy (model defaults hava array or [] value will generating dirty data)
+    var new_default = {};
+    if (defaults) {
+        for (var key in defaults) {
+            var obj = defaults[key];
+            if (_.isArray(obj)) {
+                new_default[key] = _.clone(defaults[key]);
+            } else {
+                new_default[key] = obj;
+            }
+        }
+    } else {
+        new_default = defaults;
+    }
+    
+    attrs = _.defaults(_.extend({}, new_default, attrs), new_default);
     this.set(attrs, options);
     this.changed = {};
     this.initialize.apply(this, arguments);

--- a/test/model.js
+++ b/test/model.js
@@ -421,13 +421,14 @@
   });
 
   QUnit.test('defaults', function(assert) {
-    assert.expect(9);
+    assert.expect(11);
     var Defaulted = Backbone.Model.extend({
       defaults: {
         one: 1,
         two: 2
       }
     });
+	
     var model = new Defaulted({two: undefined});
     assert.equal(model.get('one'), 1);
     assert.equal(model.get('two'), 2);
@@ -454,6 +455,17 @@
     assert.equal(model.get('hasOwnProperty'), true);
     model = new Defaulted({hasOwnProperty: false});
     assert.equal(model.get('hasOwnProperty'), false);
+    // test array or [] defaults , dirty data
+    Defaulted = Backbone.Model.extend({
+      defaults: {
+          array: []
+      }
+    });
+    model = new Defaulted();
+    assert.equal(model.get('array').length, 0);
+    model.get('array').push("obj1");
+    model = new Defaulted();
+    assert.equal(model.get('array').length, 0);
   });
 
   QUnit.test('change, hasChanged, changedAttributes, previous, previousAttributes', function(assert) {


### PR DESCRIPTION
if model defaults have array or [] params, then new Model() for array will be error data.
example:

    var Defaulted = Backbone.Model.extend({
      defaults: {
          array: []
      }
    });
    model = new Defaulted();
    assert.equal(model.get('array').length, 0);
    model.get('array').push("obj1");
    model = new Defaulted();
    assert.equal(model.get('array').length, 0);

last equal will fail, array.length is 1.