### PR TITLE
Add warning to documentation about setting the model id in the defaults

### DIFF
--- a/index.html
+++ b/index.html
@@ -1405,14 +1405,13 @@ alert("Dessert will be " + (new Meal).get('dessert'));
     </p>
 
     <p class="warning">
-      In nearly all cases, the defaults should <b>not</b> set a value for the
-      model&rsquo;s <a href="#Model-idAttribute"><tt>idAttribute</tt></a>. Doing
-      so would likely prevent an instance of <tt>Backbone.Collection</tt> from
-      correctly identifying model hashes and is almost certainly a mistake. If
-      you know what you are doing and you really <u>must</u> set the model id in
-      the defaults, make sure that you either (a) never add instances of the
-      model class to a collection or (b) define the defaults as a function that
-      returns a different, <u>universally</u> unique id on every invocation.
+      If you set a value for the model&rsquo;s
+      <a href="#Model-idAttribute"><tt>idAttribute</tt></a>, you should define
+      the defaults as a function that returns a different, <u>universally</u>
+      unique id on every invocation. Not doing so would likely prevent an
+      instance of <tt>Backbone.Collection</tt> from correctly identifying model
+      hashes and is almost certainly a mistake, unless you never add instances
+      of the model class to a collection.
     </p>
 
     <p id="Model-toJSON">

--- a/index.html
+++ b/index.html
@@ -1404,6 +1404,17 @@ alert("Dessert will be " + (new Meal).get('dessert'));
       Instead, define <b>defaults</b> as a function.
     </p>
 
+    <p class="warning">
+      In nearly all cases, the defaults should <b>not</b> set a value for the
+      model&rsquo;s <a href="#Model-idAttribute"><tt>idAttribute</tt></a>. Doing
+      so would likely prevent an instance of <tt>Backbone.Collection</tt> from
+      correctly identifying model hashes and is almost certainly a mistake. If
+      you know what you are doing and you really <u>must</u> set the model id in
+      the defaults, make sure that you either (a) never add instances of the
+      model class to a collection or (b) define the defaults as a function that
+      returns a different, <u>universally</u> unique id on every invocation.
+    </p>
+
     <p id="Model-toJSON">
       <b class="header">toJSON</b><code>model.toJSON([options])</code>
       <br />


### PR DESCRIPTION
Please see #4205 for a rationale of this change. My thoughts that led to this PR are in the bottom comment.

I have asked myself whether this should be documented at all, given that it is a rather obscure corner case (user sets the model id to a fixed value in the defaults and also adds instances of the model to a collection). However, the fact that #4205 was reported proves that users may encounter the situation.

The edit can be previewed as web page over here: https://cdn.statically.io/gh/jgonggrijp/backbone/document-defaults-idAttribute/index.html#Model-defaults.