### PR TITLE
fixes #4217 static inheritance

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -2055,7 +2055,7 @@
     // (the "constructor" property in your `extend` definition), or defaulted
     // by us to simply call the parent constructor.
     if (protoProps && _.has(protoProps, 'constructor')) {
-      child = function(){ return protoProps.constructor.apply(this, arguments); };
+      child = protoProps.constructor;
     } else {
       child = function(){ return parent.apply(this, arguments); };
     }

--- a/backbone.js
+++ b/backbone.js
@@ -2055,13 +2055,20 @@
     // (the "constructor" property in your `extend` definition), or defaulted
     // by us to simply call the parent constructor.
     if (protoProps && _.has(protoProps, 'constructor')) {
-      child = protoProps.constructor;
+      child = function(){ return protoProps.constructor.apply(this, arguments); };
     } else {
       child = function(){ return parent.apply(this, arguments); };
     }
 
+    // Perform static property inheritance
+    if (Object.setPrototypeOf) {
+      Object.setPrototypeOf(child, parent);
+    } else {
+      child.__proto__ = parent;
+    }
+
     // Add static properties to the constructor function, if supplied.
-    _.extend(child, parent, staticProps);
+    _.extend(child, staticProps);
 
     // Set the prototype chain to inherit from `parent`, without calling
     // `parent`'s constructor function and add the prototype properties.


### PR DESCRIPTION
[#4217](https://github.com/jashkenas/backbone/issues/4217)
* Added ES6-style constructor and static property inheritance rather than just copying the enumerable static properties each time.