### PR TITLE
Added missing parenthesis in the Collection preinitialize code example

### DIFF
--- a/index.html
+++ b/index.html
@@ -1876,7 +1876,7 @@ class Library extends Backbone.Collection {
   preinitialize() {
     this.on("add", function() {
       console.log("Add model event got fired!");
-    };
+    });
   }
 }
 </pre>


### PR DESCRIPTION
The event listener was missing a closing parenthesis in the preinitialize code sample for Collections. This is reference to issue #4237