### PR TITLE
added error when jquery is not installed

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1301,8 +1301,12 @@
     // alternative DOM manipulation API and are only required to set the
     // `this.el` property.
     _setElement: function(el) {
-      this.$el = el instanceof Backbone.$ ? el : Backbone.$(el);
-      this.el = this.$el[0];
+        if ($) {
+            this.$el = el instanceof Backbone.$ ? el : Backbone.$(el);
+            this.el = this.$el[0];
+        } else {
+            throw new Error('jQuery is not installed.')
+        }
     },
 
     // Set callbacks, where `this.events` is a hash of


### PR DESCRIPTION
calling new View() without jQuery will throw this error: 

`backbone.js:1287 Uncaught TypeError: Right-hand side of 'instanceof' is not an object_setElement @ backbone.js:1287setElement @ backbone.js:1275_ensureElement @ backbone.js:1362Backbone.View @ backbone.js:1223child @ backbone.js:1888(anonymous function) @ main.js:237`