### PR TITLE
location.hash broken chracter issue on Safari browser

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1730,7 +1730,7 @@
         var iWindow = body.insertBefore(this.iframe, body.firstChild).contentWindow;
         iWindow.document.open();
         iWindow.document.close();
-        iWindow.location.hash = '#' + this.fragment;
+        this._changeHash(iWindow, this.fragment);
       }
 
       // Add a cross-platform `addEventListener` shim for older browsers.
@@ -1882,10 +1882,14 @@
         location.replace(href + '#' + fragment);
       } else {
         // Some browsers require that `hash` contains a leading #.
-        location.hash = '#' + fragment;
+        this._changeHash(window, fragment);
       }
+    },
+    // `location.hash` broken chracter issue on Safari browser
+    _changeHash: function(context, fragment) {
+      var frameWindow = context || window;
+      frameWindow.location.href = location.href.replace(/#.+/, '#' + fragment);
     }
-
   });
 
   // Create the default Backbone.history.

--- a/backbone.js
+++ b/backbone.js
@@ -1730,7 +1730,7 @@
         var iWindow = body.insertBefore(this.iframe, body.firstChild).contentWindow;
         iWindow.document.open();
         iWindow.document.close();
-        iWindow.location.hash = '#' + fragment
+        iWindow.location.hash = '#' + this.fragment
       }
 
       // Add a cross-platform `addEventListener` shim for older browsers.

--- a/backbone.js
+++ b/backbone.js
@@ -1730,7 +1730,7 @@
         var iWindow = body.insertBefore(this.iframe, body.firstChild).contentWindow;
         iWindow.document.open();
         iWindow.document.close();
-        iWindow.location.hash = '#' + this.fragment
+        iWindow.location.hash = '#' + this.fragment;
       }
 
       // Add a cross-platform `addEventListener` shim for older browsers.
@@ -1882,7 +1882,7 @@
         location.replace(href + '#' + fragment);
       } else {
         // Some browsers require that `hash` contains a leading #.
-        location.hash = '#' + fragment
+        location.hash = '#' + fragment;
       }
     }
   });

--- a/backbone.js
+++ b/backbone.js
@@ -1730,7 +1730,7 @@
         var iWindow = body.insertBefore(this.iframe, body.firstChild).contentWindow;
         iWindow.document.open();
         iWindow.document.close();
-        this._changeHash(iWindow, this.fragment);
+        iWindow.location.hash = '#' + fragment
       }
 
       // Add a cross-platform `addEventListener` shim for older browsers.
@@ -1882,14 +1882,8 @@
         location.replace(href + '#' + fragment);
       } else {
         // Some browsers require that `hash` contains a leading #.
-        this._changeHash(window, fragment);
+        location.hash = '#' + fragment
       }
-    },
-    // `location.hash` broken chracter issue on Safari browser
-    _changeHash: function(context, fragment) {
-      var frameWindow = context || window;
-      // frameWindow.location.href = frameWindow.location.href.replace(/#.+/, '#' + fragment);
-      frameWindow.location.hash = '#' + fragment;
     }
   });
 

--- a/backbone.js
+++ b/backbone.js
@@ -1888,7 +1888,7 @@
     // `location.hash` broken chracter issue on Safari browser
     _changeHash: function(context, fragment) {
       var frameWindow = context || window;
-      frameWindow.location.href = location.href.replace(/#.+/, '#' + fragment);
+      frameWindow.location.href = frameWindow.location.href.replace(/#.+/, '#' + fragment);
     }
   });
 

--- a/backbone.js
+++ b/backbone.js
@@ -1888,7 +1888,8 @@
     // `location.hash` broken chracter issue on Safari browser
     _changeHash: function(context, fragment) {
       var frameWindow = context || window;
-      frameWindow.location.href = frameWindow.location.href.replace(/#.+/, '#' + fragment);
+      // frameWindow.location.href = frameWindow.location.href.replace(/#.+/, '#' + fragment);
+      frameWindow.location.hash = '#' + fragment;
     }
   });
 


### PR DESCRIPTION
HI :D,
I has fixed below issue.
`location.hash` broken chracter(Kroean) issue on Safari browser.

e.g.
console.log("전체") // `전체` character is Korean..
-> #%04%B4 // it's invalid character. I look forward to `전체`.

Thank you :)