### PR TITLE
Change to splice method so it is observable

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -770,12 +770,8 @@
   // Splices `insert` into `array` at index `at`.
   var splice = function(array, insert, at) {
     at = Math.min(Math.max(at, 0), array.length);
-    var tail = Array(array.length - at);
-    var length = insert.length;
-    var i;
-    for (i = 0; i < tail.length; i++) tail[i] = array[i + at];
-    for (i = 0; i < length; i++) array[i + at] = insert[i];
-    for (i = 0; i < tail.length; i++) array[i + length + at] = tail[i];
+    var args = [at, 0].concat(insert);
+    Array.prototype.splice.apply(array, args);
   };
 
   // Define the Collection's inheritable methods.


### PR DESCRIPTION
The existing splice method uses the indexer:

`array[i + at] = insert[i]`

This is not a natively observable change, e.g. using Array.observe.

This PR changes the method to achieve the same effect but using native Array.splice.

This may be useful when using Backbone with other frameworks e.g. it may be desirable to use Backbone modelling for the excellent collection methods and REST APIs, but Aurelia or Angular for UI data-binding.

The latter frameworks can't observe changes on collection.models array if they're done with the indexer. Splice is observable.




