### PR TITLE
Clarify Router.navigate docs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2500,7 +2500,8 @@ open: function(id) { ... }
       If you also wish to call the route function, set the <b>trigger</b>
       option to <tt>true</tt>.
       To update the URL without creating an entry in the browser's history,
-      set the <b>replace</b> option to <tt>true</tt>.
+      set the <b>replace</b> option to <tt>true</tt> when navigating away from
+      the URL that you do not want in the history.
     </p>
 
 <pre>


### PR DESCRIPTION
#3183 Clarify the use `{ replace: true }` with Router.navigate - that is if you do not want the current url in history that you should use this option when navigating away from that route. The current documentation led me to believe that it was for navigating to a route that I did not want in history.