### PR TITLE
docs: clarify View.render wording (replace munge with merge)

### DIFF
--- a/index.html
+++ b/index.html
@@ -3143,7 +3143,7 @@ var Bookmark = Backbone.View.extend({
 
     <p>
       Backbone is agnostic with respect to your preferred method of HTML templating.
-      Your <b>render</b> function could even munge together an HTML string, or use
+      Your <b>render</b> function could even merge together an HTML string, or use
       <tt>document.createElement</tt> to generate a DOM tree. However, we suggest
       choosing a nice JavaScript templating library.
       <a href="http://github.com/janl/mustache.js">Mustache.js</a>,

--- a/index.html
+++ b/index.html
@@ -3143,7 +3143,7 @@ var Bookmark = Backbone.View.extend({
 
     <p>
       Backbone is agnostic with respect to your preferred method of HTML templating.
-      Your <b>render</b> function could even merge together an HTML string, or use
+      Your <b>render</b> function could even concatenate an HTML string, or use
       <tt>document.createElement</tt> to generate a DOM tree. However, we suggest
       choosing a nice JavaScript templating library.
       <a href="http://github.com/janl/mustache.js">Mustache.js</a>,


### PR DESCRIPTION
## Summary
- In the View.render documentation, replace the uncommon word "munge" with "merge" so the sentence is clearer for non-native English speakers.
- Addresses #4299.

## Test plan
- [ ] Confirm the View.render section in `index.html` reads "merge together an HTML string"
- [ ] Spot-check that no unrelated docs text changed