### PR TITLE
fix Collection.model breaks w/ shorthand function

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1099,7 +1099,8 @@
 
     // Define how to uniquely identify models in the collection.
     modelId: function(attrs) {
-      return attrs[this.model.prototype.idAttribute || 'id'];
+      var modelPrototype = this.model.prototype || {};
+      return attrs[modelPrototype.idAttribute || 'id'];
     },
 
     // Get an iterator of all models in this collection.


### PR DESCRIPTION
({ bar() {} }).bar.prototype === undefined in Node, Firefox, Chrome

while

({ bar: function() {} }).bar.prototype is an object

In the shorthand function case, Collection.prototype.modelId throws