### PR TITLE
Postpone development mark until after release publication

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "lint": "eslint backbone.js test/*.js modules/*.js",
     "mark-release": "replace-in-file MARK_DEVELOPMENT MARK_RELEASE modules/debug-info.js && npm run build-debug",
     "mark-develop": "replace-in-file MARK_RELEASE MARK_DEVELOPMENT modules/debug-info.js && npm run build-debug",
-    "prepublishOnly": "npm run test && npm run mark-release && npm run build && npm run alias-sourcemap && npm run doc && git add -u && npm run mark-develop"
+    "prepublishOnly": "npm run test && npm run mark-release && npm run build && npm run alias-sourcemap && npm run doc",
+    "postpublish": "git add -u && npm run mark-develop"
   },
   "main": "backbone.js",
   "version": "1.6.1",


### PR DESCRIPTION
This caused the debug-info.js to *always* contain `MARK_DEVELOPMENT`, even in official releases. Quite an oversight!

CC @GammaGames @Yahasana