### PR TITLE
Add CDN links

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,6 +646,19 @@
       <a href="http://zeptojs.com/">Zepto</a>, will
       also tend to work, with varying degrees of compatibility.)</i>
     </p>
+    
+    <h2 id="CDN-usage">CDN Usage</h2>
+    
+<pre>
+  &lt;!-- Development Version --&gt;
+  &lt;script src="https://cdn.jsdelivr.net/npm/underscore@1.8.3/underscore.js"&gt;&lt;/script&gt;
+  &lt;script src="https://cdn.jsdelivr.net/npm/backbone@1.3.3/backbone.js"&gt;&lt;/script&gt;
+  
+  &lt;!-- Production Version --&gt;
+  &lt;script src="https://cdn.jsdelivr.net/npm/underscore@1.8.3/underscore-min.js"&gt;&lt;/script&gt;
+  &lt;script src="https://cdn.jsdelivr.net/npm/backbone@1.3.3/backbone-min.js"&gt;&lt;/script&gt;
+</pre>
+    
     <h2 id="Getting-started">Getting Started</h2>
 
     <p>


### PR DESCRIPTION
I added a [jsDelivr CDN links](https://www.jsdelivr.com/package/npm/backbone) to your site so that people can use files directly without downloading them. jsDelivr is also the [fastest opensource CDN](https://www.cdnperf.com/) available and built specifically for production usage. 