### PR TITLE
Collections: Add => Check id against the default specified instead of just null

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1178,7 +1178,7 @@
     _addReference: function(model, options) {
       this._byId[model.cid] = model;
       var id = this.modelId(model.attributes),
-      did = this.modelId(model.defaults) || null;
+      did = this.modelId(model.defaults);
       if (id != did) this._byId[id] = model;
       model.on('all', this._onModelEvent, this);
     },

--- a/backbone.js
+++ b/backbone.js
@@ -1177,8 +1177,9 @@
     // Internal method to create a model's ties to a collection.
     _addReference: function(model, options) {
       this._byId[model.cid] = model;
-      var id = this.modelId(model.attributes);
-      if (id != null) this._byId[id] = model;
+      var id = this.modelId(model.attributes),
+      did = this.modelId(model.defaults) || null;
+      if (id != did) this._byId[id] = model;
       model.on('all', this._onModelEvent, this);
     },
 


### PR DESCRIPTION
Hi, 

Say you have a collection and add some new models to it.  If you had specified some default for empty id other then null it will fail.  So it would be better to check against the default value instead of only considering null.

```
 var myFancyModel = Backbone.Model.extend({
       defaults: {
           id: -1,
           roleId: "",
           claimType: "",
           claimValue: ""
       }
   });
var myFancyCollection = Backbone.Collection.extend({
    model: myFancyModel ,
    initialize: function (models, options) {
      ...
    }
});

var test = new myFancyCollection();
//add 2 new models to the collection
test.add(new  myFancyModel ());  
test.add(new  myFancyModel ()); //does not insert a new model


```
Validating against the default solves this, see PR.