### PR TITLE
fix remove

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1151,7 +1151,7 @@
         var model = this.get(models[i]);
         if (!model) continue;
 
-        var index = this.indexOf(model);
+        var index = this.models.indexOf(model);
         this.models.splice(index, 1);
         this.length--;
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -402,10 +402,15 @@
   });
 
   QUnit.test('shift and pop', function(assert) {
-    assert.expect(2);
+    assert.expect(7);
     var collection = new Backbone.Collection([{a: 'a'}, {b: 'b'}, {c: 'c'}]);
     assert.equal(collection.shift().get('a'), 'a');
+    assert.equal(collection.at(0).get('b'), 'b');
+    assert.equal(collection.at(1).get('c'), 'c');
     assert.equal(collection.pop().get('c'), 'c');
+    assert.equal(collection.at(0).get('b'), 'b');
+    assert.equal(collection.shift().get('b'), 'b');
+    assert.ok(collection.length === 0);
   });
 
   QUnit.test('slice', function(assert) {


### PR DESCRIPTION
In particular this bug prevented shift() to work more than once, but in
general left the collection in a wrong state after a remove.