### PR TITLE
#3391 - Match trailing slash on root to how root was configured.

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1851,6 +1851,7 @@
       // Is pushState desired ... is it available?
       this.options          = _.extend({root: '/'}, this.options, options);
       this.root             = this.options.root;
+      this._trailingSlash   = this.options.trailingSlash;
       this._wantsHashChange = this.options.hashChange !== false;
       this._hasHashChange   = 'onhashchange' in window && (document.documentMode === void 0 || document.documentMode > 7);
       this._useHashChange   = this._wantsHashChange && this._hasHashChange;
@@ -1993,9 +1994,9 @@
       // Normalize the fragment.
       fragment = this.getFragment(fragment || '');
 
-      // Don't include a trailing slash on the root.
+      // Strip trailing slash on the root unless _trailingSlash is true
       var rootPath = this.root;
-      if (fragment === '' || fragment.charAt(0) === '?') {
+      if (!this._trailingSlash && (fragment === '' || fragment.charAt(0) === '?')) {
         rootPath = rootPath.slice(0, -1) || '/';
       }
       var url = rootPath + fragment;

--- a/index.html
+++ b/index.html
@@ -2706,7 +2706,17 @@ var Router = Backbone.Router.extend({
     <p>
       If your application is not being served from the root url <tt>/</tt> of your
       domain, be sure to tell History where the root really is, as an option:
-      <tt>Backbone.history.start({pushState: true, root: "/public/search/"})</tt>
+      <tt>Backbone.history.start({pushState: true, root: "/public/search/"})</tt>.
+    </p>
+
+    <p>
+      The value provided for <tt>root</tt> will be normalized to include a leading
+      and trailing slash. When navigating to a route the default behavior is to
+      exclude the trailing slash from the URL (e.g., <tt>/public/search?query=...</tt>).
+      If you prefer to include the trailing slash (e.g., <tt>/public/search/?query=...</tt>)
+      use <tt>Backbone.history.start({trailingSlash: true})</tt>.
+      URLs will always contain a leading slash. When root is <tt>/</tt> URLs will
+      look like <tt>/?query=...</tt> regardless of the value of <tt>trailingSlash</tt>.
     </p>
 
     <p>

--- a/test/router.js
+++ b/test/router.js
@@ -807,6 +807,38 @@
     Backbone.history.navigate('?x=1');
   });
 
+  QUnit.test('#3391 - Empty root normalizes to single slash.', function(assert) {
+    assert.expect(1);
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: {
+        pushState: function(state, title, url) {
+          assert.strictEqual(url, '/');
+        }
+      }
+    });
+    location.replace('http://example.com/root/path');
+    Backbone.history.start({pushState: true, hashChange: false, root: ''});
+    Backbone.history.navigate('');
+  });
+
+  QUnit.test('#3391 - Use trailing slash on root when trailingSlash is true.', function(assert) {
+    assert.expect(1);
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {
+      location: location,
+      history: {
+        pushState: function(state, title, url) {
+          assert.strictEqual(url, '/root/');
+        }
+      }
+    });
+    location.replace('http://example.com/root/path');
+    Backbone.history.start({pushState: true, hashChange: false, root: 'root', trailingSlash: true});
+    Backbone.history.navigate('');
+  });
+
   QUnit.test('#2765 - Fragment matching sans query/hash.', function(assert) {
     assert.expect(2);
     Backbone.history.stop();


### PR DESCRIPTION
Fixes #3391 - Allow developers to control whether a trailing-slash should be included or not.