### PR TITLE
Bump GitHub workflows to latest version

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 14
           cache: 'npm'


### PR DESCRIPTION
This PR bump GitHub workflows to their latest versions, thus avoiding deprecation warnings as seen [here](https://github.com/jashkenas/backbone/actions/runs/8035882913).