### PR TITLE
Add a .editorconfig; prepare for switching to 4-space indentation

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,17 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+
+indent_style = space
+indent_size = 2
+charset = utf-8
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[**/package.json]
+indent_size = 2


### PR DESCRIPTION
I've been keeping an untracked `.editorconfig` for the past couple of days, because I usually use 4-space indentation while Backbone uses 2-space indentation.

I plan to modularize Backbone and grasp the opportunity to switch to 4-space indentation, since it is a major code disruption anyway. This will be easier to manage between different branches if I commit the `.editorconfig`.

If somebody thinks I should **not** change the indentation, now is the time to tell me! (Don't worry, I will keep different types of changes in separate commits so they are easier to trace.)

There is currently a subsection for `package.json` because that will have to stick to 2-space indentation. I don't mind removing the special case for the time being. Other comments on details are also welcome.