### PR TITLE
Fix navigate with replace: true and diacriticals/unicode characters in the hash

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1763,7 +1763,7 @@
     // Checks the current URL to see if it has changed, and if it has,
     // calls `loadUrl`, normalizing across the hidden iframe.
     checkUrl: function(e) {
-      var current = this.getFragment();
+      var current = this.decodeFragment(this.getFragment());
 
       // If the user pressed the back button, the iframe's hash will have
       // changed and we should use that for comparison.
@@ -1782,7 +1782,8 @@
     loadUrl: function(fragment) {
       // If the root doesn't match, no routes can match either.
       if (!this.matchRoot()) return false;
-      fragment = this.fragment = this.getFragment(fragment);
+      fragment = this.getFragment(fragment);
+      this.fragment = this.decodeFragment(fragment);
       return _.some(this.handlers, function(handler) {
         if (handler.route.test(fragment)) {
           handler.callback(fragment);

--- a/test/router.js
+++ b/test/router.js
@@ -72,6 +72,8 @@
   var Router = Backbone.Router.extend({
 
     count: 0,
+    UTFCount: 0,
+    anythingCount: 0,
 
     routes: {
       'noCallback': 'noCallback',
@@ -114,6 +116,7 @@
     },
 
     charUTF: function() {
+      this.UTFCount++;
       this.charType = 'UTF';
     },
 
@@ -159,6 +162,7 @@
     },
 
     anything: function(whatever) {
+      this.anythingCount++;
       this.anything = whatever;
     },
 
@@ -424,6 +428,70 @@
     assert.equal(router.charType, 'UTF');
     Backbone.history.navigate('char%C3%B1', {trigger: true});
     assert.equal(router.charType, 'UTF');
+  });
+
+  QUnit.test('#4085 - Hashes with UTF8 in them.', function(assert) {
+    var done = assert.async();
+
+    assert.expect(4);
+    router.anythingCount = router.UTFCount = 0;
+    Backbone.history.navigate('charñ', {trigger: true});
+    assert.equal(router.UTFCount, 1);
+    assert.equal(router.anythingCount, 0);
+
+    setTimeout(function() {
+      assert.equal(router.UTFCount, 1);
+      assert.equal(router.anythingCount, 0);
+      done();
+    }, 1000);
+  });
+
+  QUnit.test('#4085 - Hashes with UTF8 in them, no trigger.', function(assert) {
+    var done = assert.async();
+
+    assert.expect(4);
+    router.anythingCount = router.UTFCount = 0;
+    Backbone.history.navigate('charñ', {trigger: false});
+    assert.equal(router.UTFCount, 0);
+    assert.equal(router.anythingCount, 0);
+
+    setTimeout(function() {
+      assert.equal(router.UTFCount, 0);
+      assert.equal(router.anythingCount, 0);
+      done();
+    }, 1000);
+  });
+
+  QUnit.test('#4085 - Hashes with UTF8 in them, replace.', function(assert) {
+    var done = assert.async();
+
+    assert.expect(4);
+    router.anythingCount = router.UTFCount = 0;
+    Backbone.history.navigate('charñ', {trigger: true, replace: true});
+    assert.equal(router.UTFCount, 1);
+    assert.equal(router.anythingCount, 0);
+
+    setTimeout(function() {
+      assert.equal(router.UTFCount, 1);
+      assert.equal(router.anythingCount, 0);
+      done();
+    }, 1000);
+  });
+
+  QUnit.test('#4085 - Hashes with UTF8 in them, replace, no trigger.', function(assert) {
+    var done = assert.async();
+
+    assert.expect(4);
+    router.anythingCount = router.UTFCount = 0;
+    Backbone.history.navigate('charñ', {trigger: false, replace: true});
+    assert.equal(router.UTFCount, 0);
+    assert.equal(router.anythingCount, 0);
+
+    setTimeout(function() {
+      assert.equal(router.UTFCount, 0);
+      assert.equal(router.anythingCount, 0);
+      done();
+    }, 1000);
   });
 
   QUnit.test('#1185 - Use pathname when hashChange is not wanted.', function(assert) {


### PR DESCRIPTION
It seems there is a change in chrome 63 (also similarly
introduced a while ago in some earlier version of iOS Safari) where the
hash portion of the location.href is encoded, where it used to be
decoded

Fixes https://github.com/jashkenas/backbone/issues/4085