### PR TITLE
Add model changeId event

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -516,7 +516,11 @@
       }
 
       // Update the `id`.
-      if (this.idAttribute in attrs) this.id = this.get(this.idAttribute);
+      if (this.idAttribute in attrs) {
+        var prevId = this.id;
+        this.id = this.get(this.idAttribute);
+        this.trigger('changeId', this, prevId, options);
+      }
 
       // Trigger all relevant attribute changes.
       if (!silent) {
@@ -1207,13 +1211,11 @@
       if (model) {
         if ((event === 'add' || event === 'remove') && collection !== this) return;
         if (event === 'destroy') this.remove(model, options);
-        if (event === 'change') {
+        if (event === 'changeId') {
           var prevId = this.modelId(model.previousAttributes(), model.idAttribute);
           var id = this.modelId(model.attributes, model.idAttribute);
-          if (prevId !== id) {
-            if (prevId != null) delete this._byId[prevId];
-            if (id != null) this._byId[id] = model;
-          }
+          if (prevId != null) delete this._byId[prevId];
+          if (id != null) this._byId[id] = model;
         }
       }
       this.trigger.apply(this, arguments);

--- a/index.html
+++ b/index.html
@@ -1032,6 +1032,7 @@ view.stopListening(model);
       <li><b>"reset"</b> (collection, options) &mdash; when the collection's entire contents have been <a href="#Collection-reset">reset</a>.</li>
       <li><b>"sort"</b> (collection, options) &mdash; when the collection has been re-sorted.</li>
       <li><b>"change"</b> (model, options) &mdash; when a model's attributes have changed.</li>
+      <li><b>"changeId"</b> (model, previousId, options) &mdash; when the model's id has been updated.</li>
       <li><b>"change:[attribute]"</b> (model, value, options) &mdash; when a specific attribute has been updated.</li>
       <li><b>"destroy"</b> (model, collection, options) &mdash; when a model is <a href="#Model-destroy">destroyed</a>.</li>
       <li><b>"request"</b> (model_or_collection, xhr, options) &mdash; when a model or collection has started a request to the server.</li>

--- a/test/collection.js
+++ b/test/collection.js
@@ -122,7 +122,7 @@
   });
 
   QUnit.test('update index when id changes', function(assert) {
-    assert.expect(4);
+    assert.expect(6);
     var collection = new Backbone.Collection();
     collection.add([
       {id: 0, name: 'one'},
@@ -130,7 +130,11 @@
     ]);
     var one = collection.get(0);
     assert.equal(one.get('name'), 'one');
-    collection.on('change:name', function(model) { assert.ok(this.get(model)); });
+    collection.on('change:name', function(model) {
+      assert.ok(this.get(model));
+      assert.equal(model, this.get(101));
+      assert.equal(this.get(0), null);
+    });
     one.set({name: 'dalmatians', id: 101});
     assert.equal(collection.get(0), null);
     assert.equal(collection.get(101).get('name'), 'dalmatians');


### PR DESCRIPTION
Fixes #3882
Fixes #4159

Backbone does a bit of extra work to determine when to update `_byId` on every model change event because `change:id` will not work if `idAttribute` has changed.  This causes issues as the `change` event happens after every `change:` event which means during a change the `_byId` hasn't updated.  Rather than adding complexity to collection the solution is to have the model notify with the id changes.

If adding a public event isn't desired, for an internal solution the model is aware of it's collection and could modify model.collection._byId directly within the set.

Either of these solutions seem preferrable to handling `change:[idAttribute]`

Replaces the need for:
https://github.com/jashkenas/backbone/pull/4227/files#diff-c773bb9be277f0f3f2baa308b6e0f3a486790fe99fea81ddd0ba409846250571R1205