### PR TITLE
Clarifying improvements to router documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2433,7 +2433,7 @@ var Workspace = Backbone.Router.extend({
     <p>
       For example, a route of <tt>"search/:query/p:page"</tt> will match
       a fragment of <tt>#search/obama/p2</tt>, passing <tt>"obama"</tt>
-      and <tt>"2"</tt> to the action.
+      and <tt>"2"</tt> to the action as positional arguments.
     </p>
 
     <p>

--- a/index.html
+++ b/index.html
@@ -2391,7 +2391,7 @@ var othello = nypl.create({
     <p id="Router-extend">
       <b class="header">extend</b><code>Backbone.Router.extend(properties, [classProperties])</code>
       <br />
-      Get started by creating a custom router class. Define actions that are
+      Get started by creating a custom router class. Define action functions that are
       triggered when certain URL fragments are
       matched, and provide a <a href="#Router-routes">routes</a> hash
       that pairs routes to actions. Note that you'll want to avoid using a


### PR DESCRIPTION
Given that route wildcards have names, it is easy to expect they might be passed to the action function as key/value pairs.

Additionally, the definition of an "action" is quite vague, and could easily be confused with an event or some other construct. I've attempted a minor improvement here.