### PR TITLE
Add check for `this.model.prototype`

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1134,7 +1134,15 @@
       }
       options = options ? _.clone(options) : {};
       options.collection = this;
-      var model = new this.model(attrs, options);
+
+      var model;
+      if (this.model.prototype) {
+        model = new this.model(attrs, options);
+      } else {
+        // ES class methods didn't have prototype
+        model = this.model(attrs, options);
+      }
+
       if (!model.validationError) return model;
       this.trigger('invalid', this, model.validationError, options);
       return false;

--- a/test/collection.js
+++ b/test/collection.js
@@ -2118,7 +2118,7 @@
           '        var MyModel = Backbone.Model.extend({});\n' +
           '        return new MyModel(attrs, options);\n' +
           '    }\n' +
-          '}).model');
+          '}).model')();
     } catch (error) {
       model = error;
     }

--- a/test/collection.js
+++ b/test/collection.js
@@ -2138,14 +2138,8 @@
       model: model
     });
 
-    var result, instance;
-    try {
-      instance = new MyCollection([{a: 2}]);
-      result = true;
-    } catch (error) {
-      result = false;
-    }
+    var instance = new MyCollection([{a: 2}]);
 
-    assert.ok(result && instance, 'Should instantiate collection with model');
+    assert.ok(instance, 'Should instantiate collection with model');
   });
 })(QUnit);

--- a/test/collection.js
+++ b/test/collection.js
@@ -2113,12 +2113,12 @@
   QUnit.test('#4233 - can instantiate new model in ES class Collection', function(assert) {
     var model;
     try {
-      model = new Function('return ' + '({\n' +
+      model = new Function('return ({\n' +
           '    model(attrs, options) {\n' +
           '        var MyModel = Backbone.Model.extend({});\n' +
           '        return new MyModel(attrs, options);\n' +
-          '    }).model;\n' +
-          '}');
+          '    }\n' +
+          '}).model');
     } catch (error) {
       model = error;
     }

--- a/test/collection.js
+++ b/test/collection.js
@@ -2109,4 +2109,43 @@
     var collection = new Backbone.Collection([model]);
     assert.ok(collection.get(model));
   });
+
+  QUnit.test('#4233 - can instantiate new model in ES class Collection', function(assert) {
+    var model;
+    try {
+      model = new Function('return ' + '({\n' +
+          '    model(attrs, options) {\n' +
+          '        var MyModel = Backbone.Model.extend({});\n' +
+          '        return new MyModel(attrs, options);\n' +
+          '    }).model;\n' +
+          '}');
+    } catch (error) {
+      model = error;
+    }
+
+    if (model instanceof SyntaxError) {
+      assert.expect(0);
+      return;
+    }
+
+    assert.expect(1);
+
+    var MyCollection = Backbone.Collection.extend({
+      modelId: function(attr) {
+        return attr.x;
+      },
+
+      model: model
+    });
+
+    var result, instance;
+    try {
+      instance = new MyCollection([{a: 2}]);
+      result = true;
+    } catch (error) {
+      result = false;
+    }
+
+    assert.ok(result && instance, 'Should instantiate collection with model');
+  });
 })(QUnit);


### PR DESCRIPTION
Simple check that `this.model` is constructor. We could have more complicated check, but looks like it doesn't required.

Fixes #4233 