### PR TITLE
Comment about combined defaults and extend

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -404,7 +404,13 @@
     if (options.collection) this.collection = options.collection;
     if (options.parse) attrs = this.parse(attrs, options) || {};
     var defaults = _.result(this, 'defaults');
+
+    // Additional `_.defaults()` wrap after `_.extend()` makes sense
+    // when `attrs` has a property explicitly set to `undefined`.
+    // Also it helps to avoid conflicts with Object.prototype properties.
+    // Issue #3842
     attrs = _.defaults(_.extend({}, defaults, attrs), defaults);
+
     this.set(attrs, options);
     this.changed = {};
     this.initialize.apply(this, arguments);

--- a/backbone.js
+++ b/backbone.js
@@ -405,10 +405,8 @@
     if (options.parse) attrs = this.parse(attrs, options) || {};
     var defaults = _.result(this, 'defaults');
 
-    // Additional `_.defaults()` wrap after `_.extend()` makes sense
-    // when `attrs` has a property explicitly set to `undefined`.
-    // Also it helps to avoid conflicts with Object.prototype properties.
-    // Issue #3842
+    // Just _.defaults would work fine, but the additional _.extends
+    // is in there for historical reasons. See #3843.
     attrs = _.defaults(_.extend({}, defaults, attrs), defaults);
 
     this.set(attrs, options);


### PR DESCRIPTION
This proposal replaces #4088 by @unclechu. I squashed their commits and then changed the comment again in a commit of my own. In this way, @unclechu is still credited for their effort to document the code, although their PR will be marked as rejected.

In my opinion, the line in question was misguided (see also #4266). It has no advantage over a simple call to `_.defaults`, except that it allows you to set attribute keys that collide with `Object.prototype` properties. I consider that a footgun rather than a feature.

Reviews welcome.