### PR TITLE
avoid Object.prototype inheritance for col._byId

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1122,7 +1122,7 @@
     _reset: function() {
       this.length = 0;
       this.models = [];
-      this._byId  = {};
+      this._byId  = Object.create(null);
     },
 
     // Prepare a hash of attributes (or other model) to be added to this

--- a/test/collection.js
+++ b/test/collection.js
@@ -101,6 +101,26 @@
     assert.equal(collection2.get(model.clone()), collection2.first());
   });
 
+  QUnit.test('#4224 - internal map this._byId does not inherit from Object.prototype', function(assert) {
+    assert.expect(4);
+
+    var col1 = new Backbone.Collection();
+    assert.equal(col1._byId.constructor, undefined, 'this._byId has a constructor');
+    assert.equal(col1._byId.hasOwnProperty, undefined, 'object prototype methods are present on this._byId');
+
+    var model = new Backbone.Model({id: 'hasOwnProperty'});
+    // will throw if regression
+    col1.set([model]);
+    assert.deepEqual(col1.models, [model], 'models not correctly added');
+
+    var KeyedModel = Backbone.Model.extend({idAttribute: 'key'});
+    var KeyedCollection = Backbone.Collection.extend({model: KeyedModel});
+    var col2 = new KeyedCollection();
+    // will throw if regression
+    col2.add({key: 'hasOwnProperty'});
+    assert.deepEqual(col2.models[0].attributes, {key: 'hasOwnProperty'}, 'models not correctly added');
+  });
+
   QUnit.test('has', function(assert) {
     assert.expect(15);
     assert.ok(col.has(a));


### PR DESCRIPTION
fixes issue #4224

`collection._byId` is an internal object used solely for mapping ids to models, and doesn't need any of the standard object prototype methods for its internal usage.  
Unlikely to be a breaking change for any external uses, unless someone is really hacking into the core backbone functionality, and they can simply do things like `Object.prototype.hasOwnProperty.apply(collection._byId)`.

Alternative solution could be to use a `Map()` object for `collection._byId`, but that would require many more code changes, would not be supported in old browsers, and is more likely to break external uses.