### PR TITLE
Trigger error from failing Collection.create with wait:true

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1082,7 +1082,7 @@
       var forwardPristineError;
       options.success = function(m, resp, callbackOpts) {
         if (wait) {
-          model.off('error', forwardPristineError);
+          m.off('error', forwardPristineError, this);
           collection.add(m, callbackOpts);
         }
         if (success) success.call(callbackOpts.context, m, resp, callbackOpts);
@@ -1096,8 +1096,11 @@
       // causes the collection to listen, and then invoke the callback
       // that triggers the event.)
       if (wait) {
-        forwardPristineError = _.bind(this._onModelEvent, this, 'error');
-        model.once('error', forwardPristineError);
+        forwardPristineError = function(mod, col, opt) {
+          if (this.has(mod)) return;
+          this._onModelEvent('error', mod, col, opt);
+        };
+        model.once('error', forwardPristineError, this);
       }
       model.save(null, options);
       return model;

--- a/test/collection.js
+++ b/test/collection.js
@@ -654,6 +654,15 @@
     assert.equal(collection.length, 1);
   });
 
+  QUnit.test('failing create with wait:true triggers error event (#4262)', function(assert) {
+    assert.expect(1);
+    var collection = new Backbone.Collection;
+    collection.url = '/test';
+    collection.on('error', function() { assert.ok(true); });
+    collection.create({id: '1'}, {wait: true});
+    this.ajaxSettings.error();
+  });
+
   QUnit.test('initialize', function(assert) {
     assert.expect(1);
     var Collection = Backbone.Collection.extend({

--- a/test/collection.js
+++ b/test/collection.js
@@ -664,6 +664,16 @@
     this.ajaxSettings.error();
   });
 
+  QUnit.test('successful create with wait:true triggers success event (#4262)', function(assert) {
+    assert.expect(2);
+    var collection = new Backbone.Collection;
+    collection.url = '/test';
+    collection.on('sync', function() { assert.ok(true); });
+    var model = collection.create({id: '1'}, {wait: true});
+    model.on('sync', function() { assert.ok(true); });
+    this.ajaxSettings.success();
+  });
+
   QUnit.test('initialize', function(assert) {
     assert.expect(1);
     var Collection = Backbone.Collection.extend({

--- a/test/collection.js
+++ b/test/collection.js
@@ -655,11 +655,12 @@
   });
 
   QUnit.test('failing create with wait:true triggers error event (#4262)', function(assert) {
-    assert.expect(1);
+    assert.expect(2);
     var collection = new Backbone.Collection;
     collection.url = '/test';
     collection.on('error', function() { assert.ok(true); });
-    collection.create({id: '1'}, {wait: true});
+    var model = collection.create({id: '1'}, {wait: true});
+    model.on('error', function() { assert.ok(true); });
     this.ajaxSettings.error();
   });
 

--- a/test/collection.js
+++ b/test/collection.js
@@ -674,6 +674,27 @@
     this.ajaxSettings.success();
   });
 
+  QUnit.test('failing create pre-existing with wait:true triggers once (#4262)', function(assert) {
+    assert.expect(1);
+    var model = new Backbone.Model;
+    var collection = new Backbone.Collection([model]);
+    collection.url = '/test';
+    collection.on('error', function() { assert.ok(true); });
+    collection.create(model, {wait: true});
+    this.ajaxSettings.error();
+  });
+
+  QUnit.test('successful create pre-existing with wait:true preserves other error bindings (#4262)', function(assert) {
+    assert.expect(1);
+    var model = new Backbone.Model;
+    var collection = new Backbone.Collection([model]);
+    collection.url = '/test';
+    model.on('error', function() { assert.ok(true); });
+    collection.create(model, {wait: true});
+    this.ajaxSettings.success();
+    model.trigger('error');
+  });
+
   QUnit.test('initialize', function(assert) {
     assert.expect(1);
     var Collection = Backbone.Collection.extend({

--- a/test/model.js
+++ b/test/model.js
@@ -712,6 +712,15 @@
     this.ajaxSettings.success();
   });
 
+  QUnit.test('failing save with wait:true triggers error event (#4262)', function(assert) {
+    assert.expect(1);
+    var model = new Backbone.Model;
+    model.urlRoot = '/test';
+    model.on('error', function() { assert.ok(true); });
+    model.save({id: '1'}, {wait: true});
+    this.ajaxSettings.error();
+  });
+
   QUnit.test('fetch', function(assert) {
     assert.expect(2);
     doc.fetch();


### PR DESCRIPTION
This fixes #4262.

The bug arose because the transaction with the backend is mediated through `model.save` and the `'error'` event is initially triggered by the model. Normally, the collection will forward all events from the model, but with `wait: true`, the model is not yet added to the collection when the event triggers, so the collection is not listening, either. I addressed this by special-casing the `'error'` event in this particular scenario.

I determined that a similar fix is not required for the `'sync'` event on successful `create`. In that case, the model is still added to the collection before the event triggers.

I foresee two possible criticisms on the solution:

1. One could argue that a similar fix is still needed for the `'request'` event. However, since the timing of this event is fully predictable (i.e., just before the end of the call to `create`), users do not need to listen for it in order to match the timing of a callback. Adding special case code for the `'request'` event as well would further inflate the code size.
2. It is theoretically possible that a user would call `collection.create` with a model that is already in the collection. In that case, with `wait: true`, I expect that the collection will forward the `'error'` event *twice*. If this scenario is considered problematic enough, I am willing to address it.

On the other hand, someone might also argue that this issue does not need fixing at all. The old behavior, while surprising, could be argued to be consistent, since the collection cannot be expected to forward events from a model it does not yet contain.

Reviews and discussion welcome!

CC @paulfalgout @ogonkov @alanhamlett @recursivk