### PR TITLE
Adding .gitattributes to force Unix line feeds

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Ensure autocrlf happens for text files
+* text=auto
+
+
+# JavaScript files must use Unix line endings to comply with tooling
+*.js eol=lf


### PR DESCRIPTION
When I ran ESLint on my local machine, I got many, many `linebreak-style` errors. This is because my local `git` was checking out the files with Windows-style line endings. Adding this file will ensure files are checked out and committed with Unix-style line endings even on Windows machines, for all contributors.

To be safe, I only applied this to JavaScript files, since those are the only ones that go through linting anyway.

Please let me know if I need to modify the commit summary for changelog purposes (or any other purpose).