### PR TITLE
Remove model from collection when model ID is unset

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -769,6 +769,9 @@
   var setOptions = {add: true, remove: true, merge: true};
   var addOptions = {add: true, remove: false};
 
+  // Regular expression for "change" event with attribute
+  var changeEventRegExp = /^change:\w*$/;
+
   // Splices `insert` into `array` at index `at`.
   var splice = function(array, insert, at) {
     at = Math.min(Math.max(at, 0), array.length);
@@ -1199,7 +1202,7 @@
       if (model) {
         if ((event === 'add' || event === 'remove') && collection !== this) return;
         if (event === 'destroy') this.remove(model, options);
-        if (event === 'change') {
+        if (event === 'change' || event && event.match(changeEventRegExp)) {
           var prevId = this.modelId(model.previousAttributes());
           var id = this.modelId(model.attributes);
           if (prevId !== id) {

--- a/test/collection.js
+++ b/test/collection.js
@@ -2100,4 +2100,21 @@
     var collection = new Backbone.Collection([model]);
     assert.ok(collection.get(model));
   });
+
+  QUnit.test('#4159 - model should not remain in collection after model ID is unset', function(assert) {
+    var model = new Backbone.Model({id: 'foo', foo: 'bar'});
+    var collection = new Backbone.Collection(model);
+
+    model.on('change:id', function(changedModel, id) {
+      if (id == null) {
+        collection.remove(changedModel);
+      }
+    });
+
+    model.unset('id');
+
+    assert.deepEqual(collection.models, []);
+    assert.deepEqual(collection._byId, {});
+    assert.equal(collection.get('foo'), undefined);
+  });
 })(QUnit);


### PR DESCRIPTION
This PR fixes issue #4159, where a model was not properly removed from a collection after its ID was unset. The cause for this is that `_onModelEvent` handles potential model deletions upon detecting an event called "change", when the actual event name being sent was "change:_(attribute)_". An extra check was added so that the latter case is handled as well.