### PR TITLE
separate view's dom target from its constructed element

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1242,7 +1242,7 @@
   var delegateEventSplitter = /^(\S+)\s*(.*)$/;
 
   // List of view options to be set as properties.
-  var viewOptions = ['model', 'collection', 'el', 'id', 'attributes', 'className', 'tagName', 'events'];
+  var viewOptions = ['model', 'collection', 'el', 'target', 'id', 'attributes', 'className', 'tagName', 'events'];
 
   // Set up all inheritable **Backbone.View** properties and methods.
   _.extend(View.prototype, Events, {
@@ -1295,14 +1295,16 @@
       return this;
     },
 
-    // Creates the `this.el` and `this.$el` references for this view using the
-    // given `el`. `el` can be a CSS selector or an HTML string, a jQuery
+    // Creates the bindings on `this` for an element and a wrapped context
+    // with `name`. `el` can be a CSS selector or an HTML string, a jQuery
     // context or an element. Subclasses can override this to utilize an
     // alternative DOM manipulation API and are only required to set the
-    // `this.el` property.
-    _setElement: function(el) {
-      this.$el = el instanceof Backbone.$ ? el : Backbone.$(el);
-      this.el = this.$el[0];
+    // native element property.
+    _setElement: function(el, name) {
+      if (name == null) name = 'el';
+      var jQueryName = '$' + name;
+      this[jQueryName] = el instanceof Backbone.$ ? el : Backbone.$(el);
+      this[name] = this[jQueryName][0];
     },
 
     // Set callbacks, where `this.events` is a hash of
@@ -1372,6 +1374,7 @@
         if (this.className) attrs['class'] = _.result(this, 'className');
         this.setElement(this._createElement(_.result(this, 'tagName')));
         this._setAttributes(attrs);
+        this._setElement(_.result(this, 'target'), 'target');
       } else {
         this.setElement(_.result(this, 'el'));
       }


### PR DESCRIPTION
This PR allows for a separation of a view's dom target from the view's constructed element, so that a view with a dom target can have access to the constructed element before it is in the dom.

Currently, if a view is assigned an `el`, when the template html is appended to it (with whatever custom rendering process), it is reflected in the dom. You could use a temporary element, but then you lose the niceties of this.el's integration in the view. It seems like this.el should be precisely the element the view builds, and separate from the target element in the dom. This PR is backwards compatible with current behavior, but allows for this separation. A non-theoretical use case for the separation is for plugins - to be able to pass actual elements for transformation before they are added to the dom. In order to do this now, an `el` must not be passed to the view, and something must sit over the view to manage this. This proposal would allow for the separation of concerns by the view itself.

I could very well be missing something in backbone that would already foster this; or maybe I am too entrenched in how I see views and need to re-imagine their construction. Part of the difficulty in writing this is that there are so many possible scenarios for views - from simple wrappers for already rendered dom elements, to deeply nested hierarchies in single page apps.

If there is positive feedback I'll add tests and update the docs. Thanks for your feedback!