### PR TITLE
Call model.toJSON always when sync model

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -437,7 +437,8 @@
 
     // Return a copy of the model's `attributes` object.
     toJSON: function(options) {
-      return _.clone(this.attributes);
+        options || (options = {});
+        return options.attrs ? options.attrs : _.clone(this.attributes);
     },
 
     // Proxy `Backbone.sync` by default -- but override this if you need
@@ -1573,7 +1574,7 @@
     // Ensure that we have the appropriate request data.
     if (options.data == null && model && (method === 'create' || method === 'update' || method === 'patch')) {
       params.contentType = 'application/json';
-      params.data = JSON.stringify(options.attrs || model.toJSON(options));
+      params.data = JSON.stringify(model.toJSON(options));
     }
 
     // For older servers, emulate JSON by encoding the request into an HTML-form.

--- a/test/model.js
+++ b/test/model.js
@@ -1447,6 +1447,19 @@
     model.save({x: 1}, {wait: true});
   });
 
+  QUnit.test('toJSON is called during save(..., {patch: true})', function(assert) {
+    assert.expect(1);
+    var Model = Backbone.Model.extend({
+      url: '/test',
+      toJSON: function() {
+        assert.strictEqual(this.attributes.x, 1);
+        return _.clone(this.attributes);
+      }
+    });
+    var model = new Model({id: 1});
+    model.save({x: 1}, {patch: true});
+  });
+
   QUnit.test('#2034 - nested set with silent only triggers one change', function(assert) {
     assert.expect(1);
     var model = new Backbone.Model();


### PR DESCRIPTION
When you save your model with patch option to true, toJSON isn't called. This behavior goes against the issue #1019 where it tells that:

> toJSON is already the complement of parse

With this PR the default behavior is the same as the current one, but it gives us the opportunity to manipulate the attributes before send them to the persistent layer, either using a CREATE, PATCH or PUT method.