### PR TITLE
Bug Collection:reset calls add model in case of models undefined

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -961,7 +961,7 @@
       }
       options.previousModels = this.models;
       this._reset();
-      models = this.add(models, _.extend({silent: true}, options));
+      models = models && this.add(models, _.extend({silent: true}, options));
       if (!options.silent) this.trigger('reset', this, options);
       return models;
     },


### PR DESCRIPTION
Currently if you call reset() on a collection it will use the add(models) function with models == undefined.

So I think it is rather logical to call the add if the models is not undefined.