### PR TITLE
Explicitly specified return value for findWhere if no model matches.

### DIFF
--- a/index.html
+++ b/index.html
@@ -2200,6 +2200,7 @@ alert(musketeers.length);
       <br />
       Just like <a href="#Collection-where">where</a>, but directly returns only
       the first model in the collection that matches the passed <b>attributes</b>.
+      If no model matches returns <tt>undefined</tt>.
     </p>
 
     <p id="Collection-url">


### PR DESCRIPTION
I've used this method today and I have to test what it will return if no model matches, so I decided to make this pull request to make things clear in docs.