### PR TITLE
Clarifies that changes cause Collection update event

### DIFF
--- a/index.html
+++ b/index.html
@@ -1031,7 +1031,7 @@ view.stopListening(model);
     <ul class="small">
       <li><b>"add"</b> (model, collection, options) &mdash; when a model is added to a collection.</li>
       <li><b>"remove"</b> (model, collection, options) &mdash; when a model is removed from a collection.</li>
-      <li><b>"update"</b> (collection, options) &mdash; single event triggered after any number of models have been added or removed from a collection.</li>
+      <li><b>"update"</b> (collection, options) &mdash; single event triggered after any number of models have been added, removed or changed in a collection.</li>
       <li><b>"reset"</b> (collection, options) &mdash; when the collection's entire contents have been <a href="#Collection-reset">reset</a>.</li>
       <li><b>"sort"</b> (collection, options) &mdash; when the collection has been re-sorted.</li>
       <li><b>"change"</b> (model, options) &mdash; when a model's attributes have changed.</li>


### PR DESCRIPTION
This fixes #4109 by indicating that any set on a model, which causes a
change event will results in the change event being bubbled up to the
collection.