### PR TITLE
Make optional jQuery require bundler-friendly (#4184)

### DIFF
--- a/backbone.js
+++ b/backbone.js
@@ -23,7 +23,13 @@
   // Next for Node.js or CommonJS. jQuery may not be needed as a module.
   } else if (typeof exports !== 'undefined') {
     var _ = require('underscore'), $;
-    try { $ = require('jquery'); } catch (e) {}
+    // Indirect the optional jQuery require through a variable so that
+    // Webpack, Rollup, esbuild, packd and friends do not try to resolve
+    // it at bundle time. The literal `require('jquery')` form was being
+    // statically analyzed by bundlers and failing the build for users
+    // who don't actually want jQuery (#4184).
+    var nodeRequire = typeof require === 'function' && require;
+    try { if (nodeRequire) $ = nodeRequire('jquery'); } catch (e) {}
     factory(root, exports, _, $);
 
   // Finally, as a browser global.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,14 @@
   "dependencies": {
     "underscore": ">=1.8.3"
   },
+  "peerDependencies": {
+    "jquery": ">=1.11.0"
+  },
+  "peerDependenciesMeta": {
+    "jquery": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "coffeescript": "^2.7.0",
     "cpy-cli": "^5.0.0",


### PR DESCRIPTION
Fixes #4184.

## Problem

The CommonJS branch of the UMD wrapper does:

```js
var _ = require('underscore'), $;
try { $ = require('jquery'); } catch (e) {}
```

The `try/catch` is correct at runtime in Node.js, but Webpack, Rollup,
esbuild, packd and other bundlers statically analyze the literal
`require('jquery')` call before the try/catch ever runs. Users who
don't actually want jQuery still see their bundles fail with
`Cannot find module 'jquery'`.

## Fix

Indirect the optional require through a variable so the bundler's
static analysis does not follow it:

```js
var nodeRequire = typeof require === 'function' && require;
try { if (nodeRequire) $ = nodeRequire('jquery'); } catch (e) {}
```

This is the same trick used by `ws` and other libraries with optional
native deps. Runtime behavior is unchanged: the require still happens
in Node, the try/catch still swallows ENOENT, and `Backbone.$` is
still populated when jQuery is installed.

Also declare `jquery` as an optional peer dependency in `package.json`
so npm/yarn/pnpm document the relationship cleanly without forcing the
install:

```json
"peerDependencies": { "jquery": ">=1.11.0" },
"peerDependenciesMeta": { "jquery": { "optional": true } }
```

## Test

- `npm run lint` passes.
- Smoke-tested `require('./backbone.js')` in a fresh Node process with
  no jQuery installed: loads cleanly, `Backbone.VERSION === '1.6.1'`,
  `Backbone.$ === undefined` as expected.