### PR TITLE
History notfound event

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -1985,7 +1985,10 @@
         current = this.getHash(this.iframe.contentWindow);
       }
 
-      if (current === this.fragment) return false;
+      if (current === this.fragment) {
+        if (!this.matchRoot()) return this.notfound();
+        return false;
+      }
       if (this.iframe) this.navigate(current);
       this.loadUrl();
     },
@@ -1995,14 +1998,22 @@
     // returns `false`.
     loadUrl: function(fragment) {
       // If the root doesn't match, no routes can match either.
-      if (!this.matchRoot()) return false;
+      if (!this.matchRoot()) return this.notfound();
       fragment = this.fragment = this.getFragment(fragment);
       return _.some(this.handlers, function(handler) {
         if (handler.route.test(fragment)) {
           handler.callback(fragment);
           return true;
         }
-      });
+      }) || this.notfound();
+    },
+
+    // When no route could be matched, this method is called internally to
+    // trigger the `'notfound'` event. It returns `false` so that it can be used
+    // in tail position.
+    notfound: function() {
+      this.trigger('notfound');
+      return false;
     },
 
     // Save a fragment into the hash history, or replace the URL state if the

--- a/index.html
+++ b/index.html
@@ -1040,6 +1040,7 @@ view.stopListening(model);
       <li><b>"route:[name]"</b> (params) &mdash; Fired by the router when a specific route is matched.</li>
       <li><b>"route"</b> (route, params) &mdash; Fired by the router when <i>any</i> route has been matched.</li>
       <li><b>"route"</b> (router, route, params) &mdash; Fired by history when <i>any</i> route has been matched.</li>
+      <li><b>"notfound"</b> () &mdash; Fired by history when <i>no</i> route could be matched.</li>
       <li><b>"all"</b> &mdash; this special event fires for <i>any</i> triggered event, passing the event name as the first argument followed by all trigger arguments.</li>
     </ul>
 
@@ -2716,6 +2717,9 @@ var Router = Backbone.Router.extend({
     <p>
       <b>History</b> serves as a global router (per frame) to handle <tt>hashchange</tt>
       events or <tt>pushState</tt>, match the appropriate route, and trigger callbacks.
+      It forwards the <tt>"route"</tt> and <tt>"route[name]"</tt> events of the
+      matching router, or <tt>"notfound"</tt> when no route in any router
+      matches the current URL.
       You shouldn't ever have to create one of these yourself since <tt>Backbone.history</tt>
       already contains one.
     </p>
@@ -2772,8 +2776,10 @@ var Router = Backbone.Router.extend({
 
     <p>
       When called, if a route succeeds with a match for the current URL,
-      <tt>Backbone.history.start()</tt> returns <tt>true</tt>. If no defined
-      route matches the current URL, it returns <tt>false</tt>.
+      <tt>Backbone.history.start()</tt> returns <tt>true</tt> and
+      the <tt>"route"</tt> and <tt>"route[name]"</tt> events are triggered. If
+      no defined route matches the current URL, it returns <tt>false</tt>
+      and <tt>"notfound"</tt> is triggered instead.
     </p>
 
     <p>

--- a/test/router.js
+++ b/test/router.js
@@ -1110,4 +1110,89 @@
     assert.strictEqual(location.hash, '#' + route);
   });
 
+  QUnit.test('initial non-matching root triggers notfound event', function(assert) {
+    assert.expect(1);
+    location.replace('http://example.com/root#foo');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    Backbone.history.on('notfound', function() { assert.ok(true); });
+    var MyRouter = Backbone.Router.extend({
+      routes: {foo: function() { assert.ok(false); }}
+    });
+    var myRouter = new MyRouter;
+    Backbone.history.start({root: 'other'});
+  });
+
+  QUnit.test('later non-matching root triggers notfound event', function(assert) {
+    assert.expect(2);
+    location.replace('http://example.com/root#foo');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    Backbone.history.on('notfound', function() { assert.ok(true); });
+    var MyRouter = Backbone.Router.extend({
+      routes: {foo: function() { assert.ok(true); }}
+    });
+    var myRouter = new MyRouter;
+    Backbone.history.start({root: 'root'});
+    location.replace('http://example.com/other#foo');
+    Backbone.history.checkUrl();
+  });
+
+  QUnit.test('initial non-matching route triggers notfound event', function(assert) {
+    assert.expect(1);
+    location.replace('http://example.com/root#bar');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    Backbone.history.on('notfound', function() { assert.ok(true); });
+    var MyRouter = Backbone.Router.extend({
+      routes: {foo: function() { assert.ok(false); }}
+    });
+    var myRouter = new MyRouter;
+    Backbone.history.start({root: 'root'});
+  });
+
+  QUnit.test('later non-matching route triggers notfound event', function(assert) {
+    assert.expect(2);
+    location.replace('http://example.com/root#foo');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    Backbone.history.on('notfound', function() { assert.ok(true); });
+    var MyRouter = Backbone.Router.extend({
+      routes: {foo: function() { assert.ok(true); }}
+    });
+    var myRouter = new MyRouter;
+    Backbone.history.start({root: 'root'});
+    location.replace('http://example.com/other#bar');
+    Backbone.history.checkUrl();
+  });
+
+  QUnit.test('non-matching pushState route triggers notfound event', function(assert) {
+    assert.expect(2);
+    location.replace('http://example.com/root/foo');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    Backbone.history.on('notfound', function() { assert.ok(true); });
+    var MyRouter = Backbone.Router.extend({
+      routes: {foo: function() { assert.ok(true); }}
+    });
+    var myRouter = new MyRouter;
+    Backbone.history.start({root: 'root', pushState: true});
+    location.replace('http://example.com/other/bar');
+    Backbone.history.checkUrl();
+  });
+
+  QUnit.test('non-matching navigate triggers notfound event', function(assert) {
+    assert.expect(2);
+    location.replace('http://example.com/root#foo');
+    Backbone.history.stop();
+    Backbone.history = _.extend(new Backbone.History, {location: location});
+    Backbone.history.on('notfound', function() { assert.ok(true); });
+    var MyRouter = Backbone.Router.extend({
+      routes: {foo: function() { assert.ok(true); }}
+    });
+    var myRouter = new MyRouter;
+    Backbone.history.start({root: 'root'});
+    Backbone.history.navigate('http://example.com/other#bar', {trigger: true});
+  });
+
 })(QUnit);


### PR DESCRIPTION
This is a new feature that I factored out of an application I built at Utrecht University. It makes it possible to display a generic "404 not found" view whenever the URL changes but does not match any route known to `Backbone.history`. In the application, I hacked the feature in by overriding `Backbone.history.loadUrl`, which is an undocumented method. With this feature added to Backbone itself, that hack would no longer be necessary.

It was already possible to inspect the return value of `Backbone.history.start()` and display a 404 view if that value was `false`. However, there was no way to detect a non-matching URL that occurred after a `hashchange` or `pushstate` event, for example due to a coding error or a creative user hacking faulty URLs into the page. The `notfound` event addresses that gap.

Another way to look at it, is that `notfound` brings parity with the `Backbone.sync` events: `notfound` is to `route` as `error` is to `sync`.

I have some specific questions to the reviewer:

- Do you agree that the feature is useful enough to justify a couple of extra lines of code?
- Do you agree that `notfound` is an appropriate name for this event?
- The event as currently proposed has no payload. Should it? If so, what should that payload be?
- The change *should* be entirely non-breaking (just an extra event, no other changes in behavior), but please do not hesitate to warn me if you think I might be mistaken.