### PR TITLE
CoffeeScript 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "underscore": ">=1.8.3"
       },
       "devDependencies": {
-        "coffeescript": "^1.12.7",
+        "coffeescript": "^2.7.0",
         "cpy-cli": "^3.1.1",
         "docco": "^0.9.1",
         "eslint": "^8.7.0",
@@ -128,6 +128,15 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.90"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -880,16 +889,16 @@
       }
     },
     "node_modules/coffeescript": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
-      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==",
       "dev": true,
       "bin": {
         "cake": "bin/cake",
         "coffee": "bin/coffee"
       },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=6"
       }
     },
     "node_modules/collection-visit": {
@@ -922,15 +931,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.1.90"
-      }
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -1137,9 +1137,9 @@
       }
     },
     "node_modules/date-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.3.tgz",
-      "integrity": "sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.9.tgz",
+      "integrity": "sha512-+8J+BOUpSrlKLQLeF8xJJVTxS8QfRSuJgwxSVvslzgO3E6khbI0F5mMEPf5mTYhCCm4h99knYP6H3W9n3BQFrg==",
       "dev": true,
       "engines": {
         "node": ">=4.0"
@@ -1988,15 +1988,15 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true,
       "funding": [
         {
@@ -2797,15 +2797,15 @@
       }
     },
     "node_modules/karma": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
-      "integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
+      "version": "6.3.19",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.19.tgz",
+      "integrity": "sha512-NDhWckzES/Y9xMiddyU1RzaKL76/scCsu8Mp0vR0Z3lQRvC3p72+Ab4ppoxs36S9tyPNX5V48yvaV++RNEBPZw==",
       "dev": true,
       "dependencies": {
+        "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
-        "colors": "1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",
@@ -2814,13 +2814,14 @@
         "http-proxy": "^1.18.1",
         "isbinaryfile": "^4.0.8",
         "lodash": "^4.17.21",
-        "log4js": "^6.3.0",
+        "log4js": "^6.4.1",
         "mime": "^2.5.2",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.5",
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
         "rimraf": "^3.0.2",
-        "socket.io": "^4.2.0",
+        "socket.io": "^4.4.1",
         "source-map": "^0.6.1",
         "tmp": "^0.2.1",
         "ua-parser-js": "^0.7.30",
@@ -3086,25 +3087,25 @@
       "dev": true
     },
     "node_modules/log4js": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.0.tgz",
-      "integrity": "sha512-ysc/XUecZJuN8NoKOssk3V0cQ29xY4fra6fnigZa5VwxFsCsvdqsdnEuAxNN89LlHpbE4KUD3zGcn+kFqonSVQ==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.6.tgz",
+      "integrity": "sha512-1XMtRBZszmVZqPAOOWczH+Q94AI42mtNWjvjA5RduKTSWjEc56uOBbyM1CJnfN4Ym0wSd8cQ43zOojlSHgRDAw==",
       "dev": true,
       "dependencies": {
-        "date-format": "^4.0.3",
-        "debug": "^4.3.3",
-        "flatted": "^3.2.4",
+        "date-format": "^4.0.9",
+        "debug": "^4.3.4",
+        "flatted": "^3.2.5",
         "rfdc": "^1.3.0",
-        "streamroller": "^3.0.2"
+        "streamroller": "^3.0.8"
       },
       "engines": {
         "node": ">=8.0"
       }
     },
     "node_modules/log4js/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -3331,9 +3332,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/minimist-options": {
@@ -4909,23 +4910,23 @@
       }
     },
     "node_modules/streamroller": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.2.tgz",
-      "integrity": "sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.8.tgz",
+      "integrity": "sha512-VI+ni3czbFZrd1MrlybxykWZ8sMDCMtTU7YJyhgb9M5X6d1DDxLdJr+gSnmRpXPMnIWxWKMaAE8K0WumBp3lDg==",
       "dev": true,
       "dependencies": {
-        "date-format": "^4.0.3",
-        "debug": "^4.1.1",
-        "fs-extra": "^10.0.0"
+        "date-format": "^4.0.9",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0"
       },
       "engines": {
         "node": ">=8.0"
       }
     },
     "node_modules/streamroller/node_modules/debug": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-      "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "dependencies": {
         "ms": "2.1.2"
@@ -4937,6 +4938,32 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/streamroller/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/streamroller/node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dev": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
       }
     },
     "node_modules/streamroller/node_modules/ms": {
@@ -5662,6 +5689,12 @@
         }
       }
     },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true
+    },
     "@eslint/eslintrc": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.5.tgz",
@@ -6254,9 +6287,9 @@
       }
     },
     "coffeescript": {
-      "version": "1.12.7",
-      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-1.12.7.tgz",
-      "integrity": "sha512-pLXHFxQMPklVoEekowk8b3erNynC+DVJzChxS/LCBBgR6/8AJkHivkm//zbowcfc7BTCAjryuhx6gPqPRfsFoA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/coffeescript/-/coffeescript-2.7.0.tgz",
+      "integrity": "sha512-hzWp6TUE2d/jCcN67LrW1eh5b/rSDKQK6oD6VMLlggYVUUFexgTH9z3dNYihzX4RMhze5FTUsUmOXViJKFQR/A==",
       "dev": true
     },
     "collection-visit": {
@@ -6282,12 +6315,6 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "colors": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
       "dev": true
     },
     "combined-stream": {
@@ -6446,9 +6473,9 @@
       }
     },
     "date-format": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.3.tgz",
-      "integrity": "sha512-7P3FyqDcfeznLZp2b+OMitV9Sz2lUnsT87WaTat9nVwqsBkTzPG3lPLNwW3en6F4pHUiWzr6vb8CLhjdK9bcxQ==",
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/date-format/-/date-format-4.0.9.tgz",
+      "integrity": "sha512-+8J+BOUpSrlKLQLeF8xJJVTxS8QfRSuJgwxSVvslzgO3E6khbI0F5mMEPf5mTYhCCm4h99knYP6H3W9n3BQFrg==",
       "dev": true
     },
     "debug": {
@@ -7124,15 +7151,15 @@
       }
     },
     "flatted": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.4.tgz",
-      "integrity": "sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
+      "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.7",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
-      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
+      "version": "1.14.9",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
+      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
       "dev": true
     },
     "for-in": {
@@ -7762,15 +7789,15 @@
       "dev": true
     },
     "karma": {
-      "version": "6.3.11",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.11.tgz",
-      "integrity": "sha512-QGUh4yXgizzDNPLB5nWTvP+wysKexngbyLVWFOyikB661hpa2RZLf5anZQzqliWtAQuYVep0ot0D1U7UQKpsxQ==",
+      "version": "6.3.19",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-6.3.19.tgz",
+      "integrity": "sha512-NDhWckzES/Y9xMiddyU1RzaKL76/scCsu8Mp0vR0Z3lQRvC3p72+Ab4ppoxs36S9tyPNX5V48yvaV++RNEBPZw==",
       "dev": true,
       "requires": {
+        "@colors/colors": "1.5.0",
         "body-parser": "^1.19.0",
         "braces": "^3.0.2",
         "chokidar": "^3.5.1",
-        "colors": "1.4.0",
         "connect": "^3.7.0",
         "di": "^0.0.1",
         "dom-serialize": "^2.2.1",
@@ -7779,13 +7806,14 @@
         "http-proxy": "^1.18.1",
         "isbinaryfile": "^4.0.8",
         "lodash": "^4.17.21",
-        "log4js": "^6.3.0",
+        "log4js": "^6.4.1",
         "mime": "^2.5.2",
         "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.5",
         "qjobs": "^1.2.0",
         "range-parser": "^1.2.1",
         "rimraf": "^3.0.2",
-        "socket.io": "^4.2.0",
+        "socket.io": "^4.4.1",
         "source-map": "^0.6.1",
         "tmp": "^0.2.1",
         "ua-parser-js": "^0.7.30",
@@ -7981,22 +8009,22 @@
       "dev": true
     },
     "log4js": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.0.tgz",
-      "integrity": "sha512-ysc/XUecZJuN8NoKOssk3V0cQ29xY4fra6fnigZa5VwxFsCsvdqsdnEuAxNN89LlHpbE4KUD3zGcn+kFqonSVQ==",
+      "version": "6.4.6",
+      "resolved": "https://registry.npmjs.org/log4js/-/log4js-6.4.6.tgz",
+      "integrity": "sha512-1XMtRBZszmVZqPAOOWczH+Q94AI42mtNWjvjA5RduKTSWjEc56uOBbyM1CJnfN4Ym0wSd8cQ43zOojlSHgRDAw==",
       "dev": true,
       "requires": {
-        "date-format": "^4.0.3",
-        "debug": "^4.3.3",
-        "flatted": "^3.2.4",
+        "date-format": "^4.0.9",
+        "debug": "^4.3.4",
+        "flatted": "^3.2.5",
         "rfdc": "^1.3.0",
-        "streamroller": "^3.0.2"
+        "streamroller": "^3.0.8"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
@@ -8153,9 +8181,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {
@@ -9382,23 +9410,44 @@
       "dev": true
     },
     "streamroller": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.2.tgz",
-      "integrity": "sha512-ur6y5S5dopOaRXBuRIZ1u6GC5bcEXHRZKgfBjfCglMhmIf+roVCECjvkEYzNQOXIN2/JPnkMPW/8B3CZoKaEPA==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/streamroller/-/streamroller-3.0.8.tgz",
+      "integrity": "sha512-VI+ni3czbFZrd1MrlybxykWZ8sMDCMtTU7YJyhgb9M5X6d1DDxLdJr+gSnmRpXPMnIWxWKMaAE8K0WumBp3lDg==",
       "dev": true,
       "requires": {
-        "date-format": "^4.0.3",
-        "debug": "^4.1.1",
-        "fs-extra": "^10.0.0"
+        "date-format": "^4.0.9",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0"
       },
       "dependencies": {
         "debug": {
-          "version": "4.3.3",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
-          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "version": "4.3.4",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+          "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"
+          }
+        },
+        "fs-extra": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
           }
         },
         "ms": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "underscore": ">=1.8.3"
   },
   "devDependencies": {
-    "coffeescript": "^1.12.7",
+    "coffeescript": "^2.7.0",
     "cpy-cli": "^3.1.1",
     "docco": "^0.9.1",
     "eslint": "^8.7.0",

--- a/test/model.coffee
+++ b/test/model.coffee
@@ -32,7 +32,7 @@ ok tempest.get('length') is 123
 class ProperDocument extends Document
 
   fullName: ->
-    "Mr. " + super
+    "Mr. " + super(arguments...)
 
 properTempest = new ProperDocument tempest.attributes
 


### PR DESCRIPTION
CoffeeScript 2 came out in 2017. This PR updates Backbone’s CoffeeScript dependency to version 2, and updates the related test per https://coffeescript.org/#breaking-changes-super-extends.